### PR TITLE
Add LF endings for `docker/docker-entrypoint.sh` to `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 # Line-endings behavior
 * text=auto
+# docker-entrypoint.sh needs LF (see https://github.com/hpi-sam/digital-fuesim-manv/issues/479)
+docker/docker-entrypoint.sh eol=lf
 
 # Git lfs
 *.jpg filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Closes #479 

Please verify that this works on Windows. On Linux, this is the default behavior, so I can't check it.