### PR TITLE
One job for all tests

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -139,7 +139,7 @@ jobs:
               run: cd backend; npm audit; cd ..
 
     test:
-        timeout-minutes: 2
+        timeout-minutes: 4
         runs-on: ${{ matrix.os }}
 
         needs: build
@@ -149,7 +149,6 @@ jobs:
                 # As the CI seems to have high run times, limit it to ubuntu-latest
                 # os: [ubuntu-latest, windows-latest, macos-latest]
                 os: [ubuntu-latest]
-                environment: [shared, frontend, backend]
             fail-fast: false
 
         steps:
@@ -177,73 +176,21 @@ jobs:
               with:
                   path: shared/dist
                   key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('shared/src/**') }}
-            - name: Cache coverage files
-              uses: actions/cache@v2
-              id: cache-coverage
-              env:
-                  cache-name: cache-coverage-${{ matrix.environment }}
-              with:
-                  path: ${{ matrix.environment }}/coverage
-                  key: ${{ matrix.environment }}-${{ hashFiles('${{ matrix.environment }}/coverage/**') }}
-            - name: Run Tests
-              run: cd ${{ matrix.environment }} && npm run test:ci
-
-    test-merge-coverage:
-        timeout-minutes: 1
-        runs-on: ${{ matrix.os }}
-
-        needs: test
-
-        strategy:
-            matrix:
-                os: [ubuntu-latest]
-            fail-fast: false
-
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
-              with:
-                  node-version: '16'
-            - name: Cache node modules
-              uses: actions/cache@v2
-              id: cache-node-modules
-              env:
-                  cache-name: cache-node-modules
-              with:
-                  path: |
-                      node_modules
-                      shared/node_modules
-                      frontend/node_modules
-                      backend/node_modules
-                  key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('package-lock.json') }}
-            - name: Cache coverage backend
-              uses: actions/cache@v2
-              id: cache-coverage-backend
-              env:
-                  cache-name: cache-coverage-backend
-              with:
-                  path: backend/coverage
-                  key: backend-${{ hashFiles('backend/coverage/**') }}
-            - name: Cache coverage frontend
-              uses: actions/cache@v2
-              id: cache-coverage-frontend
-              env:
-                  cache-name: cache-coverage-frontend
-              with:
-                  path: frontend/coverage
-                  key: frontend-${{ hashFiles('frontend/coverage/**') }}
-            - name: Cache coverage shared
-              uses: actions/cache@v2
-              id: cache-coverage-shared
-              env:
-                  cache-name: cache-coverage-shared
-              with:
-                  path: shared/coverage
-                  key: shared-${{ hashFiles('shared/coverage/**') }}
+            - name: Run Backend Tests
+              run: cd backend && npm run test:ci; cd ..
+              if: always()
+            - name: Run Frontend Tests
+              run: cd frontend && npm run test:ci; cd ..
+              if: always()
+            - name: Run Shared Tests
+              run: cd shared && npm run test:ci; cd ..
+              if: always()
             - name: Merge coverage
               run: npm run merge-coverage
+              if: always()
             - name: Upload coverage
               uses: actions/upload-artifact@v2
+              if: always()
               with:
                   name: coverage-output
                   path: coverage


### PR DESCRIPTION
Closes #319 

This seems to be way more efficient: Compare the billable and the real time of https://github.com/hpi-sam/digital-fuesim-manv/actions/runs/2219567998 (from this branch) and https://github.com/hpi-sam/digital-fuesim-manv/actions/runs/2219539892 (from another branch).