### PR TITLE
TransferTargetDropdown doesn't show hospitals

### DIFF
--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/choose-transfer-target-popup/choose-transfer-target-popup.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/choose-transfer-target-popup/choose-transfer-target-popup.component.html
@@ -21,7 +21,7 @@
             [transferPointId]="reachableTransferPoint.id"
         ></app-transfer-point-name>
     </button>
-    <ng-container *ngIf="droppedElementType === 'vehicle'">
+    <ng-container *ngIf="droppedElementType === 'vehicles'">
         <div
             *ngIf="
                 (reachableTransferPoints$ | async)?.length &&

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/choose-transfer-target-popup/choose-transfer-target-popup.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/choose-transfer-target-popup/choose-transfer-target-popup.component.ts
@@ -20,7 +20,7 @@ export class ChooseTransferTargetPopupComponent
 {
     // These properties are only set after OnInit
     public transferPointId!: UUID;
-    public droppedElementType!: 'personnel' | 'vehicle';
+    public droppedElementType!: 'personnel' | 'vehicles';
 
     public transferToCallback!: (
         targetId: UUID,


### PR DESCRIPTION
The root problem is that the `droppedElement.type` is of type `any` in `onFeatureDrop()`.

This type should probably be improved sometime in the future. I add it as a comment to #530 . 