### PR TITLE
Only select elements in viewports

### DIFF
--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/viewport-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/viewport-feature-manager.ts
@@ -1,6 +1,5 @@
 import type { Store } from '@ngrx/store';
-import { Size } from 'digital-fuesim-manv-shared';
-import type { Viewport } from 'digital-fuesim-manv-shared/src/models/viewport';
+import { Viewport, Size } from 'digital-fuesim-manv-shared';
 import type { Feature } from 'ol';
 import type OlMap from 'ol/Map';
 import type LineString from 'ol/geom/LineString';
@@ -25,12 +24,10 @@ export function isInViewport(
     coordinate: Coordinate,
     viewport: Viewport
 ): boolean {
-    return (
-        viewport.position.x <= coordinate[0] &&
-        coordinate[0] <= viewport.position.x + viewport.size.width &&
-        viewport.position.y - viewport.size.height <= coordinate[1] &&
-        coordinate[1] <= viewport.position.y
-    );
+    return Viewport.isInViewport(viewport, {
+        x: coordinate[0],
+        y: coordinate[1],
+    });
 }
 
 class BaseViewportFeatureManager

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
@@ -13,7 +13,7 @@ import VectorSource from 'ol/source/Vector';
 import XYZ from 'ol/source/XYZ';
 import {
     selectViewports,
-    getSelectWithPosition,
+    getSelectVisibleElements,
     selectCateringLines,
     selectTransferLines,
     selectMapImages,
@@ -225,7 +225,12 @@ export class OlMapManager {
                 transferPointLayer,
                 this.apiService
             ),
-            this.store.select(getSelectWithPosition('transferPoints'))
+            this.store.select(
+                getSelectVisibleElements(
+                    'transferPoints',
+                    this.apiService.ownClientId!
+                )
+            )
         ).togglePopup$.subscribe(this.changePopup$);
 
         this.registerFeatureElementManager(
@@ -235,7 +240,12 @@ export class OlMapManager {
                 patientLayer,
                 this.apiService
             ),
-            this.store.select(getSelectWithPosition('patients'))
+            this.store.select(
+                getSelectVisibleElements(
+                    'patients',
+                    this.apiService.ownClientId!
+                )
+            )
         ).togglePopup$.subscribe(this.changePopup$);
 
         this.registerFeatureElementManager(
@@ -245,7 +255,12 @@ export class OlMapManager {
                 vehicleLayer,
                 this.apiService
             ),
-            this.store.select(getSelectWithPosition('vehicles'))
+            this.store.select(
+                getSelectVisibleElements(
+                    'vehicles',
+                    this.apiService.ownClientId!
+                )
+            )
         ).togglePopup$.subscribe(this.changePopup$);
 
         this.registerFeatureElementManager(
@@ -255,7 +270,12 @@ export class OlMapManager {
                 personnelLayer,
                 this.apiService
             ),
-            this.store.select(getSelectWithPosition('personnel'))
+            this.store.select(
+                getSelectVisibleElements(
+                    'personnel',
+                    this.apiService.ownClientId!
+                )
+            )
         );
 
         this.registerFeatureElementManager(
@@ -265,7 +285,12 @@ export class OlMapManager {
                 materialLayer,
                 this.apiService
             ),
-            this.store.select(getSelectWithPosition('materials'))
+            this.store.select(
+                getSelectVisibleElements(
+                    'materials',
+                    this.apiService.ownClientId!
+                )
+            )
         );
 
         this.registerFeatureElementManager(

--- a/shared/src/models/viewport.ts
+++ b/shared/src/models/viewport.ts
@@ -39,4 +39,13 @@ export class Viewport {
         height: 1800,
         aspectRatio: 1600 / 900,
     };
+
+    static isInViewport(viewport: Viewport, position: Position): boolean {
+        return (
+            viewport.position.x <= position.x &&
+            position.x <= viewport.position.x + viewport.size.width &&
+            viewport.position.y - viewport.size.height <= position.y &&
+            position.y <= viewport.position.y
+        );
+    }
 }


### PR DESCRIPTION
This improves the performance for participants in viewports by only selecting elements in their viewports. This means that OpenLayers has to create much fewer elements (and has to react to much fewer changes).