### PR TITLE
Add link to main branch in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Digitale FüSim MANV
 
+## If you're interested in the most recent stable release, please check out the [main](https://github.com/hpi-sam/digital-fuesim-manv/tree/main) branch.
+
 This is the codebase for a digital implementation of the "FüSim MANV" (Führungssimulation Massenanfall von Verletzen), a German simulation system for training emergency medical services leadership personnel on how to manage [Mass Casualty Incidents](https://en.wikipedia.org/wiki/Mass-casualty_incident).
 
 **You can try it out at [https://fuesim-manv.de/](https://fuesim-manv.de/)**.


### PR DESCRIPTION
Since we want to continue using `dev` as default branch, this PR should make it easier to find the most recent stable version of this project by adding a link to the `main`-branch in the readme.