### PR TITLE
Remove unecessary unsupportedChangeProperties

### DIFF
--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/catering-lines-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/catering-lines-feature-manager.ts
@@ -11,15 +11,9 @@ import { LineStyleHelper } from '../utility/style-helper/line-style-helper';
 import { ElementManager } from './element-manager';
 
 export class CateringLinesFeatureManager
-    extends ElementManager<
-        CateringLine,
-        LineString,
-        ReadonlySet<keyof CateringLine>
-    >
+    extends ElementManager<CateringLine, LineString>
     implements FeatureManager<LineString>
 {
-    readonly unsupportedChangeProperties = new Set(['id'] as const);
-
     private readonly lineStyleHelper = new LineStyleHelper(
         (feature) => ({
             color: rgbColorPalette.cyan,

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/map-images-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/map-images-feature-manager.ts
@@ -75,6 +75,4 @@ export class MapImageFeatureManager extends MoveableFeatureManager<MapImage> {
             !mapImage.isLocked
         );
     }
-
-    override unsupportedChangeProperties = new Set(['id', 'image'] as const);
 }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/material-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/material-feature-manager.ts
@@ -57,8 +57,6 @@ export class MaterialFeatureManager extends MoveableFeatureManager<
         ]);
     }
 
-    override unsupportedChangeProperties = new Set(['id', 'image'] as const);
-
     public override onFeatureClicked(
         event: MapBrowserEvent<any>,
         feature: Feature<any>

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/moveable-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/moveable-feature-manager.ts
@@ -18,15 +18,15 @@ import { TranslateInteraction } from '../utility/translate-interaction';
 import { ElementManager } from './element-manager';
 
 /**
- * The base class for all element feature managers.
- * * manages the position of the element
- * * manages the default interactions of the element
+ * Manages the position of the element.
+ * Manages the default interactions of the element.
+ * Automatically redraws a feature (= reevaluates its style function) when an element property has changed.
  */
 export abstract class MoveableFeatureManager<
         Element extends PositionableElement,
         FeatureType extends GeometryWithCoordinates = Point
     >
-    extends ElementManager<Element, FeatureType, ReadonlySet<keyof Element>>
+    extends ElementManager<Element, FeatureType>
     implements FeatureManager<FeatureType>
 {
     public readonly togglePopup$ = new Subject<OpenPopupOptions<any>>();
@@ -49,9 +49,6 @@ export abstract class MoveableFeatureManager<
         );
     }
 
-    override unsupportedChangeProperties: ReadonlySet<keyof Element> = new Set(
-        [] as const
-    );
     createFeature(element: Element): Feature<FeatureType> {
         const elementFeature = this.geometryHelper.create(element);
         elementFeature.setId(element.id);
@@ -82,7 +79,6 @@ export abstract class MoveableFeatureManager<
     changeFeature(
         oldElement: Element,
         newElement: Element,
-        // It is too much work to correctly type this param with {@link unsupportedChangeProperties}
         changedProperties: ReadonlySet<keyof Element>,
         elementFeature: Feature<FeatureType>
     ): void {
@@ -92,7 +88,7 @@ export abstract class MoveableFeatureManager<
                 this.geometryHelper.getElementCoordinates(newElement)
             );
         }
-        // If the style has updated, we need to redraw the feature
+        // Redraw the feature to reevaluate its style function
         elementFeature.changed();
     }
 

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/patient-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/patient-feature-manager.ts
@@ -101,6 +101,4 @@ export class PatientFeatureManager extends MoveableFeatureManager<
             })
         );
     }
-
-    override unsupportedChangeProperties = new Set(['id', 'image'] as const);
 }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/personnel-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/personnel-feature-manager.ts
@@ -58,8 +58,6 @@ export class PersonnelFeatureManager extends MoveableFeatureManager<
         ]);
     }
 
