### PR TITLE
Fix database migrations

### DIFF
--- a/backend/src/database/state-migrations/migrations.ts
+++ b/backend/src/database/state-migrations/migrations.ts
@@ -137,7 +137,7 @@ export async function migrateInDatabaseTo(
                 actionsToUpdate.map(async ({ index, actionString }) =>
                     entityManager.update(
                         ActionWrapperEntity,
-                        { index },
+                        { index, exercise: { id: exerciseId } },
                         { actionString }
                     )
                 )

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -54,7 +54,8 @@ async function main() {
                 console.error(
                     `Error while restoring exercise \`${e.exerciseId}\`:`,
                     e.message,
-                    e.stack
+                    e.stack,
+                    e.cause
                 );
                 return;
             }

--- a/backend/src/utils/restore-error.ts
+++ b/backend/src/utils/restore-error.ts
@@ -1,7 +1,12 @@
 import type { UUID } from 'digital-fuesim-manv-shared';
 
 export class RestoreError extends Error {
-    public constructor(message: string, public readonly exerciseId: UUID) {
+    public constructor(
+        message: string,
+        public readonly exerciseId: UUID,
+        innerError?: Error
+    ) {
         super(`Failed to restore exercise \`${exerciseId}\`: ${message}`);
+        this.cause = innerError;
     }
 }


### PR DESCRIPTION
Previously, they overrode actions from all exercises with the same id due to a missing where clause