### PR TITLE
Don't pull LFS in Cypress

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -259,13 +259,14 @@ jobs:
                 os: [ubuntu-latest]
             fail-fast: false
 
+        # Don't pull LFS to reduce bandwidth usage
         steps:
             - uses: actions/checkout@v2
-              with:
-                  lfs: 'true'
+            #   with:
+            #       lfs: 'true'
             - name: checkoutLFS
               uses: actions/checkout@v2
-            - run: git lfs pull
+            # - run: git lfs pull
             - uses: actions/setup-node@v2
               with:
                   node-version: '16'


### PR DESCRIPTION
Addresses #310 

I thought about just disabling LFS in Cypress to reduce the number Jobs using LFS (the docker builds have to use them).