### PR TITLE
Refactor SupportedChangeProperties in feature managers

### DIFF
--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/catering-lines-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/catering-lines-feature-manager.ts
@@ -18,10 +18,7 @@ export class CateringLinesFeatureManager
     >
     implements FeatureManager<Feature<LineString>>
 {
-    readonly supportedChangeProperties = new Set([
-        'catererPosition',
-        'patientPosition',
-    ] as const);
+    readonly unsupportedChangeProperties = new Set(['id'] as const);
 
     constructor(public readonly layer: VectorLayer<VectorSource<LineString>>) {
         super();

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/element-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/element-feature-manager.ts
@@ -15,7 +15,6 @@ import type { FeatureManager } from '../utility/feature-manager';
 import { ElementManager } from './element-manager';
 
 type ElementFeature = Feature<Point>;
-type SupportedChangeProperties = ReadonlySet<'position'>;
 export type PositionableElement = Immutable<{
     id: UUID;
     position: Position;
@@ -28,7 +27,7 @@ export type PositionableElement = Immutable<{
  * * manages the default interactions of the element
  */
 export abstract class ElementFeatureManager<Element extends PositionableElement>
-    extends ElementManager<Element, ElementFeature, SupportedChangeProperties>
+    extends ElementManager<Element, ElementFeature, ReadonlySet<keyof Element>>
     implements FeatureManager<ElementFeature>
 {
     private readonly movementAnimator = new MovementAnimator(
@@ -49,6 +48,9 @@ export abstract class ElementFeatureManager<Element extends PositionableElement>
         super();
     }
 
+    override unsupportedChangeProperties: ReadonlySet<keyof Element> = new Set(
+        [] as const
+    );
     createFeature(element: Element): void {
         const elementFeature = new Feature(
             new Point([element.position.x, element.position.y])
@@ -65,11 +67,11 @@ export abstract class ElementFeatureManager<Element extends PositionableElement>
         this.movementAnimator.stopMovementAnimation(elementFeature);
     }
 
-    readonly supportedChangeProperties = new Set(['position'] as const);
     changeFeature(
         oldElement: Element,
         newElement: Element,
-        changedProperties: SupportedChangeProperties,
+        // It is too much work to correctly type this param with {@link unsupportedChangeProperties}
+        changedProperties: ReadonlySet<keyof Element>,
         patientFeature: ElementFeature
     ): void {
         if (changedProperties.has('position')) {

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/material-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/material-feature-manager.ts
@@ -27,6 +27,8 @@ class BaseMaterialFeatureManager extends ElementFeatureManager<
             });
         });
     }
+
+    override unsupportedChangeProperties = new Set(['id', 'image'] as const);
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/patient-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/patient-feature-manager.ts
@@ -30,6 +30,8 @@ class PatientFeatureManagerBase extends ElementFeatureManager<
             });
         });
     }
+
+    override unsupportedChangeProperties = new Set(['id', 'image'] as const);
 }
 
 const PatientFeatureManagerWithImageStyle = withElementImageStyle<

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/personnel-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/personnel-feature-manager.ts
@@ -27,6 +27,8 @@ class BasePersonnelFeatureManager extends ElementFeatureManager<
             });
         });
     }
+
+    override unsupportedChangeProperties = new Set(['id', 'image'] as const);
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/vehicle-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/vehicle-feature-manager.ts
@@ -73,6 +73,8 @@ class VehicleFeatureManagerBase extends ElementFeatureManager<
         }
         return false;
     }
+
+    override unsupportedChangeProperties = new Set(['id', 'image'] as const);
 }
 
 const VehicleFeatureManagerWithImageStyle = withElementImageStyle<


### PR DESCRIPTION
* Fixes #221

* Opt-out of `changeFeature` via `unsupportedChangeProperties` instead of opt-in via `supportedChangeProperties`
* The typings are not perfect, but good enough (I think)