### PR TITLE
Increase lint timeout to 3 mins (from 2)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -46,7 +46,7 @@ jobs:
               run: cd shared && npm run build && cd ..
 
     lint:
-        timeout-minutes: 2
+        timeout-minutes: 3
         runs-on: ${{ matrix.os }}
 
         needs: build


### PR DESCRIPTION
This keeps failing in the last few days. Not sure why, probably our code base is too large now.