### PR TITLE
Fix #621 Features disappear from the map in imported exercises

### DIFF
--- a/frontend/src/app/core/exercise.service.ts
+++ b/frontend/src/app/core/exercise.service.ts
@@ -54,28 +54,11 @@ export class ExerciseService {
         ...socketIoTransports,
     });
 
-    private readonly optimisticActionHandler = new OptimisticActionHandler<
+    private optimisticActionHandler?: OptimisticActionHandler<
         ExerciseAction,
         ExerciseState,
         SocketResponse
-    >(
-        (exercise) =>
-            this.store.dispatch(createSetExerciseStateAction(exercise)),
-        () => selectStateSnapshot(selectExerciseState, this.store),
-        (action) => this.store.dispatch(createApplyServerActionAction(action)),
-        async (action) => {
-            const response = await new Promise<SocketResponse>((resolve) => {
-                this.socket.emit('proposeAction', action, resolve);
-            });
-            if (!response.success) {
-                this.messageService.postError({
-                    title: 'Fehler beim Senden der Aktion',
-                    error: response.message,
-                });
-            }
-            return response;
-        }
-    );
+    >;
 
     constructor(
         private readonly store: Store<AppState>,
@@ -83,7 +66,7 @@ export class ExerciseService {
     ) {
         this.socket.on('performAction', (action: ExerciseAction) => {
             freeze(action, true);
-            this.optimisticActionHandler.performAction(action);
+            this.optimisticActionHandler?.performAction(action);
         });
         this.socket.on('disconnect', (reason) => {
             if (reason === 'io client disconnect') {
@@ -156,7 +139,32 @@ export class ExerciseService {
                 clientName
             )
         );
-        // Only start them after the correct state is in the store
+        // Only do this after the correct state is in the store
+        this.optimisticActionHandler = new OptimisticActionHandler<
+            ExerciseAction,
+            ExerciseState,
+            SocketResponse
+        >(
+            (exercise) =>
+                this.store.dispatch(createSetExerciseStateAction(exercise)),
+            () => selectStateSnapshot(selectExerciseState, this.store),
+            (action) =>
+                this.store.dispatch(createApplyServerActionAction(action)),
+            async (action) => {
+                const response = await new Promise<SocketResponse>(
+                    (resolve) => {
+                        this.socket.emit('proposeAction', action, resolve);
+                    }
+                );
+                if (!response.success) {
+                    this.messageService.postError({
+                        title: 'Fehler beim Senden der Aktion',
+                        error: response.message,
+                    });
+                }
+                return response;
+            }
+        );
         this.startNotifications();
         return true;
     }
@@ -167,6 +175,7 @@ export class ExerciseService {
     public leaveExercise() {
         this.socket.disconnect();
         this.stopNotifications();
+        this.optimisticActionHandler = undefined;
         this.store.dispatch(createLeaveExerciseAction());
     }
 
@@ -178,7 +187,8 @@ export class ExerciseService {
     public async proposeAction(action: ExerciseAction, optimistic = false) {
         if (
             selectStateSnapshot(selectExerciseStateMode, this.store) !==
-            'exercise'
+                'exercise' ||
+            this.optimisticActionHandler === undefined
         ) {
             // Especially during timeTravel, buttons that propose actions are only deactivated via best effort
             this.messageService.postError({


### PR DESCRIPTION
### Bug description

This bug can only be observed if (at least) two actions are simultaneously optimistically proposed **and** the client didn't receive any other action from the server yet since he joined the exercise.

In the provided reproduction (https://github.com/hpi-sam/digital-fuesim-manv/issues/621#issuecomment-1402155917) this was the case as dropping a patient on a vehicle doesn't just propose the `[Vehicle] Load vehicle`-action, but also sends a `[Patient] Move patient`-action right before.

The bug only occurred in these specific circumstances as we need to trigger the `general and "safe" way` to perform an action from the server (= reset the state in the client to the `serverState` and reapply all optimistic actions that are still pending) and the `serverState` must be the initial one.

The actual bug was that when initializing the `OptimisticUpdateHandler`, `getState` would still return `undefined` as the initial exercise state hasn't been retrieved yet, and the store would therefore be still empty for this value. Therefore the initial `serverState` in the `OptimisticUpdateHandler` would be `undefined` instead of the correct value.

### Fix

Initialize the `optimisticUpdateHandler` only after the exercise state is saved in the store.