### PR TITLE
Improve timeTravel and statistics

### DIFF
--- a/frontend/src/app/core/time-travel-helper.ts
+++ b/frontend/src/app/core/time-travel-helper.ts
@@ -21,6 +21,7 @@ export class TimeTravelHelper {
         });
         this.setState(exerciseTimeLine.initialState);
         this.timeJumpHelper = new TimeJumpHelper(exerciseTimeLine);
+        this.jumpToTime(this.timeConstraints.start);
     }
 
     // Initially set in constructor

--- a/shared/src/state.ts
+++ b/shared/src/state.ts
@@ -24,13 +24,13 @@ import type {
     Vehicle,
     Viewport,
 } from './models';
+import { EocLogEntry, MapImageTemplate, VehicleTemplate } from './models';
 import { ExerciseConfiguration } from './models/exercise-configuration';
-import { EocLogEntry, VehicleTemplate, MapImageTemplate } from './models';
-import { getCreate } from './models/utils';
-import type { UUID } from './utils';
-import { uuidValidationOptions, uuid } from './utils';
 import { PatientCategory } from './models/patient-category';
+import { getCreate } from './models/utils';
 import { ExerciseStatus } from './models/utils/exercise-status';
+import type { UUID } from './utils';
+import { uuid, uuidValidationOptions } from './utils';
 
 export class ExerciseState {
     @IsUUID(4, uuidValidationOptions)
@@ -39,6 +39,8 @@ export class ExerciseState {
      * The number of ms since the start of the exercise.
      * This time is updated each `tick` by a constant value, is guaranteed to be (a bit) slower than the real time
      * (depending on the server load and overhead of the tick).
+     *
+     * It is guaranteed that the `ExerciseTickAction` is the only action that modifies this value.
      */
     @IsInt()
     @Min(0)

--- a/shared/src/store/index.ts
+++ b/shared/src/store/index.ts
@@ -6,3 +6,4 @@ export * from './reducer-error';
 export * from './reduce-exercise-state';
 export * from './action-reducers';
 export * from './action-reducer';
+export * from './time-travel-utilities';

--- a/shared/src/store/time-travel-utilities.ts
+++ b/shared/src/store/time-travel-utilities.ts
@@ -1,7 +1,7 @@
 import produce from 'immer';
-import { ExerciseState } from '../state';
+import type { ExerciseState } from '../state';
 import { cloneDeepMutable, sleep } from '../utils';
-import { ExerciseAction } from './action-reducers';
+import type { ExerciseAction } from './action-reducers';
 import { applyAction } from './reduce-exercise-state';
 
 /**

--- a/shared/src/store/time-travel-utilities.ts
+++ b/shared/src/store/time-travel-utilities.ts
@@ -1,0 +1,67 @@
+import produce from 'immer';
+import { ExerciseState } from '../state';
+import { cloneDeepMutable, sleep } from '../utils';
+import { ExerciseAction } from './action-reducers';
+import { applyAction } from './reduce-exercise-state';
+
+/**
+ * @param callback a function that is called at the end of every second in the exerciseState with the respective state at this time. The time itself can be get via `state.currentTime`. If this function returns true, the loop breaks.
+ *
+ * This function is asynchronous to not block the main thread. You should therefore always await it, if you want to make use of side-effects from {@link callback}.
+ */
+export async function loopTroughTime(
+    initialState: ExerciseState,
+    actions: readonly ExerciseAction[],
+    callback: (stateAtTime: ExerciseState) => boolean
+) {
+    const currentState = cloneDeepMutable(initialState);
+    for (const [i, action] of actions.entries()) {
+        applyAction(currentState, action);
+        const nextAction = actions[i + 1];
+        // Because this action type is the only one that increases the currentTime
+        // and we always want the state after the last action at the currentTime
+        if (!nextAction || nextAction.type === '[Exercise] Tick') {
+            if (callback(currentState)) {
+                return;
+            }
+        }
+        // Do not block the main thread for too long
+        if (i % 100 === 0) {
+            // eslint-disable-next-line no-await-in-loop
+            await sleep(0);
+        }
+    }
+}
+
+/**
+ * @param actions all the actions that were applied to the {@link initialState} to get to the present state
+ * @returns the last state that still is at the provided {@link time} and the index in {@link actions} of the last action that was still applied to the state at this time.
+ */
+export function jumpToTime(
+    initialState: ExerciseState,
+    actions: readonly ExerciseAction[],
+    time: number
+): { stateAtTime: ExerciseState; lastAppliedActionIndex: number } {
+    let lastAppliedActionIndex = 0;
+    // TODO: find a heuristic for whether using produce or deepCloning it
+    // Default is produce
+    const stateAtTime = produce(initialState, (draftState) => {
+        for (const action of actions) {
+            applyAction(draftState, action);
+            const nextAction = actions[lastAppliedActionIndex + 1];
+            // Because this action type is the only one that increases the currentTime
+            // and we always want the state after the last action at the currentTime
+            if (
+                nextAction?.type === '[Exercise] Tick' &&
+                draftState.currentTime >= time
+            ) {
+                break;
+            }
+            lastAppliedActionIndex++;
+        }
+    });
+    return {
+        lastAppliedActionIndex,
+        stateAtTime,
+    };
+}


### PR DESCRIPTION
* The start and end of an exercise are now always included in the statistics
* Instead of the first state in a second, the last state in a second is now used.
    * This fixes #497 and also lets the first state during timeTravel be the one right before the first tick