### PR TITLE
Fix state migrations

### DIFF
--- a/backend/src/database/state-migrations/impossible-migration.ts
+++ b/backend/src/database/state-migrations/impossible-migration.ts
@@ -1,8 +1,8 @@
 import type { UUID } from 'digital-fuesim-manv-shared';
 import { RestoreError } from '../../utils/restore-error';
-import type { MigrationSpecification } from './migrations';
+import type { Migration } from './migrations';
 
-export const impossibleMigration: MigrationSpecification = {
+export const impossibleMigration: Migration = {
     actions: (initialState, actions) => {
         throw new RestoreError(
             'The migration is not possible',

--- a/backend/src/database/state-migrations/impossible-migration.ts
+++ b/backend/src/database/state-migrations/impossible-migration.ts
@@ -1,0 +1,20 @@
+import { RestoreError } from '../../utils/restore-error';
+import type { MigrationFunctions } from './migrations';
+
+export const impossibleMigration: MigrationFunctions = {
+    database: (_entityManager, exerciseId) => {
+        throw new RestoreError('The migration is not possible', exerciseId);
+    },
+    inMemory: (exerciseWrapper) => {
+        throw new RestoreError(
+            'The migration is not possible',
+            exerciseWrapper.id ?? 'unknown id'
+        );
+    },
+    stateExport: (stateExport) => {
+        throw new RestoreError(
+            'The migration is not possible',
+            stateExport.currentState.id ?? 'unknown id'
+        );
+    },
+};

--- a/backend/src/database/state-migrations/impossible-migration.ts
+++ b/backend/src/database/state-migrations/impossible-migration.ts
@@ -1,14 +1,18 @@
+import type { UUID } from 'digital-fuesim-manv-shared';
 import { RestoreError } from '../../utils/restore-error';
-import type { Migrations } from './migrations';
+import type { MigrationSpecification } from './migrations';
 
-export const impossibleMigration: Migrations = {
-    database: (_entityManager, exerciseId) => {
-        throw new RestoreError('The migration is not possible', exerciseId);
-    },
-    stateExport: (stateExport) => {
+export const impossibleMigration: MigrationSpecification = {
+    actions: (initialState, actions) => {
         throw new RestoreError(
             'The migration is not possible',
-            stateExport.currentState.id ?? 'unknown id'
+            (initialState as { id?: UUID }).id ?? 'unknown'
+        );
+    },
+    state: (state) => {
+        throw new RestoreError(
+            'The migration is not possible',
+            (state as { id?: UUID }).id ?? 'unknown'
         );
     },
 };

--- a/backend/src/database/state-migrations/impossible-migration.ts
+++ b/backend/src/database/state-migrations/impossible-migration.ts
@@ -1,15 +1,9 @@
 import { RestoreError } from '../../utils/restore-error';
-import type { MigrationFunctions } from './migrations';
+import type { Migrations } from './migrations';
 
-export const impossibleMigration: MigrationFunctions = {
+export const impossibleMigration: Migrations = {
     database: (_entityManager, exerciseId) => {
         throw new RestoreError('The migration is not possible', exerciseId);
-    },
-    inMemory: (exerciseWrapper) => {
-        throw new RestoreError(
-            'The migration is not possible',
-            exerciseWrapper.id ?? 'unknown id'
-        );
     },
     stateExport: (stateExport) => {
         throw new RestoreError(

--- a/backend/src/database/state-migrations/migrations.ts
+++ b/backend/src/database/state-migrations/migrations.ts
@@ -1,39 +1,40 @@
-import type { StateExport, UUID } from 'digital-fuesim-manv-shared';
+import type {
+    ExerciseState,
+    StateExport,
+    UUID,
+} from 'digital-fuesim-manv-shared';
 import type { EntityManager } from 'typeorm';
+import { RestoreError } from '../../utils/restore-error';
+import { ActionWrapperEntity } from '../entities/action-wrapper.entity';
+import { ExerciseWrapperEntity } from '../entities/exercise-wrapper.entity';
 import { impossibleMigration } from './impossible-migration';
 
 /**
- * Such a function MUST update the initial state of the exercise with the provided {@link exerciseId} as well as every action associated with it from its current state version to the next version in a way that they are valid states/actions.
- * It MAY throw a {@link RestoreError} in a case where upgrading is impossible and a terminal incompatibility with older exercises is necessary.
- * It MUST update the respective updates to the exercise and its associated objects in the database.
- * All database interaction MUST use the provided {@link EntityManager}.
+ * Such a function gets the already migrated initial state of the exercise and an array of all actions (not yet migrated).
+ * It is expected that afterwards the actions in the provided array are migrated.
+ * It is not allowed to modify the order of the actions, to add an action or to remove an action.
+ * To indicate that an action should be removed it can be replaced by `null`.
+ * It may throw a {@link RestoreError} when a migration is not possible.
  */
-export type DbMigration = (
-    entityManager: EntityManager,
-    exerciseId: UUID
-) => Promise<void>;
+type MigrateActionsFunction = (
+    initialState: object,
+    actions: (object | null)[]
+) => void;
 
 /**
- * Such a function MUST update the current state, and, if present, the initial state and the action history of the provided {@link stateExport} from its current state version to the next version in a way that they are valid states/actions.
- * It MAY throw a {@link RestoreError} in a case where upgrading is impossible and a terminal incompatibility with older exercises is necessary.
- * It MUST NOT use the database or any other resources like the exerciseMap.
+ * Such a function gets the not yet migrated state and is expected to return a migrated version of it.
+ * It may throw a {@link RestoreError} when a migration is not possible.
  */
-export type StateExportMigration = (
-    stateExport: StateExport
-) => Promise<StateExport>;
+type MigrateStateFunction = (state: object) => object;
 
-export interface Migrations {
-    database: DbMigration;
-    stateExport: StateExportMigration;
+export interface MigrationSpecification {
+    actions: MigrateActionsFunction | null;
+    state: MigrateStateFunction | null;
 }
 
 // TODO: It'd probably be better not to export this
-/**
- * This object MUST provide entries for every positive integer greater than 1 and less than or equal to ExerciseState.currentStateVersion.
- * A function with key `k` MUST be able to transform a valid exercise of state version `k-1` to a valid exercise of state version `k`.
- */
 export const migrations: {
-    [key: number]: Migrations;
+    [key: number]: MigrationSpecification;
 } = {
     2: impossibleMigration,
 };
@@ -44,25 +45,145 @@ export async function migrateInDatabaseTo(
     exerciseId: UUID,
     entityManager: EntityManager
 ): Promise<void> {
-    let currentVersion = currentStateVersion;
-    while (++currentVersion <= targetStateVersion) {
-        // eslint-disable-next-line no-await-in-loop
-        await migrations[currentVersion]!.database(entityManager, exerciseId);
+    const migrationFunctions = getRelevantFunctions(
+        currentStateVersion,
+        targetStateVersion
+    );
+    const stateMigrationFunctions = migrationFunctions.state;
+    const originalStates = await entityManager.findOne(ExerciseWrapperEntity, {
+        where: { id: exerciseId },
+        select: { initialStateString: true, currentStateString: true },
+    });
+    if (originalStates === null) {
+        throw new RestoreError(
+            'Cannot find exercise to convert in database',
+            exerciseId
+        );
+    }
+    let initialState: object | null = null,
+        currentState: object | null = null;
+    if (stateMigrationFunctions.length > 0) {
+        initialState = JSON.parse(originalStates.initialStateString);
+        currentState = JSON.parse(originalStates.currentStateString);
+        stateMigrationFunctions.forEach((stateMigrationFunction) => {
+            initialState = stateMigrationFunction(initialState!);
+            currentState = stateMigrationFunction(currentState!);
+        });
+    }
+    const actionsMigrationFunctions = migrationFunctions.actions;
+    let actions: (object | null)[] | null = null;
+    if (actionsMigrationFunctions.length > 0) {
+        const originalActions = await entityManager.find(ActionWrapperEntity, {
+            where: { exercise: { id: exerciseId } },
+            select: { actionString: true },
+            order: { index: 'ASC' },
+        });
+        actions = originalActions.map((originalAction) =>
+            JSON.parse(originalAction.actionString)
+        );
+        initialState ??= JSON.parse(originalStates.initialStateString);
+        actionsMigrationFunctions.forEach((actionsMigrationFunction) => {
+            actionsMigrationFunction(initialState!, actions!);
+        });
+    }
+    const patch: Partial<ExerciseWrapperEntity> = {
+        stateVersion: targetStateVersion,
+    };
+    if (currentState !== null) {
+        patch.initialStateString = JSON.stringify(initialState);
+        patch.currentStateString = JSON.stringify(currentState);
+    }
+    await entityManager.update(
+        ExerciseWrapperEntity,
+        { id: exerciseId },
+        patch
+    );
+    if (actions !== null) {
+        let index = 0;
+        const indicesToRemove: number[] = [];
+        const actionsToUpdate: [number, string][] = [];
+        actions.forEach((action, i) => {
+            if (action === null) {
+                indicesToRemove.push(i);
+                return;
+            }
+            actionsToUpdate.push([index++, JSON.stringify(action)]);
+        });
+        if (indicesToRemove.length > 0) {
+            await entityManager
+                .createQueryBuilder()
+                .delete()
+                .from(ActionWrapperEntity)
+                // eslint-disable-next-line unicorn/string-content
+                .where('index IN (:...ids)', { ids: indicesToRemove })
+                .execute();
+        }
+        if (actionsToUpdate.length > 0) {
+            await Promise.all(
+                actionsToUpdate.map(async (action) =>
+                    entityManager.update(
+                        ActionWrapperEntity,
+                        { index: action[0] },
+                        { actionString: action[1] }
+                    )
+                )
+            );
+        }
     }
 }
 
-export async function migrateStateExportTo(
+export function migrateStateExportTo(
     targetStateVersion: number,
     currentStateVersion: number,
     stateExport: StateExport
-): Promise<StateExport> {
-    let currentVersion = currentStateVersion;
-    let currentStateExport = stateExport;
-    while (++currentVersion <= targetStateVersion) {
-        // eslint-disable-next-line no-await-in-loop
-        currentStateExport = await migrations[currentVersion]!.stateExport(
-            currentStateExport
-        );
+): StateExport {
+    const migrationFunctions = getRelevantFunctions(
+        currentStateVersion,
+        targetStateVersion
+    );
+    migrationFunctions.state.forEach((fn) => {
+        stateExport.currentState = fn(
+            stateExport.currentState
+        ) as ExerciseState;
+        if (stateExport.history) {
+            stateExport.history.initialState = fn(
+                stateExport.history.initialState
+            ) as ExerciseState;
+        }
+    });
+    if (stateExport.history) {
+        migrationFunctions.actions.forEach((fn) => {
+            fn(
+                stateExport.history!.initialState,
+                stateExport.history!.actionHistory
+            );
+        });
+        stateExport.history.actionHistory.filter((action) => action !== null);
     }
-    return currentStateExport;
+    return stateExport;
+}
+
+function getRelevantFunctions(
+    initialVersion: number,
+    targetVersion: number
+): { actions: MigrateActionsFunction[]; state: MigrateStateFunction[] } {
+    const functions = Object.entries(migrations)
+        .filter(
+            ([key]) =>
+                Number.parseInt(key) > initialVersion &&
+                Number.parseInt(key) <= targetVersion
+        )
+        .map(([, migration]) => migration);
+    return {
+        actions: functions
+            .filter((thisFunctions) => thisFunctions.actions !== null)
+            .map(
+                (thisFunctions) => thisFunctions.actions
+            ) as MigrateActionsFunction[],
+        state: functions
+            .filter((thisFunctions) => thisFunctions.state !== null)
+            .map(
+                (thisFunctions) => thisFunctions.state
+            ) as MigrateStateFunction[],
+    };
 }

--- a/backend/src/database/state-migrations/migrations.ts
+++ b/backend/src/database/state-migrations/migrations.ts
@@ -1,6 +1,5 @@
 import type { StateExport, UUID } from 'digital-fuesim-manv-shared';
 import type { EntityManager } from 'typeorm';
-import type { ExerciseWrapper } from '../../exercise/exercise-wrapper';
 import { impossibleMigration } from './impossible-migration';
 
 /**
@@ -9,33 +8,23 @@ import { impossibleMigration } from './impossible-migration';
  * It MUST update the respective updates to the exercise and its associated objects in the database.
  * All database interaction MUST use the provided {@link EntityManager}.
  */
-export type DbMigrationFunction = (
+export type DbMigration = (
     entityManager: EntityManager,
     exerciseId: UUID
 ) => Promise<void>;
-
-/**
- * Such a function MUST update the initial state of the provided {@link exerciseWrapper} as well as every action associated with it from its current state version to the next version in a way that they are valid states/actions.
- * It MAY throw a {@link RestoreError} in a case where upgrading is impossible and a terminal incompatibility with older exercises is necessary.
- * It MUST NOT use the database.
- */
-export type InMemoryMigrationFunction = (
-    exerciseWrapper: ExerciseWrapper
-) => Promise<ExerciseWrapper>;
 
 /**
  * Such a function MUST update the current state, and, if present, the initial state and the action history of the provided {@link stateExport} from its current state version to the next version in a way that they are valid states/actions.
  * It MAY throw a {@link RestoreError} in a case where upgrading is impossible and a terminal incompatibility with older exercises is necessary.
  * It MUST NOT use the database or any other resources like the exerciseMap.
  */
-export type StateExportMigrationFunction = (
+export type StateExportMigration = (
     stateExport: StateExport
 ) => Promise<StateExport>;
 
-export interface MigrationFunctions {
-    database: DbMigrationFunction;
-    inMemory: InMemoryMigrationFunction;
-    stateExport: StateExportMigrationFunction;
+export interface Migrations {
+    database: DbMigration;
+    stateExport: StateExportMigration;
 }
 
 // TODO: It'd probably be better not to export this
@@ -44,7 +33,7 @@ export interface MigrationFunctions {
  * A function with key `k` MUST be able to transform a valid exercise of state version `k-1` to a valid exercise of state version `k`.
  */
 export const migrations: {
-    [key: number]: MigrationFunctions;
+    [key: number]: Migrations;
 } = {
     2: impossibleMigration,
 };
@@ -60,22 +49,6 @@ export async function migrateInDatabaseTo(
         // eslint-disable-next-line no-await-in-loop
         await migrations[currentVersion]!.database(entityManager, exerciseId);
     }
-}
-
-export async function migrateInMemoryTo(
-    targetStateVersion: number,
-    currentStateVersion: number,
-    exercise: ExerciseWrapper
-): Promise<ExerciseWrapper> {
-    let currentVersion = currentStateVersion;
-    let currentExercise = exercise;
-    while (++currentVersion <= targetStateVersion) {
-        // eslint-disable-next-line no-await-in-loop
-        currentExercise = await migrations[currentVersion]!.inMemory(
-            currentExercise
-        );
-    }
-    return currentExercise;
 }
 
 export async function migrateStateExportTo(

--- a/backend/src/exercise/exercise-wrapper.ts
+++ b/backend/src/exercise/exercise-wrapper.ts
@@ -23,10 +23,7 @@ import { Config } from '../config';
 import { RestoreError } from '../utils/restore-error';
 import { UserReadableIdGenerator } from '../utils/user-readable-id-generator';
 import type { ActionWrapperEntity } from '../database/entities/action-wrapper.entity';
-import {
-    migrateInDatabaseTo,
-    migrateInMemoryTo,
-} from '../database/state-migrations/migrations';
+import { migrateInDatabaseTo } from '../database/state-migrations/migrations';
 import { ActionWrapper } from './action-wrapper';
 import type { ClientWrapper } from './client-wrapper';
 import { exerciseMap } from './exercise-map';
@@ -243,21 +240,10 @@ export class ExerciseWrapper extends NormalType<
         public readonly temporaryActionHistory: ActionWrapper[],
         databaseService: DatabaseService,
         private readonly stateVersion: number,
-        private initialState = ExerciseState.create(),
+        private readonly initialState = ExerciseState.create(),
         private currentState: ExerciseState = initialState
     ) {
         super(databaseService);
-    }
-
-    public migrateStates(
-        update: (
-            initialState: unknown,
-            currentState: unknown
-        ) => { initialState: unknown; currentState: unknown }
-    ): void {
-        const result = update(this.initialState, this.currentState);
-        this.initialState = result.initialState as ExerciseState;
-        this.currentState = result.currentState as ExerciseState;
     }
 
     /**
@@ -269,7 +255,7 @@ export class ExerciseWrapper extends NormalType<
         exerciseIds: ExerciseIds
     ): Promise<ExerciseWrapper> {
         const importOperations = async (manager: EntityManager | undefined) => {
-            let exercise = new ExerciseWrapper(
+            const exercise = new ExerciseWrapper(
                 exerciseIds.participantId,
                 exerciseIds.trainerId,
                 [],
@@ -288,31 +274,6 @@ export class ExerciseWrapper extends NormalType<
                     )
             );
             exercise.temporaryActionHistory.push(...actions);
-            if (manager === undefined) {
-                // eslint-disable-next-line require-atomic-updates
-                exercise = await migrateInMemoryTo(
-                    ExerciseState.currentStateVersion,
-                    exercise.stateVersion,
-                    exercise
-                );
-            } else {
-                const exerciseEntity = await exercise.save(manager);
-                await migrateInDatabaseTo(
-                    ExerciseState.currentStateVersion,
-                    exercise.stateVersion,
-                    exerciseEntity.id,
-                    manager
-                );
-                // eslint-disable-next-line require-atomic-updates
-                exercise = ExerciseWrapper.createFromEntity(
-                    await databaseService.exerciseWrapperService.getFindById(
-                        exerciseEntity.id
-                    )(manager),
-                    databaseService
-                );
-                // Reset actions to apply them (they are removed when saving the entity to the database)
-                exercise.temporaryActionHistory.push(...actions);
-            }
             exercise.restore();
             exercise.applyAction(
                 {

--- a/shared/src/export-import/file-format/state-export.ts
+++ b/shared/src/export-import/file-format/state-export.ts
@@ -18,7 +18,7 @@ export class StateHistoryCompound {
 
     @ValidateNested()
     @Type(() => ExerciseState)
-    public readonly initialState: ExerciseState;
+    public initialState: ExerciseState;
 
     public validateActions(): (ValidationError | string)[][] {
         return this.actionHistory.map((action) =>
@@ -42,7 +42,7 @@ export class StateExport extends BaseExportImportFile {
 
     @ValidateNested()
     @Type(() => ExerciseState)
-    public readonly currentState: ExerciseState;
+    public currentState: ExerciseState;
 
     @IsOptional()
     @ValidateNested()


### PR DESCRIPTION
Fixed:

* Not awaiting updates to the database
* Impossibility of updating an `ExerciseWrapper`
* Impossibility of importing an outdated export

An example of a migration can be seen in #477 