### PR TITLE
Stop propagation of the translateend event if the position didn't change

### DIFF
--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
@@ -24,6 +24,7 @@ import type { ApiService } from 'src/app/core/api.service';
 import type { NgZone } from '@angular/core';
 import type Geometry from 'ol/geom/Geometry';
 import type LineString from 'ol/geom/LineString';
+import { isEqual } from 'lodash-es';
 import { startingPosition } from '../../starting-position';
 import { MaterialFeatureManager } from '../feature-managers/material-feature-manager';
 import { PatientFeatureManager } from '../feature-managers/patient-feature-manager';
@@ -89,6 +90,14 @@ export class OlMapManager {
         const translateInteraction = new Translate({
             layers: [patientLayer, vehicleLayer, personnelLayer, materialLayer],
         });
+        // Clicking on an element should not trigger a drag event - use a `singleclick` interaction instead
+        // Be aware that this means that not every `dragstart` event will have an accompanying `dragend` event
+        translateInteraction.on('translateend', (event) => {
+            if (isEqual(event.coordinate, event.startCoordinate)) {
+                event.stopPropagation();
+            }
+        });
+
         TranslateHelper.registerTranslateEvents(translateInteraction);
 
         this.olMap = new OlMap({

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/translate-helper.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/translate-helper.ts
@@ -33,20 +33,10 @@ export class TranslateHelper {
         feature: Feature<Point>,
         callback: (newCoordinates: Position) => void
     ) {
-        let startPosition: Position | undefined;
-        // These events are only called on features
-        feature.addEventListener('translatestart', (event) => {
-            const [x, y] = feature.getGeometry()!.getCoordinates();
-            startPosition = { x, y };
-        });
         feature.addEventListener('translateend', (event) => {
-            // The start and end coordinates in the event are the mouse coordinates and not the feature coordinates.
+            // The end coordinates in the event are the mouse coordinates and not the feature coordinates.
             const [x, y] = feature.getGeometry()!.getCoordinates();
-            if (startPosition?.x !== x || startPosition?.y !== y) {
-                // Only call the callback if the feature has moved.
-                callback({ x, y });
-            }
-            startPosition = undefined;
+            callback({ x, y });
         });
     }
 


### PR DESCRIPTION
Fixes #249 

If we need the `translatestart` and `translateend` events to match up at a later point in time, we could add this to check for each individual event handler instead.