### PR TITLE
Fix #390 - treat actions always as immutable

### DIFF
--- a/frontend/src/app/core/time-jump-helper.ts
+++ b/frontend/src/app/core/time-jump-helper.ts
@@ -2,7 +2,7 @@ import type {
     ExerciseState,
     ExerciseTimeline,
 } from 'digital-fuesim-manv-shared';
-import { applyAction, cloneDeepMutable } from 'digital-fuesim-manv-shared';
+import { applyAction } from 'digital-fuesim-manv-shared';
 import produce from 'immer';
 import { environment } from 'src/environments/environment';
 import { TimeLineCache } from './time-line-cache';

--- a/frontend/src/app/core/time-jump-helper.ts
+++ b/frontend/src/app/core/time-jump-helper.ts
@@ -49,16 +49,7 @@ export class TimeJumpHelper {
                 lastAppliedActionIndex < actions.length;
                 lastAppliedActionIndex++
             ) {
-                const action = actions[lastAppliedActionIndex];
-                // If an action has been applied and adds part of it to the state (e.g. add a new element from the action),
-                // this part is immutable, because the action is immutable.
-                // If we try to mutate this part later on, we get an error because we modified the action, which is an immutable object
-                // (enforced via Object.freeze).
-                // To mitigate this, we clone the action to make it mutable.
-                // TODO: Think more about Should this maybe even be another requirement in the reducers (Mutable actions)?
-                // this could still fail because of a `Object.frozen` error (the action applies an immutable object to the state)
-                const unfrozenAction = cloneDeepMutable(action);
-                applyAction(draftState, unfrozenAction);
+                applyAction(draftState, actions[lastAppliedActionIndex]);
 
                 // TODO: We actually want the last action after which currentTime <= exerciseTime
                 // Maybe look whether the action is a tick action and if so, check how much time would go by

--- a/shared/README.md
+++ b/shared/README.md
@@ -17,3 +17,7 @@ Keep in mind to add new exports to the `index.ts` file in the folder.
 ## Updates to state types
 
 Note that whenever the state types get updated you have to update `ExerciseState.currentStateVersion` in [`state.ts`](./src/state.ts).
+
+## IsDevelopment
+
+To check whether the current environment is in development or production mode, a global environment variable is assumed to be set. Look at [`utils/is-development.ts`](./src/utils/is-development.ts) for further information.

--- a/shared/src/models/utils/get-create.ts
+++ b/shared/src/models/utils/get-create.ts
@@ -1,7 +1,5 @@
 import type { Constructor } from '../../utils';
-
-// @ts-expect-error It is not guaranteed to run in node environment, but if it does we want to check for development mode
-export const isDevelopment = process?.env?.NODE_ENV === 'development';
+import { isDevelopment } from '../../utils/is-development';
 
 /**
  * Models must be JSON objects. This means they mustn't have any functions.

--- a/shared/src/models/utils/index.ts
+++ b/shared/src/models/utils/index.ts
@@ -9,7 +9,7 @@ export { ImageProperties } from './image-properties';
 export * from './tile-map-properties';
 export * from './biometric-information';
 export * from './health-points';
-export { getCreate, isDevelopment } from './get-create';
+export * from './get-create';
 export * from './immutable-date';
 export { AlarmGroupVehicle } from './alarm-group-vehicle';
 export * from './patient-status-code';

--- a/shared/src/models/utils/patient-status-code.ts
+++ b/shared/src/models/utils/patient-status-code.ts
@@ -15,7 +15,7 @@ export const colorCodeMap = {
 
 // This is only for typesafety
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const _colorCodeMap: { [key in ColorCode]: string } = colorCodeMap;
+const _colorCodeMap: { readonly [key in ColorCode]: string } = colorCodeMap;
 
 export const behaviourCodeMap: { [key in BehaviourCode]: string } = {
     A: 'bi-arrow-right-square-fill',

--- a/shared/src/store/action-reducer.ts
+++ b/shared/src/store/action-reducer.ts
@@ -51,6 +51,22 @@ export interface Action {
  * const anAction: ExerciseAction = { type: 'some action' };
  * exerciseReducerMap[anAction.type](draftState, anAction);
  * ```
+ *
+ *
+ * Be aware that the action is immutable!
+ * [TypeScript allows assigning immutable objects to properties of mutable objects](https://github.com/microsoft/TypeScript/issues/13347).
+ * Therefore you must always clone parts of the action before assigning them to the draftState.
+ * The same could also apply for objects created inside the reducer function - like with a `Model.create()`, which by default returns an immutable object.
+ *
+ * Example:
+ * ```ts
+ * const reducerFunction = (draftState, anAction) =>  {
+ *     draftState.someObject = cloneDeepMutable(anAction.someObject);
+ *     draftState.someOtherObject = cloneDeepMutable(SomeOtherObject.create());
+ *     return draftState;
+ * }
+ * ```
+ *
  */
 type ReducerFunction<A extends Action> = (
     // These functions can only work with a mutable state object, because we expect them to be executed in immers produce context.

--- a/shared/src/store/action-reducers/alarm-group.ts
+++ b/shared/src/store/action-reducers/alarm-group.ts
@@ -9,7 +9,7 @@ import {
 import { AlarmGroup } from '../../models/alarm-group';
 import { AlarmGroupVehicle } from '../../models/utils/alarm-group-vehicle';
 import type { Mutable } from '../../utils';
-import { UUID, uuidValidationOptions } from '../../utils';
+import { cloneDeepMutable, UUID, uuidValidationOptions } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { ReducerError } from '../reducer-error';
 import { getElement } from './utils/get-element';
@@ -83,7 +83,8 @@ export namespace AlarmGroupActionReducers {
     export const addAlarmGroup: ActionReducer<AddAlarmGroupAction> = {
         action: AddAlarmGroupAction,
         reducer: (draftState, { alarmGroup }) => {
-            draftState.alarmGroups[alarmGroup.id] = alarmGroup;
+            draftState.alarmGroups[alarmGroup.id] =
+                cloneDeepMutable(alarmGroup);
             return draftState;
         },
         rights: 'trainer',
@@ -123,7 +124,7 @@ export namespace AlarmGroupActionReducers {
                     alarmGroupId
                 );
                 alarmGroup.alarmGroupVehicles[alarmGroupVehicle.id] =
-                    alarmGroupVehicle;
+                    cloneDeepMutable(alarmGroupVehicle);
                 return draftState;
             },
             rights: 'trainer',

--- a/shared/src/store/action-reducers/client.ts
+++ b/shared/src/store/action-reducers/client.ts
@@ -7,7 +7,7 @@ import {
     IsBoolean,
 } from 'class-validator';
 import { Client } from '../../models';
-import { uuidValidationOptions, UUID } from '../../utils';
+import { uuidValidationOptions, UUID, cloneDeepMutable } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { getElement } from './utils/get-element';
 
@@ -49,7 +49,7 @@ export namespace ClientActionReducers {
     export const addClient: ActionReducer<AddClientAction> = {
         action: AddClientAction,
         reducer: (draftState, { client }) => {
-            draftState.clients[client.id] = client;
+            draftState.clients[client.id] = cloneDeepMutable(client);
             return draftState;
         },
         rights: 'server',

--- a/shared/src/store/action-reducers/configuration.ts
+++ b/shared/src/store/action-reducers/configuration.ts
@@ -1,6 +1,7 @@
 import { Type } from 'class-transformer';
 import { IsBoolean, IsString, ValidateNested } from 'class-validator';
 import { TileMapProperties } from '../../models/utils';
+import { cloneDeepMutable } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 
 export class SetTileMapPropertiesAction implements Action {
@@ -33,7 +34,8 @@ export namespace ConfigurationActionReducers {
         {
             action: SetTileMapPropertiesAction,
             reducer: (draftState, { tileMapProperties }) => {
-                draftState.configuration.tileMapProperties = tileMapProperties;
+                draftState.configuration.tileMapProperties =
+                    cloneDeepMutable(tileMapProperties);
                 return draftState;
             },
             rights: 'trainer',

--- a/shared/src/store/action-reducers/hospital.ts
+++ b/shared/src/store/action-reducers/hospital.ts
@@ -8,11 +8,11 @@ import {
 } from 'class-validator';
 import { Hospital } from '../../models';
 import { HospitalPatient } from '../../models/hospital-patient';
-import { UUID, uuidValidationOptions } from '../../utils';
+import { cloneDeepMutable, UUID, uuidValidationOptions } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
-import { deleteVehicle } from './vehicle';
 import { calculateTreatments } from './utils/calculate-treatments';
 import { getElement } from './utils/get-element';
+import { deleteVehicle } from './vehicle';
 
 export class AddHospitalAction implements Action {
     @IsString()
@@ -64,7 +64,7 @@ export namespace HospitalActionReducers {
     export const addHospital: ActionReducer<AddHospitalAction> = {
         action: AddHospitalAction,
         reducer: (draftState, { hospital }) => {
-            draftState.hospitals[hospital.id] = hospital;
+            draftState.hospitals[hospital.id] = cloneDeepMutable(hospital);
             return draftState;
         },
         rights: 'trainer',

--- a/shared/src/store/action-reducers/map-image-templates.ts
+++ b/shared/src/store/action-reducers/map-image-templates.ts
@@ -4,7 +4,7 @@ import { MapImageTemplate } from '../../models';
 import { ImageProperties } from '../../models/utils';
 import type { ExerciseState } from '../../state';
 import type { Mutable } from '../../utils';
-import { UUID, uuidValidationOptions } from '../../utils';
+import { cloneDeepMutable, UUID, uuidValidationOptions } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { ReducerError } from '../reducer-error';
 
@@ -54,7 +54,9 @@ export namespace MapImageTemplatesActionReducers {
                         `MapImageTemplate with id ${mapImageTemplate.id} already exists`
                     );
                 }
-                draftState.mapImageTemplates.push(mapImageTemplate);
+                draftState.mapImageTemplates.push(
+                    cloneDeepMutable(mapImageTemplate)
+                );
                 return draftState;
             },
             rights: 'trainer',
@@ -66,7 +68,7 @@ export namespace MapImageTemplatesActionReducers {
             reducer: (draftState, { id, name, image }) => {
                 const mapImageTemplate = getMapImageTemplate(draftState, id);
                 mapImageTemplate.name = name;
-                mapImageTemplate.image = image;
+                mapImageTemplate.image = cloneDeepMutable(image);
                 return draftState;
             },
             rights: 'trainer',

--- a/shared/src/store/action-reducers/map-images.ts
+++ b/shared/src/store/action-reducers/map-images.ts
@@ -8,7 +8,7 @@ import {
 } from 'class-validator';
 import { MapImage } from '../../models';
 import { Position } from '../../models/utils';
-import { uuidValidationOptions, UUID } from '../../utils';
+import { uuidValidationOptions, UUID, cloneDeepMutable } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { getElement } from './utils/get-element';
 
@@ -75,7 +75,7 @@ export namespace MapImagesActionReducers {
     export const addMapImage: ActionReducer<AddMapImageAction> = {
         action: AddMapImageAction,
         reducer: (draftState, { mapImage }) => {
-            draftState.mapImages[mapImage.id] = mapImage;
+            draftState.mapImages[mapImage.id] = cloneDeepMutable(mapImage);
             return draftState;
         },
         rights: 'trainer',
@@ -85,7 +85,7 @@ export namespace MapImagesActionReducers {
         action: MoveMapImageAction,
         reducer: (draftState, { mapImageId, targetPosition }) => {
             const mapImage = getElement(draftState, 'mapImages', mapImageId);
-            mapImage.position = targetPosition;
+            mapImage.position = cloneDeepMutable(targetPosition);
             return draftState;
         },
         rights: 'trainer',

--- a/shared/src/store/action-reducers/material.ts
+++ b/shared/src/store/action-reducers/material.ts
@@ -1,7 +1,7 @@
 import { Type } from 'class-transformer';
 import { IsString, IsUUID, ValidateNested } from 'class-validator';
 import { Position } from '../../models/utils';
-import { uuidValidationOptions, UUID } from '../../utils';
+import { uuidValidationOptions, UUID, cloneDeepMutable } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { calculateTreatments } from './utils/calculate-treatments';
 import { getElement } from './utils/get-element';
@@ -23,7 +23,7 @@ export namespace MaterialActionReducers {
         action: MoveMaterialAction,
         reducer: (draftState, { materialId, targetPosition }) => {
             const material = getElement(draftState, 'materials', materialId);
-            material.position = targetPosition;
+            material.position = cloneDeepMutable(targetPosition);
             calculateTreatments(draftState);
             return draftState;
         },

--- a/shared/src/store/action-reducers/patient.ts
+++ b/shared/src/store/action-reducers/patient.ts
@@ -101,7 +101,7 @@ export namespace PatientActionReducers {
         action: MovePatientAction,
         reducer: (draftState, { patientId, targetPosition }) => {
             const patient = getElement(draftState, 'patients', patientId);
-            patient.position = targetPosition;
+            patient.position = cloneDeepMutable(targetPosition);
             calculateTreatments(draftState);
             return draftState;
         },

--- a/shared/src/store/action-reducers/personnel.ts
+++ b/shared/src/store/action-reducers/personnel.ts
@@ -1,7 +1,7 @@
 import { Type } from 'class-transformer';
 import { IsString, IsUUID, ValidateNested } from 'class-validator';
 import { Position } from '../../models/utils';
-import { UUID, uuidValidationOptions } from '../../utils';
+import { cloneDeepMutable, UUID, uuidValidationOptions } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { calculateTreatments } from './utils/calculate-treatments';
 import { getElement } from './utils/get-element';
@@ -23,7 +23,7 @@ export namespace PersonnelActionReducers {
         action: MovePersonnelAction,
         reducer: (draftState, { personnelId, targetPosition }) => {
             const personnel = getElement(draftState, 'personnel', personnelId);
-            personnel.position = targetPosition;
+            personnel.position = cloneDeepMutable(targetPosition);
             calculateTreatments(draftState);
             return draftState;
         },

--- a/shared/src/store/action-reducers/transfer.ts
+++ b/shared/src/store/action-reducers/transfer.ts
@@ -3,7 +3,7 @@ import type { ExerciseState } from '../..';
 import { imageSizeToPosition, Position, TransferPoint } from '../..';
 import { StartPoint } from '../../models/utils/start-points';
 import type { Mutable } from '../../utils';
-import { UUID, uuidValidationOptions } from '../../utils';
+import { cloneDeepMutable, UUID, uuidValidationOptions } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { ReducerError } from '../reducer-error';
 import { getElement } from './utils/get-element';
@@ -144,7 +144,7 @@ export namespace TransferActionReducers {
             // Set the element to transfer
             delete element.position;
             element.transfer = {
-                startPoint,
+                startPoint: cloneDeepMutable(startPoint),
                 targetTransferPointId,
                 endTimeStamp: draftState.currentTime + duration,
                 isPaused: false,

--- a/shared/src/store/action-reducers/utils/calculate-treatments.spec.ts
+++ b/shared/src/store/action-reducers/utils/calculate-treatments.spec.ts
@@ -63,7 +63,7 @@ function generatePatient(
     patient.pretriageStatus = pretriageStatus;
     patient.realStatus = realStatus;
     if (position) {
-        patient.position = { ...position };
+        patient.position = cloneDeepMutable(position);
     }
     return patient;
 }
@@ -73,7 +73,7 @@ function generatePersonnel(position?: Position) {
         Personnel.create(uuid(), 'RTW 3/83/1', 'notSan', {})
     );
     if (position) {
-        personnel.position = { ...position };
+        personnel.position = cloneDeepMutable(position);
     }
     return personnel;
 }
@@ -88,7 +88,7 @@ function generateMaterial(position?: Position) {
         )
     );
     if (position) {
-        material.position = { ...position };
+        material.position = cloneDeepMutable(position);
     }
     return material;
 }
@@ -350,7 +350,9 @@ describe('calculate treatment', () => {
                     Position.create(2, 2)
                 );
                 const material = generateMaterial(Position.create(0, 0));
-                material.canCaterFor = CanCaterFor.create(1, 0, 1, 'and');
+                material.canCaterFor = cloneDeepMutable(
+                    CanCaterFor.create(1, 0, 1, 'and')
+                );
 
                 ids.material = material.id;
                 ids.greenPatient = greenPatient.id;

--- a/shared/src/store/action-reducers/utils/calculate-treatments.ts
+++ b/shared/src/store/action-reducers/utils/calculate-treatments.ts
@@ -134,7 +134,7 @@ export function calculateTreatments(state: Mutable<ExerciseState>) {
 }
 
 function calculateCatering(
-    catering: Material | Personnel,
+    catering: Mutable<Material | Personnel>,
     patients: Mutable<Patient>[],
     pretriageEnabled: boolean,
     bluePatientsEnabled: boolean

--- a/shared/src/store/action-reducers/vehicle.ts
+++ b/shared/src/store/action-reducers/vehicle.ts
@@ -5,7 +5,7 @@ import { Position } from '../../models/utils';
 import type { ExerciseState } from '../../state';
 import { imageSizeToPosition } from '../../state-helpers';
 import type { Mutable } from '../../utils';
-import { UUID, uuidValidationOptions } from '../../utils';
+import { cloneDeepMutable, UUID, uuidValidationOptions } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { ReducerError } from '../reducer-error';
 import { deletePatient } from './patient';
@@ -109,9 +109,9 @@ export namespace VehicleActionReducers {
         reducer: (draftState, { vehicle, materials, personnel }) => {
             if (
                 materials.some(
-                    (currentMaterial) =>
-                        currentMaterial.vehicleId !== vehicle.id ||
-                        vehicle.materialIds[currentMaterial.id] === undefined
+                    (material) =>
+                        material.vehicleId !== vehicle.id ||
+                        vehicle.materialIds[material.id] === undefined
                 ) ||
                 Object.keys(vehicle.materialIds).length !== materials.length
             ) {
@@ -131,12 +131,12 @@ export namespace VehicleActionReducers {
                     'Vehicle personnel ids do not match personnel ids'
                 );
             }
-            draftState.vehicles[vehicle.id] = vehicle;
-            for (const currentMaterial of materials) {
-                draftState.materials[currentMaterial.id] = currentMaterial;
+            draftState.vehicles[vehicle.id] = cloneDeepMutable(vehicle);
+            for (const material of materials) {
+                draftState.materials[material.id] = cloneDeepMutable(material);
             }
             for (const person of personnel) {
-                draftState.personnel[person.id] = person;
+                draftState.personnel[person.id] = cloneDeepMutable(person);
             }
             return draftState;
         },
@@ -147,7 +147,7 @@ export namespace VehicleActionReducers {
         action: MoveVehicleAction,
         reducer: (draftState, { vehicleId, targetPosition }) => {
             const vehicle = getElement(draftState, 'vehicles', vehicleId);
-            vehicle.position = targetPosition;
+            vehicle.position = cloneDeepMutable(targetPosition);
             return draftState;
         },
         rights: 'participant',

--- a/shared/src/store/action-reducers/viewport.ts
+++ b/shared/src/store/action-reducers/viewport.ts
@@ -2,7 +2,7 @@ import { Type } from 'class-transformer';
 import { IsString, IsUUID, ValidateNested } from 'class-validator';
 import { Viewport } from '../../models';
 import { Position, Size } from '../../models/utils';
-import { uuidValidationOptions, UUID } from '../../utils';
+import { uuidValidationOptions, UUID, cloneDeepMutable } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { getElement } from './utils/get-element';
 
@@ -59,7 +59,7 @@ export namespace ViewportActionReducers {
     export const addViewport: ActionReducer<AddViewportAction> = {
         action: AddViewportAction,
         reducer: (draftState, { viewport }) => {
-            draftState.viewports[viewport.id] = viewport;
+            draftState.viewports[viewport.id] = cloneDeepMutable(viewport);
             return draftState;
         },
         rights: 'trainer',
@@ -79,7 +79,7 @@ export namespace ViewportActionReducers {
         action: MoveViewportAction,
         reducer: (draftState, { viewportId, targetPosition }) => {
             const viewport = getElement(draftState, 'viewports', viewportId);
-            viewport.position = targetPosition;
+            viewport.position = cloneDeepMutable(targetPosition);
             return draftState;
         },
         rights: 'trainer',
@@ -89,8 +89,8 @@ export namespace ViewportActionReducers {
         action: ResizeViewportAction,
         reducer: (draftState, { viewportId, targetPosition, newSize }) => {
             const viewport = getElement(draftState, 'viewports', viewportId);
-            viewport.position = targetPosition;
-            viewport.size = newSize;
+            viewport.position = cloneDeepMutable(targetPosition);
+            viewport.size = cloneDeepMutable(newSize);
             return draftState;
         },
         rights: 'trainer',

--- a/shared/src/store/reduce-exercise-state.ts
+++ b/shared/src/store/reduce-exercise-state.ts
@@ -21,10 +21,6 @@ export function reduceExerciseState(
     state: ExerciseState,
     action: ExerciseAction
 ): ExerciseState {
-    if (isDevelopment) {
-        // Make sure that the action isn't mutated in the reducer
-        freeze(action, true);
-    }
     // use immer to convert mutating operations to immutable ones (https://immerjs.github.io/immer/produce)
     return produce(state, (draftState) => applyAction(draftState, action));
 }

--- a/shared/src/store/reduce-exercise-state.ts
+++ b/shared/src/store/reduce-exercise-state.ts
@@ -1,10 +1,14 @@
-import { produce } from 'immer';
+import { freeze, produce, setAutoFreeze } from 'immer';
 import type { ExerciseState } from '../state';
 import type { Mutable } from '../utils';
+import { isDevelopment } from '../utils/is-development';
 import type { ExerciseAction } from './action-reducers';
 import { getExerciseActionTypeDictionary } from './action-reducers';
 
 const exerciseActionTypeDictionary = getExerciseActionTypeDictionary();
+
+// See https://immerjs.github.io/immer/freezing for more information.
+setAutoFreeze(isDevelopment);
 
 /**
  * A pure reducer function that applies the action on the state without mutating it.
@@ -17,6 +21,10 @@ export function reduceExerciseState(
     state: ExerciseState,
     action: ExerciseAction
 ): ExerciseState {
+    if (isDevelopment) {
+        // Make sure that the action isn't mutated in the reducer
+        freeze(action, true);
+    }
     // use immer to convert mutating operations to immutable ones (https://immerjs.github.io/immer/produce)
     return produce(state, (draftState) => applyAction(draftState, action));
 }
@@ -32,6 +40,10 @@ export function applyAction(
     draftState: Mutable<ExerciseState>,
     action: ExerciseAction
 ) {
+    if (isDevelopment) {
+        // Make sure that the action isn't mutated in the reducer
+        freeze(action, true);
+    }
     return exerciseActionTypeDictionary[action.type].reducer(
         draftState,
         // typescript doesn't narrow action and the reducer to the correct ones based on action.type

--- a/shared/src/utils/is-development.ts
+++ b/shared/src/utils/is-development.ts
@@ -1,0 +1,10 @@
+// This environment is set at the backend and (manually) on the frontend, therefore we can use it in here
+declare global {
+    const process: {
+        env: {
+            NODE_ENV: 'development' | 'production';
+        };
+    };
+}
+
+export const isDevelopment = process?.env?.NODE_ENV === 'development';


### PR DESCRIPTION
* Fixes #390 by 
    * adding documentation about the bug, 
    * freezing state, and actions (in development) and 
    * assuming that actions are treated as immutable in the reducer.
* There are still errors in development that only occur when trying to replay the state during time travel. Maybe we could write some tests for the reducers in the future (initialState + a lot of actions -> apply all of them synchronously and check whether 1. no error occurs, 2. the resulting state is the expected one).

I originally intended to do more in this PR, but I think I will come back to some of this stuff later -> this is ready for review.