### PR TITLE
Add directive for consistent file inputs across browsers

### DIFF
--- a/frontend/src/app/pages/landing-page/landing-page/landing-page.component.html
+++ b/frontend/src/app/pages/landing-page/landing-page/landing-page.component.html
@@ -58,7 +58,7 @@
                     class="spinner-border spinner-border-sm"
                 ></span>
                 <input
-                    (input)="importExerciseState($any($event.target).files)"
+                    (appFileInput)="importExerciseState($event)"
                     type="file"
                     accept="application/json"
                     class="d-none"

--- a/frontend/src/app/shared/directives/file-input.directive.ts
+++ b/frontend/src/app/shared/directives/file-input.directive.ts
@@ -1,6 +1,4 @@
-import type { OnDestroy } from '@angular/core';
 import { Directive, EventEmitter, HostListener, Output } from '@angular/core';
-import { Subject } from 'rxjs';
 
 /**
  * This directive must only be used on file inputs and provides an output similar to `(input)`,
@@ -14,8 +12,7 @@ import { Subject } from 'rxjs';
 @Directive({
     selector: 'input[appFileInput]',
 })
-export class FileInputDirective implements OnDestroy {
-    destroy$ = new Subject<void>();
+export class FileInputDirective {
     @Output() readonly appFileInput = new EventEmitter<FileList>();
 
     @HostListener('input', ['$event'])
@@ -25,9 +22,5 @@ export class FileInputDirective implements OnDestroy {
         // This is a workaround to fix Chrome not allowing to import the same file twice in a row
         // See https://stackoverflow.com/questions/12030686/html-input-file-selection-event-not-firing-upon-selecting-the-same-file
         inputElement.value = '';
-    }
-
-    ngOnDestroy() {
-        this.destroy$.next();
     }
 }

--- a/frontend/src/app/shared/directives/file-input.directive.ts
+++ b/frontend/src/app/shared/directives/file-input.directive.ts
@@ -1,0 +1,33 @@
+import type { OnDestroy } from '@angular/core';
+import { Directive, EventEmitter, HostListener, Output } from '@angular/core';
+import { Subject } from 'rxjs';
+
+/**
+ * This directive must only be used on file inputs and provides an output similar to `(input)`,
+ * but consistent across all supported browsers.
+ *
+ * @example
+ * ````html
+ * <input type="file" (appFileInput)="processFileList($event)" />
+ * ````
+ */
+@Directive({
+    selector: 'input[appFileInput]',
+})
+export class FileInputDirective implements OnDestroy {
+    destroy$ = new Subject<void>();
+    @Output() readonly appFileInput = new EventEmitter<FileList>();
+
+    @HostListener('input', ['$event'])
+    public onInput(event: Event) {
+        const inputElement = event.target as HTMLInputElement;
+        this.appFileInput.emit(inputElement.files!);
+        // This is a workaround to fix Chrome not allowing to import the same file twice in a row
+        // See https://stackoverflow.com/questions/12030686/html-input-file-selection-event-not-firing-upon-selecting-the-same-file
+        inputElement.value = '';
+    }
+
+    ngOnDestroy() {
+        this.destroy$.next();
+    }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -21,6 +21,7 @@ import { OnlyNumbersValidatorDirective } from './validation/only-numbers-validat
 import { UrlValidatorDirective } from './validation/url-validator.directive';
 import { PatientStatusBadgeComponent } from './components/patient-status-badge/patient-status-badge.component';
 import { OrderByPipe } from './pipes/order-by.pipe';
+import { FileInputDirective } from './directives/file-input.directive';
 
 @NgModule({
     declarations: [
@@ -45,6 +46,7 @@ import { OrderByPipe } from './pipes/order-by.pipe';
         IntegerValidatorDirective,
         PatientStatusDataFieldComponent,
         PatientStatusBadgeComponent,
+        FileInputDirective,
     ],
     imports: [CommonModule],
     exports: [
@@ -68,6 +70,7 @@ import { OrderByPipe } from './pipes/order-by.pipe';
         ViewportNameComponent,
         IntegerValidatorDirective,
         PatientStatusBadgeComponent,
+        FileInputDirective,
     ],
 })
 export class SharedModule {}


### PR DESCRIPTION
This fixes #534. It uses the same workaround as #541 but encapsulates it in a reusable directive instead of directly doing it in the component.