### PR TITLE
Update dependencies using `npm audit fix` to mitigate a prototype pollution in async

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11270,12 +11270,12 @@
             }
         },
         "node_modules/jake": {
-            "version": "10.8.4",
-            "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.4.tgz",
-            "integrity": "sha512-MtWeTkl1qGsWUtbl/Jsca/8xSoK3x0UmS82sNbjqxxG/de/M/3b1DntdjHgPMC50enlTNwXOCRqPXLLt5cCfZA==",
+            "version": "10.8.5",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+            "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
             "dev": true,
             "dependencies": {
-                "async": "0.9.x",
+                "async": "^3.2.3",
                 "chalk": "^4.0.2",
                 "filelist": "^1.0.1",
                 "minimatch": "^3.0.4"
@@ -11301,12 +11301,6 @@
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
-        },
-        "node_modules/jake/node_modules/async": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-            "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-            "dev": true
         },
         "node_modules/jake/node_modules/chalk": {
             "version": "4.1.2",
@@ -15378,9 +15372,9 @@
             }
         },
         "node_modules/portfinder/node_modules/async": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-            "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+            "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
             "dev": true,
             "dependencies": {
                 "lodash": "^4.17.14"
@@ -27348,12 +27342,12 @@
             }
         },
         "jake": {
-            "version": "10.8.4",
-            "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.4.tgz",
-            "integrity": "sha512-MtWeTkl1qGsWUtbl/Jsca/8xSoK3x0UmS82sNbjqxxG/de/M/3b1DntdjHgPMC50enlTNwXOCRqPXLLt5cCfZA==",
+            "version": "10.8.5",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+            "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
             "dev": true,
             "requires": {
-                "async": "0.9.x",
+                "async": "^3.2.3",
                 "chalk": "^4.0.2",
                 "filelist": "^1.0.1",
                 "minimatch": "^3.0.4"
@@ -27367,12 +27361,6 @@
                     "requires": {
                         "color-convert": "^2.0.1"
                     }
-                },
-                "async": {
-                    "version": "0.9.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-                    "dev": true
                 },
                 "chalk": {
                     "version": "4.1.2",
@@ -30453,9 +30441,9 @@
             },
             "dependencies": {
                 "async": {
-                    "version": "2.6.3",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-                    "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+                    "version": "2.6.4",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+                    "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
                     "dev": true,
                     "requires": {
                         "lodash": "^4.17.14"


### PR DESCRIPTION
Closes #294 

All dependencies updated themselves, so no changes to `frontend/package.json` was required.