### PR TITLE
Close popups with esc

### DIFF
--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
@@ -454,6 +454,13 @@ export class OlMapManager {
         this.olMap.getView().on(['change:resolution', 'change:center'], () => {
             this.changePopup$.next(undefined);
         });
+
+        this.openLayersContainer.addEventListener('keydown', (event) => {
+            const keyboardEvent = event as KeyboardEvent;
+            if (keyboardEvent.key === 'Escape') {
+                this.changePopup$.next(undefined);
+            }
+        });
     }
 
     private registerDropHandler(translateInteraction: TranslateInteraction) {

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
@@ -456,8 +456,7 @@ export class OlMapManager {
         });
 
         this.openLayersContainer.addEventListener('keydown', (event) => {
-            const keyboardEvent = event as KeyboardEvent;
-            if (keyboardEvent.key === 'Escape') {
+            if ((event as KeyboardEvent).key === 'Escape') {
                 this.changePopup$.next(undefined);
             }
         });


### PR DESCRIPTION
Popups can now be closed by pressing Escape. This makes it easier to use the software in environments with keyboard-based instead of touch-based interaction.