### PR TITLE
Adjust nginx configuration for about pages

### DIFF
--- a/docker/nginx/locations
+++ b/docker/nginx/locations
@@ -1,12 +1,17 @@
     # Frontend
+    root /usr/local/app/frontend/dist/digital-fuesim-manv;
+
+    location /assets/about {
+        # Requests to this location should not fall back to index.html
+    }
+
     location / {
-        alias   /usr/local/app/frontend/dist/digital-fuesim-manv/;
         try_files $uri $uri/ /index.html;
     }
 
     # API
     location /api {
-		proxy_pass	http://localhost:3201;
+        proxy_pass	http://localhost:3201;
         proxy_http_version 1.1;
         proxy_set_header   Host $host;
         proxy_set_header   X-Forwarded-Host  $host;
@@ -14,10 +19,10 @@
         proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header   X-Forwarded-Proto $scheme;
         include conf.d/upload-limit;
-	}
+    }
 
     # Websocket
-	location /socket.io {
+    location /socket.io {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_pass http://localhost:3200;
@@ -28,4 +33,4 @@
         proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header   X-Forwarded-Proto $scheme;
         include conf.d/upload-limit;
-	}
+    }

--- a/docker/nginx/locations
+++ b/docker/nginx/locations
@@ -1,10 +1,10 @@
     # Frontend
     root /usr/local/app/frontend/dist/digital-fuesim-manv;
+    error_page 404 /index.html;
+    error_page 403 /index.html;
 
     location /assets/about {
         # Requests to this location should not fall back to index.html
-        error_page 404 /non_existent_page.html;
-        error_page 403 /non_existent_page.html;
     }
 
     location / {

--- a/docker/nginx/locations
+++ b/docker/nginx/locations
@@ -3,6 +3,8 @@
 
     location /assets/about {
         # Requests to this location should not fall back to index.html
+        error_page 404 /non_existent_page.html;
+        error_page 403 /non_existent_page.html;
     }
 
     location / {

--- a/frontend/src/app/pages/about/about-placeholder/about-placeholder.component.html
+++ b/frontend/src/app/pages/about/about-placeholder/about-placeholder.component.html
@@ -3,7 +3,8 @@
     <h2 class="display-4">{{ pageTitle }}</h2>
 
     <p>
-        <a (click)="back($event)" href="#">Zurück zur vorherigen Seite</a>
+        <a (click)="back($event)" href="#">Zurück zur vorherigen Seite</a> |
+        <a routerLink="/">Zur Startseite</a>
     </p>
 
     <div


### PR DESCRIPTION
The about pages request the content for the pages from the server and rely on the server to answer either 200 if the file exists or 404 if the file doesn't. If the file doesn't exist, the page should show a hint how to customize this page.

Since the application uses client-side routing, the server serves the `index.html` for all requests where a file with a matching name could not be found. This breaks the functionality of the about pages.

This PR adjusts the configuration of the nginx in the docker container to fix the bug for the about pages while preserving the ability of client-side-routing.