### PR TITLE
Fix extent calculation of viewports and simulated regions

### DIFF
--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/exercise-map.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/exercise-map.component.html
@@ -25,7 +25,7 @@
                 (currentRole$ | async) !== 'participant' &&
                 (restrictedToViewport$ | async) === undefined
             "
-            (click)="olMapManager?.tryToFitViewToViewports()"
+            (click)="olMapManager?.tryToFitViewForOverview()"
             class="btn btn-sm btn-light"
             title="Alle Ansichten anzeigen"
         >

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
@@ -6,7 +6,6 @@ import type {
     UUID,
 } from 'digital-fuesim-manv-shared';
 import {
-    currentCoordinatesOf,
     upperLeftCornerOf,
     lowerRightCornerOf,
 } from 'digital-fuesim-manv-shared';
@@ -361,11 +360,13 @@ export class OlMapManager {
                 }
                 const center = view.getCenter()!;
                 const previousZoom = view.getZoom()!;
+                const targetUpperLeftCorner = upperLeftCornerOf(viewport);
+                const targetLowerRightCorner = lowerRightCornerOf(viewport);
                 const targetExtent = [
-                    currentCoordinatesOf(viewport).x,
-                    currentCoordinatesOf(viewport).y - viewport.size.height,
-                    currentCoordinatesOf(viewport).x + viewport.size.width,
-                    currentCoordinatesOf(viewport).y,
+                    targetUpperLeftCorner.x,
+                    targetLowerRightCorner.y,
+                    targetLowerRightCorner.x,
+                    targetUpperLeftCorner.y,
                 ];
                 view.fit(targetExtent);
                 const matchingZoom = view.getZoom()!;

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
@@ -5,7 +5,11 @@ import type {
     MergeIntersection,
     UUID,
 } from 'digital-fuesim-manv-shared';
-import { currentCoordinatesOf } from 'digital-fuesim-manv-shared';
+import {
+    currentCoordinatesOf,
+    upperLeftCornerOf,
+    lowerRightCornerOf,
+} from 'digital-fuesim-manv-shared';
 import type { Feature } from 'ol';
 import { Overlay, View } from 'ol';
 import type { Polygon } from 'ol/geom';
