### PR TITLE
Include `emitterId` in `ExerciseTimeline`

### DIFF
--- a/backend/src/exercise/exercise-wrapper.ts
+++ b/backend/src/exercise/exercise-wrapper.ts
@@ -620,6 +620,7 @@ export class ExerciseWrapper extends NormalType<
             initialState: this.initialState,
             actionsWrappers: completeHistory.map((action) => ({
                 action: action.action,
+                emitterId: action.emitterId,
                 time: action.index,
             })),
         };

--- a/shared/src/utils/exercise-time-line.ts
+++ b/shared/src/utils/exercise-time-line.ts
@@ -1,10 +1,15 @@
 import type { ExerciseState } from '../state';
 import type { ExerciseAction } from '../store';
+import type { UUID } from './uuid';
 
 export interface ExerciseTimeline {
     readonly initialState: ExerciseState;
     readonly actionsWrappers: readonly {
         readonly action: ExerciseAction;
+        /**
+         * This value is `null` iff the action was proposed by the server, otherwise it's the id of the proposing client in the state at that time.
+         */
+        readonly emitterId: UUID | null;
         readonly time: number;
     }[];
 }


### PR DESCRIPTION
Closes #437 