### PR TITLE
Treat actions always as immutable

### DIFF
--- a/frontend/src/app/core/api.service.ts
+++ b/frontend/src/app/core/api.service.ts
@@ -10,6 +10,7 @@ import type {
     StateExport,
 } from 'digital-fuesim-manv-shared';
 import { reduceExerciseState } from 'digital-fuesim-manv-shared';
+import { freeze } from 'immer';
 import type { Observable } from 'rxjs';
 import { BehaviorSubject, lastValueFrom, map, of, switchMap } from 'rxjs';
 import type { AppState } from '../state/app.state';
@@ -168,6 +169,8 @@ export class ApiService {
             });
             throw error;
         });
+        // Freeze to prevent accidental modification
+        freeze(exerciseTimeLine, true);
         if (!this.activatingTimeTravel) {
             // The timeTravel has been stopped during the retrieval of the timeline
             return;
@@ -236,7 +239,7 @@ export class ApiService {
             this.httpClient.get<ExerciseTimeline>(
                 `${httpOrigin}/api/exercise/${this.exerciseId}/history`
             )
-        );
+        ).then((value) => freeze(value, true));
     }
 
     public async deleteExercise(trainerId: string) {

--- a/frontend/src/app/core/present-exercise-helper.ts
+++ b/frontend/src/app/core/present-exercise-helper.ts
@@ -7,6 +7,7 @@ import type {
     UUID,
 } from 'digital-fuesim-manv-shared';
 import { socketIoTransports } from 'digital-fuesim-manv-shared';
+import { freeze } from 'immer';
 import { BehaviorSubject } from 'rxjs';
 import type { Socket } from 'socket.io-client';
 import { io } from 'socket.io-client';
@@ -64,6 +65,7 @@ export class PresentExerciseHelper {
         private readonly messageService: MessageService
     ) {
         this.socket.on('performAction', (action: ExerciseAction) => {
+            freeze(action, true);
             this.optimisticActionHandler.performAction(action);
         });
         this.socket.on('disconnect', (reason) => {
@@ -168,6 +170,7 @@ export class PresentExerciseHelper {
                 this.socket.emit('getState', resolve);
             }
         );
+        freeze(response, true);
         if (!response.success) {
             this.messageService.postError({
                 title: 'Fehler beim Laden der Übung',

--- a/frontend/src/app/core/time-jump-helper.ts
+++ b/frontend/src/app/core/time-jump-helper.ts
@@ -2,7 +2,7 @@ import type {
     ExerciseState,
     ExerciseTimeline,
 } from 'digital-fuesim-manv-shared';
-import { applyAction, cloneDeepMutable } from 'digital-fuesim-manv-shared';
+import { applyAction } from 'digital-fuesim-manv-shared';
 import produce from 'immer';
 import { environment } from 'src/environments/environment';
 import { TimeLineCache } from './time-line-cache';
@@ -49,16 +49,7 @@ export class TimeJumpHelper {
                 lastAppliedActionIndex < actions.length;
                 lastAppliedActionIndex++
             ) {
-                const action = actions[lastAppliedActionIndex]!;
-                // If an action has been applied and adds part of it to the state (e.g. add a new element from the action),
-                // this part is immutable, because the action is immutable.
-                // If we try to mutate this part later on, we get an error because we modified the action, which is an immutable object
-                // (enforced via Object.freeze).
-                // To mitigate this, we clone the action to make it mutable.
-                // TODO: Think more about Should this maybe even be another requirement in the reducers (Mutable actions)?
-                // this could still fail because of a `Object.frozen` error (the action applies an immutable object to the state)
-                const unfrozenAction = cloneDeepMutable(action);
-                applyAction(draftState, unfrozenAction);
+                applyAction(draftState, actions[lastAppliedActionIndex]!);
 
                 // TODO: We actually want the last action after which currentTime <= exerciseTime
                 // Maybe look whether the action is a tick action and if so, check how much time would go by

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,6 +1,20 @@
 // this import is needed for `import { Type } from 'class-transformer';` to work
 import 'reflect-metadata';
 
+// This environment is set at the backend and (manually) on the frontend, therefore we can use it in here
+declare global {
+    const process: {
+        env: {
+            NODE_ENV:
+                | string
+                | 'development'
+                | 'production'
+                | 'staging'
+                | 'testing';
+        };
+    };
+}
+
 export * from './export-import/file-format';
 export * from './models';
 export * from './models/utils';

--- a/shared/src/models/patient-template.ts
+++ b/shared/src/models/patient-template.ts
@@ -1,6 +1,6 @@
 import { Type } from 'class-transformer';
 import { IsDefined, IsUUID, ValidateNested } from 'class-validator';
-import { UUID, uuid, uuidValidationOptions } from '../utils';
+import { cloneDeepMutable, UUID, uuid, uuidValidationOptions } from '../utils';
 import type { PatientStatusCode } from './utils';
 import {
     BiometricInformation,
@@ -70,25 +70,27 @@ export class PatientTemplate {
     ): Patient {
         // Randomize function parameters
         const healthStates = Object.fromEntries(
-            Object.entries(template.healthStates).map(([stateId, state]) => {
-                const functionParameters = Object.fromEntries(
-                    Object.entries(state.functionParameters).map(
-                        ([key, value]) => [
-                            key as keyof FunctionParameters,
-                            randomizeValue(value, 0.2),
-                        ]
-                        // The signatures for Object.fromEntries and Object.entries are not made for literals...
-                    ) as [keyof FunctionParameters, any][]
-                ) as FunctionParameters;
-                // The function parameters will randomize by 20%
-                return [
-                    stateId,
-                    {
-                        ...state,
-                        functionParameters,
-                    },
-                ];
-            })
+            Object.entries(cloneDeepMutable(template.healthStates)).map(
+                ([stateId, state]) => {
+                    const functionParameters = Object.fromEntries(
+                        Object.entries(state.functionParameters).map(
+                            ([key, value]) => [
+                                key as keyof FunctionParameters,
+                                randomizeValue(value, 0.2),
+                            ]
+                            // The signatures for Object.fromEntries and Object.entries are not made for literals...
+                        ) as [keyof FunctionParameters, any][]
+                    ) as FunctionParameters;
+                    // The function parameters will randomize by 20%
+                    return [
+                        stateId,
+                        {
+                            ...state,
+                            functionParameters,
+                        },
+                    ];
+                }
+            )
         );
         const status = getStatus(template.health);
         return Patient.create(

--- a/shared/src/models/utils/get-create.ts
+++ b/shared/src/models/utils/get-create.ts
@@ -1,13 +1,11 @@
 import type { Constructor } from '../../utils';
 
-// @ts-expect-error It is not guaranteed to run in node environment, but if it does we want to check for development mode
-export const isDevelopment = process?.env?.NODE_ENV === 'development';
-
 /**
  * Models must be JSON objects. This means they mustn't have any functions.
  * The `prototype` of a class contains functions (e.g. `constructor`).
  * We still need the constructor to create a new instance of the class with a prototype, to be able to use `class-validator`.
  * We solve this by using a static factory function `create` in the class.
+ * In addition this instance is frozen, to prevent accidental mutation.
  *
  * @example
  * ```typescript
@@ -24,16 +22,14 @@ export const isDevelopment = process?.env?.NODE_ENV === 'development';
  *   }
  * ```
  * @param aClass The class whose static create method is to be returned
- * @returns a function that creates a new instance of {@link aClass} without a prototype
+ * @returns a function that creates a new immutable instance of {@link aClass} without a prototype
  */
 export function getCreate<T extends Constructor>(aClass: T) {
     return (...args: ConstructorParameters<T>): InstanceType<T> => {
         const instance = {
             ...new aClass(...args),
         };
-        if (isDevelopment) {
-            Object.freeze(instance);
-        }
+        Object.freeze(instance);
         return instance;
     };
 }

--- a/shared/src/models/utils/index.ts
+++ b/shared/src/models/utils/index.ts
@@ -9,7 +9,7 @@ export { ImageProperties } from './image-properties';
 export * from './tile-map-properties';
 export * from './biometric-information';
 export * from './health-points';
-export { getCreate, isDevelopment } from './get-create';
+export * from './get-create';
 export * from './immutable-date';
 export { AlarmGroupVehicle } from './alarm-group-vehicle';
 export * from './patient-status-code';

--- a/shared/src/models/utils/patient-status-code.ts
+++ b/shared/src/models/utils/patient-status-code.ts
@@ -15,7 +15,7 @@ export const colorCodeMap = {
 
 // This is only for typesafety
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const _colorCodeMap: { [key in ColorCode]: string } = colorCodeMap;
+const _colorCodeMap: { readonly [key in ColorCode]: string } = colorCodeMap;
 
 export const behaviourCodeMap: { [key in BehaviourCode]: string } = {
     A: 'bi-arrow-right-square-fill',

--- a/shared/src/socket-api/socket-types.ts
+++ b/shared/src/socket-api/socket-types.ts
@@ -29,13 +29,13 @@ export interface SocketData {}
 export type SocketResponse<T = undefined> =
     | (T extends undefined
           ? {
-                success: true;
+                readonly success: true;
             }
           : {
-                success: true;
-                payload: T;
+                readonly success: true;
+                readonly payload: T;
             })
     | {
-          success: false;
-          message: string;
+          readonly success: false;
+          readonly message: string;
       };

--- a/shared/src/store/action-reducer.ts
+++ b/shared/src/store/action-reducer.ts
@@ -51,6 +51,23 @@ export interface Action {
  * const anAction: ExerciseAction = { type: 'some action' };
  * exerciseReducerMap[anAction.type](draftState, anAction);
  * ```
+ *
+ *
+ * Be aware that the action is immutable!
+ * [While TypeScript allows assigning immutable objects to properties of mutable objects](https://github.com/microsoft/TypeScript/issues/13347),
+ * we have an eslint rule that shields against this.
+ * You must always clone parts of the action before assigning them to the draftState.
+ * The same could also apply for objects created inside the reducer function - like with a `Model.create()`, which by default returns an immutable object.
+ *
+ * Example:
+ * ```ts
+ * const reducerFunction = (draftState, anAction) =>  {
+ *     draftState.someObject = cloneDeepMutable(anAction.someObject);
+ *     draftState.someOtherObject = cloneDeepMutable(SomeOtherObject.create());
+ *     return draftState;
+ * }
+ * ```
+ *
  */
 type ReducerFunction<A extends Action> = (
     // These functions can only work with a mutable state object, because we expect them to be executed in immers produce context.

--- a/shared/src/store/action-reducers/alarm-group.ts
+++ b/shared/src/store/action-reducers/alarm-group.ts
@@ -9,7 +9,7 @@ import {
 import { AlarmGroup } from '../../models/alarm-group';
 import { AlarmGroupVehicle } from '../../models/utils/alarm-group-vehicle';
 import type { Mutable } from '../../utils';
-import { UUID, uuidValidationOptions } from '../../utils';
+import { cloneDeepMutable, UUID, uuidValidationOptions } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { ReducerError } from '../reducer-error';
 import { getElement } from './utils/get-element';
@@ -83,7 +83,8 @@ export namespace AlarmGroupActionReducers {
     export const addAlarmGroup: ActionReducer<AddAlarmGroupAction> = {
         action: AddAlarmGroupAction,
         reducer: (draftState, { alarmGroup }) => {
-            draftState.alarmGroups[alarmGroup.id] = alarmGroup;
+            draftState.alarmGroups[alarmGroup.id] =
+                cloneDeepMutable(alarmGroup);
             return draftState;
         },
         rights: 'trainer',
@@ -123,7 +124,7 @@ export namespace AlarmGroupActionReducers {
                     alarmGroupId
                 );
                 alarmGroup.alarmGroupVehicles[alarmGroupVehicle.id] =
-                    alarmGroupVehicle;
+                    cloneDeepMutable(alarmGroupVehicle);
                 return draftState;
             },
             rights: 'trainer',

--- a/shared/src/store/action-reducers/client.ts
+++ b/shared/src/store/action-reducers/client.ts
@@ -7,7 +7,7 @@ import {
     IsBoolean,
 } from 'class-validator';
 import { Client } from '../../models';
-import { uuidValidationOptions, UUID } from '../../utils';
+import { uuidValidationOptions, UUID, cloneDeepMutable } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { getElement } from './utils/get-element';
 
@@ -49,7 +49,7 @@ export namespace ClientActionReducers {
     export const addClient: ActionReducer<AddClientAction> = {
         action: AddClientAction,
         reducer: (draftState, { client }) => {
-            draftState.clients[client.id] = client;
+            draftState.clients[client.id] = cloneDeepMutable(client);
             return draftState;
         },
         rights: 'server',

--- a/shared/src/store/action-reducers/configuration.ts
+++ b/shared/src/store/action-reducers/configuration.ts
@@ -1,6 +1,7 @@
 import { Type } from 'class-transformer';
 import { IsBoolean, IsString, ValidateNested } from 'class-validator';
 import { TileMapProperties } from '../../models/utils';
+import { cloneDeepMutable } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 
 export class SetTileMapPropertiesAction implements Action {
@@ -33,7 +34,8 @@ export namespace ConfigurationActionReducers {
         {
             action: SetTileMapPropertiesAction,
             reducer: (draftState, { tileMapProperties }) => {
-                draftState.configuration.tileMapProperties = tileMapProperties;
+                draftState.configuration.tileMapProperties =
+                    cloneDeepMutable(tileMapProperties);
                 return draftState;
             },
             rights: 'trainer',

--- a/shared/src/store/action-reducers/exercise.ts
+++ b/shared/src/store/action-reducers/exercise.ts
@@ -15,7 +15,7 @@ import { getStatus } from '../../models/utils';
 import type { AreaStatistics } from '../../models/utils/area-statistics';
 import type { ExerciseState } from '../../state';
 import type { Mutable } from '../../utils';
-import { uuid } from '../../utils';
+import { cloneDeepMutable, uuid } from '../../utils';
 import { PatientUpdate } from '../../utils/patient-updates';
 import type { Action, ActionReducer } from '../action-reducer';
 import { letElementArrive } from './transfer';
@@ -67,7 +67,7 @@ export namespace ExerciseActionReducers {
                 'paused',
                 new Date(timestamp)
             );
-            draftState.statusHistory.push(statusHistoryEntry);
+            draftState.statusHistory.push(cloneDeepMutable(statusHistoryEntry));
             return draftState;
         },
         rights: 'trainer',
@@ -81,7 +81,7 @@ export namespace ExerciseActionReducers {
                 new Date(timestamp)
             );
 
-            draftState.statusHistory.push(statusHistoryEntry);
+            draftState.statusHistory.push(cloneDeepMutable(statusHistoryEntry));
 
             return draftState;
         },
@@ -202,7 +202,7 @@ function generateAreaStatistics(
     patients: Patient[],
     vehicles: Vehicle[],
     personnel: Personnel[]
-): AreaStatistics {
+): Mutable<AreaStatistics> {
     return {
         numberOfActiveParticipants: clients.filter(
             (client) => !client.isInWaitingRoom && client.role === 'participant'

--- a/shared/src/store/action-reducers/hospital.ts
+++ b/shared/src/store/action-reducers/hospital.ts
@@ -8,11 +8,11 @@ import {
 } from 'class-validator';
 import { Hospital } from '../../models';
 import { HospitalPatient } from '../../models/hospital-patient';
-import { UUID, uuidValidationOptions } from '../../utils';
+import { cloneDeepMutable, UUID, uuidValidationOptions } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
-import { deleteVehicle } from './vehicle';
 import { calculateTreatments } from './utils/calculate-treatments';
 import { getElement } from './utils/get-element';
+import { deleteVehicle } from './vehicle';
 
 export class AddHospitalAction implements Action {
     @IsString()
@@ -64,7 +64,7 @@ export namespace HospitalActionReducers {
     export const addHospital: ActionReducer<AddHospitalAction> = {
         action: AddHospitalAction,
         reducer: (draftState, { hospital }) => {
-            draftState.hospitals[hospital.id] = hospital;
+            draftState.hospitals[hospital.id] = cloneDeepMutable(hospital);
             return draftState;
         },
         rights: 'trainer',

--- a/shared/src/store/action-reducers/map-image-templates.ts
+++ b/shared/src/store/action-reducers/map-image-templates.ts
@@ -4,7 +4,7 @@ import { MapImageTemplate } from '../../models';
 import { ImageProperties } from '../../models/utils';
 import type { ExerciseState } from '../../state';
 import type { Mutable } from '../../utils';
-import { UUID, uuidValidationOptions } from '../../utils';
+import { cloneDeepMutable, UUID, uuidValidationOptions } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { ReducerError } from '../reducer-error';
 
@@ -54,7 +54,9 @@ export namespace MapImageTemplatesActionReducers {
                         `MapImageTemplate with id ${mapImageTemplate.id} already exists`
                     );
                 }
-                draftState.mapImageTemplates.push(mapImageTemplate);
+                draftState.mapImageTemplates.push(
+                    cloneDeepMutable(mapImageTemplate)
+                );
                 return draftState;
             },
             rights: 'trainer',
@@ -66,7 +68,7 @@ export namespace MapImageTemplatesActionReducers {
             reducer: (draftState, { id, name, image }) => {
                 const mapImageTemplate = getMapImageTemplate(draftState, id);
                 mapImageTemplate.name = name;
-                mapImageTemplate.image = image;
+                mapImageTemplate.image = cloneDeepMutable(image);
                 return draftState;
             },
             rights: 'trainer',

--- a/shared/src/store/action-reducers/map-images.ts
+++ b/shared/src/store/action-reducers/map-images.ts
@@ -9,7 +9,7 @@ import {
 } from 'class-validator';
 import { MapImage } from '../../models';
 import { Position } from '../../models/utils';
-import { UUID, uuidValidationOptions } from '../../utils';
+import { uuidValidationOptions, UUID, cloneDeepMutable } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { getElement } from './utils/get-element';
 
@@ -78,7 +78,7 @@ export namespace MapImagesActionReducers {
     export const addMapImage: ActionReducer<AddMapImageAction> = {
         action: AddMapImageAction,
         reducer: (draftState, { mapImage }) => {
-            draftState.mapImages[mapImage.id] = mapImage;
+            draftState.mapImages[mapImage.id] = cloneDeepMutable(mapImage);
             return draftState;
         },
         rights: 'trainer',
@@ -88,7 +88,7 @@ export namespace MapImagesActionReducers {
         action: MoveMapImageAction,
         reducer: (draftState, { mapImageId, targetPosition }) => {
             const mapImage = getElement(draftState, 'mapImages', mapImageId);
-            mapImage.position = targetPosition;
+            mapImage.position = cloneDeepMutable(targetPosition);
             return draftState;
         },
         rights: 'trainer',

--- a/shared/src/store/action-reducers/material.ts
+++ b/shared/src/store/action-reducers/material.ts
@@ -1,7 +1,7 @@
 import { Type } from 'class-transformer';
 import { IsString, IsUUID, ValidateNested } from 'class-validator';
 import { Position } from '../../models/utils';
-import { uuidValidationOptions, UUID } from '../../utils';
+import { uuidValidationOptions, UUID, cloneDeepMutable } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { calculateTreatments } from './utils/calculate-treatments';
 import { getElement } from './utils/get-element';
@@ -23,7 +23,7 @@ export namespace MaterialActionReducers {
         action: MoveMaterialAction,
         reducer: (draftState, { materialId, targetPosition }) => {
             const material = getElement(draftState, 'materials', materialId);
-            material.position = targetPosition;
+            material.position = cloneDeepMutable(targetPosition);
             calculateTreatments(draftState);
             return draftState;
         },

--- a/shared/src/store/action-reducers/patient.ts
+++ b/shared/src/store/action-reducers/patient.ts
@@ -4,7 +4,12 @@ import { Patient } from '../../models';
 import { PatientStatus, Position } from '../../models/utils';
 import type { ExerciseState } from '../../state';
 import type { Mutable } from '../../utils';
-import { uuidValidationOptions, UUID, cloneDeepMutable } from '../../utils';
+import {
+    cloneDeepMutable,
+    StrictObject,
+    UUID,
+    uuidValidationOptions,
+} from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { ReducerError } from '../reducer-error';
 import { calculateTreatments } from './utils/calculate-treatments';
@@ -60,7 +65,7 @@ export namespace PatientActionReducers {
         action: AddPatientAction,
         reducer: (draftState, { patient }) => {
             if (
-                Object.entries(patient.healthStates).some(
+                StrictObject.entries(patient.healthStates).some(
                     ([id, healthState]) => healthState.id !== id
                 )
             ) {
@@ -68,7 +73,7 @@ export namespace PatientActionReducers {
                     "Not all health state's ids match their key id"
                 );
             }
-            Object.values(patient.healthStates).forEach((healthState) => {
+            StrictObject.values(patient.healthStates).forEach((healthState) => {
                 healthState.nextStateConditions.forEach(
                     (nextStateCondition) => {
                         if (
@@ -101,7 +106,7 @@ export namespace PatientActionReducers {
         action: MovePatientAction,
         reducer: (draftState, { patientId, targetPosition }) => {
             const patient = getElement(draftState, 'patients', patientId);
-            patient.position = targetPosition;
+            patient.position = cloneDeepMutable(targetPosition);
             calculateTreatments(draftState);
             return draftState;
         },

--- a/shared/src/store/action-reducers/personnel.ts
+++ b/shared/src/store/action-reducers/personnel.ts
@@ -1,7 +1,7 @@
 import { Type } from 'class-transformer';
 import { IsString, IsUUID, ValidateNested } from 'class-validator';
 import { Position } from '../../models/utils';
-import { UUID, uuidValidationOptions } from '../../utils';
+import { cloneDeepMutable, UUID, uuidValidationOptions } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { calculateTreatments } from './utils/calculate-treatments';
 import { getElement } from './utils/get-element';
@@ -23,7 +23,7 @@ export namespace PersonnelActionReducers {
         action: MovePersonnelAction,
         reducer: (draftState, { personnelId, targetPosition }) => {
             const personnel = getElement(draftState, 'personnel', personnelId);
-            personnel.position = targetPosition;
+            personnel.position = cloneDeepMutable(targetPosition);
             calculateTreatments(draftState);
             return draftState;
         },

--- a/shared/src/store/action-reducers/transfer-point.ts
+++ b/shared/src/store/action-reducers/transfer-point.ts
@@ -8,7 +8,7 @@ import {
 } from 'class-validator';
 import { TransferPoint } from '../../models';
 import { Position } from '../../models/utils';
-import { uuidValidationOptions, UUID } from '../../utils';
+import { uuidValidationOptions, UUID, cloneDeepMutable } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { ReducerError } from '../reducer-error';
 import { letElementArrive } from './transfer';
@@ -111,7 +111,8 @@ export namespace TransferPointActionReducers {
     export const addTransferPoint: ActionReducer<AddTransferPointAction> = {
         action: AddTransferPointAction,
         reducer: (draftState, { transferPoint }) => {
-            draftState.transferPoints[transferPoint.id] = transferPoint;
+            draftState.transferPoints[transferPoint.id] =
+                cloneDeepMutable(transferPoint);
             return draftState;
         },
         rights: 'trainer',
@@ -125,7 +126,7 @@ export namespace TransferPointActionReducers {
                 'transferPoints',
                 transferPointId
             );
-            transferPoint.position = targetPosition;
+            transferPoint.position = cloneDeepMutable(targetPosition);
             return draftState;
         },
         rights: 'trainer',

--- a/shared/src/store/action-reducers/transfer.ts
+++ b/shared/src/store/action-reducers/transfer.ts
@@ -3,7 +3,7 @@ import type { ExerciseState } from '../..';
 import { imageSizeToPosition, Position, TransferPoint } from '../..';
 import { StartPoint } from '../../models/utils/start-points';
 import type { Mutable } from '../../utils';
-import { UUID, uuidValidationOptions } from '../../utils';
+import { cloneDeepMutable, UUID, uuidValidationOptions } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { ReducerError } from '../reducer-error';
 import { getElement } from './utils/get-element';
@@ -28,11 +28,13 @@ export function letElementArrive(
         'transferPoints',
         element.transfer.targetTransferPointId
     );
-    element.position = Position.create(
-        targetTransferPoint.position.x,
-        targetTransferPoint.position.y +
-            //  Position it in the upper half of the transferPoint)
-            imageSizeToPosition(TransferPoint.image.height / 3)
+    element.position = cloneDeepMutable(
+        Position.create(
+            targetTransferPoint.position.x,
+            targetTransferPoint.position.y +
+                //  Position it in the upper half of the transferPoint)
+                imageSizeToPosition(TransferPoint.image.height / 3)
+        )
     );
     delete element.transfer;
 }
@@ -144,7 +146,7 @@ export namespace TransferActionReducers {
             // Set the element to transfer
             delete element.position;
             element.transfer = {
-                startPoint,
+                startPoint: cloneDeepMutable(startPoint),
                 targetTransferPointId,
                 endTimeStamp: draftState.currentTime + duration,
                 isPaused: false,

--- a/shared/src/store/action-reducers/utils/calculate-treatments.spec.ts
+++ b/shared/src/store/action-reducers/utils/calculate-treatments.spec.ts
@@ -59,11 +59,11 @@ function generatePatient(
     realStatus: PatientStatus,
     position?: Position
 ): Mutable<Patient> {
-    const patient = generateDummyPatient() as Mutable<Patient>;
+    const patient = cloneDeepMutable(generateDummyPatient());
     patient.pretriageStatus = pretriageStatus;
     patient.realStatus = realStatus;
     if (position) {
-        patient.position = { ...position };
+        patient.position = cloneDeepMutable(position);
     }
     return patient;
 }
@@ -73,7 +73,7 @@ function generatePersonnel(position?: Position) {
         Personnel.create(uuid(), 'RTW 3/83/1', 'notSan', {})
     );
     if (position) {
-        personnel.position = { ...position };
+        personnel.position = cloneDeepMutable(position);
     }
     return personnel;
 }
@@ -88,7 +88,7 @@ function generateMaterial(position?: Position) {
         )
     );
     if (position) {
-        material.position = { ...position };
+        material.position = cloneDeepMutable(position);
     }
     return material;
 }
@@ -350,7 +350,9 @@ describe('calculate treatment', () => {
                     Position.create(2, 2)
                 );
                 const material = generateMaterial(Position.create(0, 0));
-                material.canCaterFor = CanCaterFor.create(1, 0, 1, 'and');
+                material.canCaterFor = cloneDeepMutable(
+                    CanCaterFor.create(1, 0, 1, 'and')
+                );
 
                 ids.material = material.id;
                 ids.greenPatient = greenPatient.id;

--- a/shared/src/store/action-reducers/utils/calculate-treatments.ts
+++ b/shared/src/store/action-reducers/utils/calculate-treatments.ts
@@ -134,7 +134,7 @@ export function calculateTreatments(state: Mutable<ExerciseState>) {
 }
 
 function calculateCatering(
-    catering: Material | Personnel,
+    catering: Mutable<Material | Personnel>,
     patients: Mutable<Patient>[],
     pretriageEnabled: boolean,
     bluePatientsEnabled: boolean

--- a/shared/src/store/action-reducers/vehicle.ts
+++ b/shared/src/store/action-reducers/vehicle.ts
@@ -5,7 +5,12 @@ import { Position } from '../../models/utils';
 import type { ExerciseState } from '../../state';
 import { imageSizeToPosition } from '../../state-helpers';
 import type { Mutable } from '../../utils';
-import { UUID, uuidValidationOptions } from '../../utils';
+import {
+    cloneDeepMutable,
+    StrictObject,
+    UUID,
+    uuidValidationOptions,
+} from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { ReducerError } from '../reducer-error';
 import { deletePatient } from './patient';
@@ -109,11 +114,12 @@ export namespace VehicleActionReducers {
         reducer: (draftState, { vehicle, materials, personnel }) => {
             if (
                 materials.some(
-                    (currentMaterial) =>
-                        currentMaterial.vehicleId !== vehicle.id ||
-                        vehicle.materialIds[currentMaterial.id] === undefined
+                    (material) =>
+                        material.vehicleId !== vehicle.id ||
+                        vehicle.materialIds[material.id] === undefined
                 ) ||
-                Object.keys(vehicle.materialIds).length !== materials.length
+                StrictObject.keys(vehicle.materialIds).length !==
+                    materials.length
             ) {
                 throw new ReducerError(
                     'Vehicle material ids do not match material ids'
@@ -125,18 +131,19 @@ export namespace VehicleActionReducers {
                         currentPersonnel.vehicleId !== vehicle.id ||
                         vehicle.personnelIds[currentPersonnel.id] === undefined
                 ) ||
-                Object.keys(vehicle.personnelIds).length !== personnel.length
+                StrictObject.keys(vehicle.personnelIds).length !==
+                    personnel.length
             ) {
                 throw new ReducerError(
                     'Vehicle personnel ids do not match personnel ids'
                 );
             }
-            draftState.vehicles[vehicle.id] = vehicle;
-            for (const currentMaterial of materials) {
-                draftState.materials[currentMaterial.id] = currentMaterial;
+            draftState.vehicles[vehicle.id] = cloneDeepMutable(vehicle);
+            for (const material of materials) {
+                draftState.materials[material.id] = cloneDeepMutable(material);
             }
             for (const person of personnel) {
-                draftState.personnel[person.id] = person;
+                draftState.personnel[person.id] = cloneDeepMutable(person);
             }
             return draftState;
         },
@@ -147,7 +154,7 @@ export namespace VehicleActionReducers {
         action: MoveVehicleAction,
         reducer: (draftState, { vehicleId, targetPosition }) => {
             const vehicle = getElement(draftState, 'vehicles', vehicleId);
-            vehicle.position = targetPosition;
+            vehicle.position = cloneDeepMutable(targetPosition);
             return draftState;
         },
         rights: 'participant',

--- a/shared/src/store/action-reducers/viewport.ts
+++ b/shared/src/store/action-reducers/viewport.ts
@@ -2,7 +2,7 @@ import { Type } from 'class-transformer';
 import { IsString, IsUUID, ValidateNested } from 'class-validator';
 import { Viewport } from '../../models';
 import { Position, Size } from '../../models/utils';
-import { uuidValidationOptions, UUID } from '../../utils';
+import { uuidValidationOptions, UUID, cloneDeepMutable } from '../../utils';
 import type { Action, ActionReducer } from '../action-reducer';
 import { getElement } from './utils/get-element';
 
@@ -59,7 +59,7 @@ export namespace ViewportActionReducers {
     export const addViewport: ActionReducer<AddViewportAction> = {
         action: AddViewportAction,
         reducer: (draftState, { viewport }) => {
-            draftState.viewports[viewport.id] = viewport;
+            draftState.viewports[viewport.id] = cloneDeepMutable(viewport);
             return draftState;
         },
         rights: 'trainer',
@@ -79,7 +79,7 @@ export namespace ViewportActionReducers {
         action: MoveViewportAction,
         reducer: (draftState, { viewportId, targetPosition }) => {
             const viewport = getElement(draftState, 'viewports', viewportId);
-            viewport.position = targetPosition;
+            viewport.position = cloneDeepMutable(targetPosition);
             return draftState;
         },
         rights: 'trainer',
@@ -89,8 +89,8 @@ export namespace ViewportActionReducers {
         action: ResizeViewportAction,
         reducer: (draftState, { viewportId, targetPosition, newSize }) => {
             const viewport = getElement(draftState, 'viewports', viewportId);
-            viewport.position = targetPosition;
-            viewport.size = newSize;
+            viewport.position = cloneDeepMutable(targetPosition);
+            viewport.size = cloneDeepMutable(newSize);
             return draftState;
         },
         rights: 'trainer',

--- a/shared/src/store/reduce-exercise-state.ts
+++ b/shared/src/store/reduce-exercise-state.ts
@@ -1,4 +1,4 @@
-import { produce } from 'immer';
+import { freeze, produce } from 'immer';
 import type { ExerciseState } from '../state';
 import type { Mutable } from '../utils';
 import type { ExerciseAction } from './action-reducers';
@@ -17,6 +17,8 @@ export function reduceExerciseState(
     state: ExerciseState,
     action: ExerciseAction
 ): ExerciseState {
+    // Make sure that the state isn't mutated in the reducer (short circuits if the state is already frozen)
+    freeze(state, true);
     // use immer to convert mutating operations to immutable ones (https://immerjs.github.io/immer/produce)
     return produce(state, (draftState) => applyAction(draftState, action));
 }
@@ -32,6 +34,8 @@ export function applyAction(
     draftState: Mutable<ExerciseState>,
     action: ExerciseAction
 ) {
+    // Make sure that the action isn't mutated in the reducer (short circuits if the action is already frozen)
+    freeze(action, true);
     return exerciseActionTypeDictionary[action.type].reducer(
         draftState,
         // typescript doesn't narrow action and the reducer to the correct ones based on action.type

--- a/shared/src/utils/index.ts
+++ b/shared/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './socket-io';
 export * from './constructor';
 export * from './merge-intersection';
 export * from './clone-deep-mutable';
+export * from './strict-object';

--- a/shared/src/utils/strict-object.ts
+++ b/shared/src/utils/strict-object.ts
@@ -1,0 +1,42 @@
+/**
+ * Provides stricter typings for common `Object.` functions.
+ * To do this, it is assumed that the provided object doesn't have more properties (at runtime) than specified in its type.
+ * Based on how the TS type system works, this assumption cannot be made for every Object -> the default typings are very weak.
+ * @See https://github.com/microsoft/TypeScript/pull/12253#issuecomment-263132208 and https://stackoverflow.com/questions/55012174/why-doesnt-object-keys-return-a-keyof-type-in-typescript
+ */
+export namespace StrictObject {
+    /**
+     * {@link Object.entries} with stricter typings
+     * See {@link StrictObject}
+     * @returns an array of key/values of the enumerable properties of an object
+     */
+    export function entries<T extends { [key: string]: any }>(
+        object: T
+    ): {
+        [Key in keyof T]: [Key, T[Key]];
+    }[keyof T][] {
+        return Object.entries(object);
+    }
+
+    /**
+     * {@link Object.values} with stricter typings
+     * See {@link StrictObject}
+     * @returns an array of values of the enumerable properties of an object
+     */
+    export function values<T extends { [key: string]: any }>(
+        object: T
+    ): T[keyof T][] {
+        return Object.values(object);
+    }
+
+    /**
+     * {@link Object.keys} with stricter typings
+     * See {@link StrictObject}
+     * @returns an array of keys of the enumerable properties of an object
+     */
+    export function keys<T extends { [key: string]: any }>(
+        object: T
+    ): (keyof T)[] {
+        return Object.keys(object);
+    }
+}


### PR DESCRIPTION
This branch replaces #448 and excludes the eslint extension ([See here](https://github.com/hpi-sam/digital-fuesim-manv/pull/448#issuecomment-1194397982)).

In addition the `isDevelopment` variable has been removed - the global environment typings remain and are now located in the top level `index.ts` of shared.
 
Fixes https://github.com/hpi-sam/digital-fuesim-manv/issues/390 by

* adding documentation about the bug,

* freezing state and actions

* Adding an eslint rule in the shared package to prevent such things and

* assuming that actions are treated as immutable in the reducer