### PR TITLE
Patients are automatically triaged without any personnel on the map

### DIFF
--- a/.eslint/typescript.eslintrc.cjs
+++ b/.eslint/typescript.eslintrc.cjs
@@ -110,6 +110,12 @@ module.exports = {
                         name: 'lodash',
                         message: 'Please use lodash-es instead.',
                     },
+                    {
+                        name: 'class-validator',
+                        importNames: ['isEmpty'],
+                        message:
+                            'You probably want to import this from lodash-es instead.',
+                    },
                 ],
                 patterns: [
                     {

--- a/shared/src/models/patient.ts
+++ b/shared/src/models/patient.ts
@@ -9,8 +9,8 @@ import {
     IsBoolean,
     IsString,
     MaxLength,
-    isEmpty,
 } from 'class-validator';
+import { isEmpty } from 'lodash-es';
 import { uuidValidationOptions, UUID, uuid, UUIDSet } from '../utils';
 import { IsLiteralUnion, IsIdMap, IsUUIDSet } from '../utils/validators';
 import { IsMetaPosition } from '../utils/validators/is-metaposition';


### PR DESCRIPTION
This was caused by the use of `isEmpty` from `class-validator` instead of `lodash`. 

The definitions are as follows:

`class-validator`:
> Checks if given value is empty (=== '', === null, === undefined)

`lodash`
> A value is considered empty unless it’s an arguments object, array, string, or jQuery-like collection with a length greater than 0 or an object with own enumerable properties.