-    override unsupportedChangeProperties = new Set(['id', 'image'] as const);
-
     public override onFeatureClicked(
         event: MapBrowserEvent<any>,
         feature: Feature<any>

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/simulated-region-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/simulated-region-feature-manager.ts
@@ -24,8 +24,6 @@ export class SimulatedRegionFeatureManager
     extends MoveableFeatureManager<SimulatedRegion, Polygon>
     implements FeatureManager<Polygon>
 {
-    override unsupportedChangeProperties = new Set(['id'] as const);
-
     constructor(
         olMap: OlMap,
         layer: VectorLayer<VectorSource<Polygon>>,

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-lines-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-lines-feature-manager.ts
@@ -11,15 +11,9 @@ import type { FeatureManager } from '../utility/feature-manager';
 import { ElementManager } from './element-manager';
 
 export class TransferLinesFeatureManager
-    extends ElementManager<
-        TransferLine,
-        LineString,
-        ReadonlySet<keyof TransferLine>
-    >
+    extends ElementManager<TransferLine, LineString>
     implements FeatureManager<LineString>
 {
-    readonly unsupportedChangeProperties = new Set(['id'] as const);
-
     constructor(public readonly layer: VectorLayer<VectorSource<LineString>>) {
         super();
         layer.setStyle(

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-point-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-point-feature-manager.ts
@@ -156,9 +156,4 @@ export class TransferPointFeatureManager extends MoveableFeatureManager<Transfer
     override isFeatureTranslatable(feature: Feature<Point>): boolean {
         return selectStateSnapshot(selectCurrentRole, this.store) === 'trainer';
     }
-
-    override unsupportedChangeProperties = new Set([
-        'id',
-        'internalName',
-    ] as const);
 }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/vehicle-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/vehicle-feature-manager.ts
@@ -94,8 +94,6 @@ export class VehicleFeatureManager extends MoveableFeatureManager<
         return false;
     }
 
-    override unsupportedChangeProperties = new Set(['id', 'image'] as const);
-
     public override onFeatureClicked(
         event: MapBrowserEvent<any>,
         feature: Feature<any>

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/viewport-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/viewport-feature-manager.ts
@@ -34,8 +34,6 @@ export class ViewportFeatureManager
     extends MoveableFeatureManager<Viewport, Polygon>
     implements FeatureManager<Polygon>
 {
-    override unsupportedChangeProperties = new Set(['id'] as const);
-
     constructor(
         olMap: OlMap,
         layer: VectorLayer<VectorSource<Polygon>>,

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
@@ -378,7 +378,7 @@ export class OlMapManager {
     private registerFeatureElementManager<
         Element extends ImmutableJsonObject,
         T extends MergeIntersection<
-            ElementManager<Element, any, any> & FeatureManager<any>
+            ElementManager<Element, any> & FeatureManager<any>
         >
     >(
         featureManager: T,


### PR DESCRIPTION
This PR removes a relict from the time when we didn't have any clue about OpenLayers.

The original idea was:
* If the element changes, we have to imperatively tell OpenLayers what exact properties of the feature should be changed (e.g., via `feature.setPosition()`)
* The same would apply to all styles as well as elements that are represented through multiple features
* This would be a lot of code
* Instead of implementing these changes for every feature, we could just delete it and create it new. We would, therefore, only have to specify the style during the creation of the element and not change the features in between.

These predictions didn't work out:
* We always just used a single feature to represent an element
* Features can have a style function that can easily be reevaluated every time the element changes.

Therefore, we didn't use `unsupportedChangeProperties` (or made incorrect use of it).

The only properties we put in it were:
* `id` - the `id` never changes as elements are identified by it
* `internalName` (for TransferPoint) - the style is reevaluated when it changes  -> no problems
* `image` - the style is reevaluated when it changes -> no problems

You can test this out by adding the following code to `shared\src\store\action-reducers\exercise.ts` in the `exerciseTick` function:

```ts
            const rtwImage = {
                url: '/assets/rtw-vehicle.png',
                height: 100,
                aspectRatio: 3693 / 1670,
            };

            const ktwImage = {
                url: '/assets/ktw-vehicle.png',
                height: 100,
                aspectRatio: 5046 / 2465,
            };
            for (const vehicle of Object.values(draftState.vehicles)) {
                vehicle.image =
                    draftState.currentTime % 2000 === 0 ? ktwImage : rtwImage;
            }
```

This PR removes this feature. Should there ever be a FeatureManager that wants to use it, it would probably be sufficient to do this on a higher abstraction level instead of directly in the `ElementManager`.

Btw. I believe this is the first refactoring that actually reduces the Lines of code 😉  