### PR TITLE
Fix performance leak in show-more-component

### DIFF
--- a/frontend/src/app/feature/messages/show-more/app-show-more.component.ts
+++ b/frontend/src/app/feature/messages/show-more/app-show-more.component.ts
@@ -55,7 +55,7 @@ export class AppShowMoreComponent
      */
     @Input()
     heightChangeObservationStrategies: HeightChangeObservationStrategies = {
-        polling: 1000,
+        polling: false,
         resizeObserver: true,
         mutationObserver: true,
     };
@@ -74,6 +74,7 @@ export class AppShowMoreComponent
 
     private resizeObserver?: ResizeObserver;
     private mutationObserver?: MutationObserver;
+    private pollingIntervallRef?: ReturnType<typeof setInterval>;
 
     ngOnChanges() {
         this.updateState();
@@ -86,7 +87,7 @@ export class AppShowMoreComponent
         // observe the height of the content and update the showingMore-state whenever it changes
         // therefore we make use of up to three different strategies to detect changes in the scrollHeight
         if (this.heightChangeObservationStrategies.polling) {
-            setInterval(
+            this.pollingIntervallRef = setInterval(
                 () => this.updateState(),
                 this.heightChangeObservationStrategies.polling
             );
@@ -164,5 +165,6 @@ export class AppShowMoreComponent
     ngOnDestroy() {
         this.resizeObserver?.disconnect();
         this.mutationObserver?.disconnect();
+        clearInterval(this.pollingIntervallRef);
     }
 }

--- a/frontend/src/app/feature/messages/show-more/app-show-more.component.ts
+++ b/frontend/src/app/feature/messages/show-more/app-show-more.component.ts
@@ -89,7 +89,7 @@ export class AppShowMoreComponent
         if (this.heightChangeObservationStrategies.polling) {
             this.pollingIntervallRef = setInterval(
                 () => this.updateState(),
-                this.heightChangeObservationStrategies.polling
+                1000
             );
         }
         if (this.heightChangeObservationStrategies.resizeObserver) {

--- a/frontend/src/app/feature/messages/show-more/height-change-observation-strategies.ts
+++ b/frontend/src/app/feature/messages/show-more/height-change-observation-strategies.ts
@@ -4,14 +4,12 @@ export interface HeightChangeObservationStrategies {
      */
     resizeObserver: boolean;
     /**
-     * Observe wether the content or its children got mutated (attributes changed, new element added, element removed etc.)
+     * Observe whether the content or its children got mutated (attributes changed, new element added, element removed etc.)
      * Can be non-performant if the content is large
      */
     mutationObserver: boolean;
     /**
-     * Check every {@link polling} ms if the scrollHeight of the content has changed
-     * number - the polling interval in ms
-     * false - disable polling
+     * Check in regular intervals whether the scrollHeight of the content has changed
      */
-    polling: number | false;
+    polling: boolean;
 }


### PR DESCRIPTION
Currently, every message with a body (e.g., when creating a new exercise) creates an interval that is never cleared. Not only can these add up over time, but they also trigger a ChangeDetectionCycle for Angular.

This PR
* clears the interval after the components destruction and
* disables polling by default

Background:

The `ShowMoreComponent` limits the message-body to a default height and provides the ability to expand it entirely when the user clicks on a button. To determine whether this button should be shown, we need the current height of the body. There is no way to observe this height directly. Therefore this component has multiple strategies to do this. The polling strategy would only be needed if the height changes after, e.g., an asynchronous request. A cleaner solution could be to use angulars changeDetection (via the `OnCheck`-hook?) or hide the button via CSS.

We currently only need this in the `MessageBodyComponent`, therefore this should be good enough.