@@ -25,6 +29,7 @@ import { handleChanges } from 'src/app/shared/functions/handle-changes';
 import type { AppState } from 'src/app/state/app.state';
 import {
     selectExerciseStatus,
+    selectSimulatedRegion,
     selectTileMapProperties,
     selectTransferLines,
     selectViewports,
@@ -506,31 +511,28 @@ export class OlMapManager {
             // We are restricted to a viewport -> you can't fit the view
             return;
         }
-        const viewports = Object.values(
-            selectStateSnapshot(selectViewports, this.store)
-        );
+        const elements = [
+            ...Object.values(selectStateSnapshot(selectViewports, this.store)),
+            ...Object.values(
+                selectStateSnapshot(selectSimulatedRegion, this.store)
+            ),
+        ];
         const view = this.olMap.getView();
-        if (viewports.length === 0) {
+        if (elements.length === 0) {
             view.setCenter([startingPosition.x, startingPosition.y]);
             return;
         }
         const minX = Math.min(
-            ...viewports.map((viewport) => currentCoordinatesOf(viewport).x)
+            ...elements.map((element) => upperLeftCornerOf(element).x)
         );
         const minY = Math.min(
-            ...viewports.map(
-                (viewport) =>
-                    currentCoordinatesOf(viewport).y - viewport.size.height
-            )
+            ...elements.map((element) => lowerRightCornerOf(element).y)
         );
         const maxX = Math.max(
-            ...viewports.map(
-                (viewport) =>
-                    currentCoordinatesOf(viewport).x + viewport.size.width
-            )
+            ...elements.map((element) => lowerRightCornerOf(element).x)
         );
         const maxY = Math.max(
-            ...viewports.map((viewport) => currentCoordinatesOf(viewport).y)
+            ...elements.map((element) => upperLeftCornerOf(element).y)
         );
         const padding = 25;
         view.fit([minX, minY, maxX, maxY], {

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
@@ -345,7 +345,7 @@ export class OlMapManager {
     }
 
     private registerViewportRestriction() {
-        this.tryToFitViewToViewports(false);
+        this.tryToFitViewForOverview(false);
         this.store
             .select(selectRestrictedViewport)
             .pipe(takeUntil(this.destroy$))
@@ -502,9 +502,9 @@ export class OlMapManager {
     }
 
     /**
-     * Sets the map's view to see all viewports.
+     * Sets the map's view to see all viewports and simulated regions.
      */
-    public tryToFitViewToViewports(animate = true) {
+    public tryToFitViewForOverview(animate = true) {
         if (
             selectStateSnapshot(selectRestrictedViewport, this.store) !==
             undefined

--- a/shared/src/models/utils/position/position-helpers.ts
+++ b/shared/src/models/utils/position/position-helpers.ts
@@ -1,11 +1,12 @@
 import type { UUID } from '../../../utils';
 import type { Transfer } from '../transfer';
-import type { MapCoordinates } from './map-coordinates';
+import { MapCoordinates } from './map-coordinates';
 import type { MapPosition } from './map-position';
 import type { Position } from './position';
 import type { SimulatedRegionPosition } from './simulated-region-position';
 import type { TransferPosition } from './transfer-position';
 import type { VehiclePosition } from './vehicle-position';
+import type { WithExtent } from './with-extent';
 import type { WithPosition } from './with-position';
 
 export function isOnMap(withPosition: WithPosition): boolean {
@@ -130,4 +131,32 @@ export function simulatedRegionIdOfPosition(position: Position): UUID {
     throw new TypeError(
         `Expected position to be in simulatedRegion. Was of type ${position.type}.`
     );
+}
+
+export function upperLeftCornerOf(element: WithExtent): MapCoordinates {
+    const corner = { ...currentCoordinatesOf(element) };
+
+    if (element.size.width < 0) {
+        corner.x += element.size.width;
+    }
+
+    if (element.size.height < 0) {
+        corner.y -= element.size.height;
+    }
+
+    return MapCoordinates.create(corner.x, corner.y);
+}
+
+export function lowerRightCornerOf(element: WithExtent): MapCoordinates {
+    const corner = { ...currentCoordinatesOf(element) };
+
+    if (element.size.width > 0) {
+        corner.x += element.size.width;
+    }
+
+    if (element.size.height > 0) {
+        corner.y -= element.size.height;
+    }
+
+    return MapCoordinates.create(corner.x, corner.y);
 }

--- a/shared/src/models/utils/position/with-extent.ts
+++ b/shared/src/models/utils/position/with-extent.ts
@@ -1,7 +1,6 @@
 import type { Size } from '../size';
-import type { Position } from './position';
+import type { WithPosition } from './with-position';
 
-export interface WithExtent {
-    readonly position: Position;
+export interface WithExtent extends WithPosition {
     readonly size: Size;
 }

--- a/shared/src/models/utils/position/with-extent.ts
+++ b/shared/src/models/utils/position/with-extent.ts
@@ -1,0 +1,7 @@
+import type { Size } from '../size';
+import type { Position } from './position';
+
+export interface WithExtent {
+    readonly position: Position;
+    readonly size: Size;
+}

--- a/shared/src/models/viewport.ts
+++ b/shared/src/models/viewport.ts
@@ -6,9 +6,11 @@ import { IsValue } from '../utils/validators';
 import {
     currentCoordinatesOf,
     getCreate,
+    lowerRightCornerOf,
     MapPosition,
     Position,
     Size,
+    upperLeftCornerOf,
 } from './utils';
 import type { ImageProperties, MapCoordinates } from './utils';
 
@@ -54,13 +56,13 @@ export class Viewport {
     };
 
     static isInViewport(viewport: Viewport, position: MapCoordinates): boolean {
+        const upperLeftCorner = upperLeftCornerOf(viewport);
+        const lowerRightCorner = lowerRightCornerOf(viewport);
         return (
-            currentCoordinatesOf(viewport).x <= position.x &&
-            position.x <=
-                currentCoordinatesOf(viewport).x + viewport.size.width &&
-            currentCoordinatesOf(viewport).y - viewport.size.height <=
-                position.y &&
-            position.y <= currentCoordinatesOf(viewport).y
+            upperLeftCorner.x <= position.x &&
+            position.x <= lowerRightCorner.x &&
+            lowerRightCorner.y <= position.y &&
+            position.y <= upperLeftCorner.y
         );
     }
 }

--- a/shared/src/models/viewport.ts
+++ b/shared/src/models/viewport.ts
@@ -4,7 +4,6 @@ import { UUID, uuid, uuidValidationOptions } from '../utils';
 import { IsPosition } from '../utils/validators/is-position';
 import { IsValue } from '../utils/validators';
 import {
-    currentCoordinatesOf,
     getCreate,
     lowerRightCornerOf,
     MapPosition,


### PR DESCRIPTION
This PR fixes the following bugs:

- When using `tryToFitViewToViewports()` (which was renamed to `tryToFitViewForOverview()` due to the change), the map view will be adjusted to show all viewports **and simulated regions** now
- When fitting the view (for overview or restriction of a client to one viewport), negative extents of viewports and simulated regions will be handled correctly now
- When checking whether coordinates are in a viewport (`Viewport.isInViewport`), negative extents of viewports will be handled correctly now