### PR TITLE
Refactoring/get element in reducers

### DIFF
--- a/.eslint/typescript.eslintrc.cjs
+++ b/.eslint/typescript.eslintrc.cjs
@@ -295,7 +295,7 @@ module.exports = {
         ],
         '@typescript-eslint/no-base-to-string': 'warn',
         '@typescript-eslint/no-confusing-non-null-assertion': 'warn',
-        '@typescript-eslint/no-namespace': 'warn',
+        '@typescript-eslint/no-namespace': 'off',
         '@typescript-eslint/non-nullable-type-assertion-style': 'warn',
         '@typescript-eslint/sort-type-union-intersection-members': 'warn',
         '@typescript-eslint/no-confusing-void-expression': [
@@ -363,7 +363,7 @@ module.exports = {
                 hoist: 'all',
             },
         ],
-        '@typescript-eslint/no-throw-literal': 'warn',
+        '@typescript-eslint/no-throw-literal': 'off',
         '@typescript-eslint/no-unused-expressions': 'warn',
         '@typescript-eslint/no-unused-vars': ['warn', { args: 'none' }],
         '@typescript-eslint/no-use-before-define': 'off',

--- a/frontend/cypress/support/index.ts
+++ b/frontend/cypress/support/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/method-signature-style */
 // ***********************************************************
 // This example support/index.js is processed and

--- a/shared/src/store/action-reducers/client.ts
+++ b/shared/src/store/action-reducers/client.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-throw-literal */
-/* eslint-disable @typescript-eslint/no-namespace */
 import { Type } from 'class-transformer';
 import {
     IsString,

--- a/shared/src/store/action-reducers/exercise.ts
+++ b/shared/src/store/action-reducers/exercise.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-throw-literal */
-/* eslint-disable @typescript-eslint/no-namespace */
-
 import { Type } from 'class-transformer';
 import {
     IsString,

--- a/shared/src/store/action-reducers/map-images.ts
+++ b/shared/src/store/action-reducers/map-images.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-throw-literal */
-/* eslint-disable @typescript-eslint/no-namespace */
 import { Type } from 'class-transformer';
 import {
     IsString,

--- a/shared/src/store/action-reducers/material.ts
+++ b/shared/src/store/action-reducers/material.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-throw-literal */
-/* eslint-disable @typescript-eslint/no-namespace */
 import { Type } from 'class-transformer';
 import { IsString, IsUUID, ValidateNested } from 'class-validator';
 import { Position } from '../../models/utils';

--- a/shared/src/store/action-reducers/patient.ts
+++ b/shared/src/store/action-reducers/patient.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-throw-literal */
-/* eslint-disable @typescript-eslint/no-namespace */
 import { Type } from 'class-transformer';
 import { IsString, IsUUID, ValidateNested } from 'class-validator';
 import { Patient } from '../../models';

--- a/shared/src/store/action-reducers/personnel.ts
+++ b/shared/src/store/action-reducers/personnel.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-throw-literal */
-/* eslint-disable @typescript-eslint/no-namespace */
 import { Type } from 'class-transformer';
 import { IsString, IsUUID, ValidateNested } from 'class-validator';
 import { Position } from '../../models/utils';

--- a/shared/src/store/action-reducers/transfer-point.ts
+++ b/shared/src/store/action-reducers/transfer-point.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-throw-literal */
-/* eslint-disable @typescript-eslint/no-namespace */
 import { Type } from 'class-transformer';
 import {
     IsNumber,

--- a/shared/src/store/action-reducers/utils/get-element.ts
+++ b/shared/src/store/action-reducers/utils/get-element.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-throw-literal */
 import type { ExerciseState } from '../../../state';
 import type { Mutable, UUID } from '../../../utils';
 import { ReducerError } from '../../reducer-error';

--- a/shared/src/store/action-reducers/utils/transfer-element.ts
+++ b/shared/src/store/action-reducers/utils/transfer-element.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-throw-literal */
 import type { Personnel, Vehicle } from '../../../models';
 import type { ExerciseState } from '../../../state';
 import type { Mutable, UUID } from '../../../utils';

--- a/shared/src/store/action-reducers/vehicle.ts
+++ b/shared/src/store/action-reducers/vehicle.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-throw-literal */
-/* eslint-disable @typescript-eslint/no-namespace */
 import { Type } from 'class-transformer';
 import { IsArray, IsString, IsUUID, ValidateNested } from 'class-validator';
 import { Material, Personnel, Vehicle } from '../../models';

--- a/shared/src/store/action-reducers/viewport.ts
+++ b/shared/src/store/action-reducers/viewport.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-throw-literal */
-/* eslint-disable @typescript-eslint/no-namespace */
 import { Type } from 'class-transformer';
 import { IsString, IsUUID, ValidateNested } from 'class-validator';
 import { Viewport } from '../../models';


### PR DESCRIPTION
This Pull request focuses on code improvements in `/shared/state/action-reducers`
* Removes the eslint rules that we disable all the time on the file level
* Adds a `getElement` helper method to reduce code duplication (and discoverabilty)