### PR TITLE
Document meaning of position and size of rects

### DIFF
--- a/shared/src/models/simulated-region.ts
+++ b/shared/src/models/simulated-region.ts
@@ -22,7 +22,8 @@ export class SimulatedRegion {
     public readonly type = 'simulatedRegion';
 
     /**
-     * top-left position
+     * Position of the viewport.
+     * For positive {@link size}s, this refers to the upper left corner of the simulated region, but during resizing, corners may be swapped.
      *
      * @deprecated Do not access directly, use helper methods from models/utils/position/position-helpers(-mutable) instead.
      */
@@ -30,6 +31,11 @@ export class SimulatedRegion {
     @IsPosition()
     public readonly position: Position;
 
+    /**
+     * Size of the viewport.
+     * The width of a viewport grows to the left, the height grows downwards.
+     * Negative sizes, referring to the opposite direction, are possible.
+     */
     @ValidateNested()
     @Type(() => Size)
     public readonly size: Size;

--- a/shared/src/models/viewport.ts
+++ b/shared/src/models/viewport.ts
@@ -21,7 +21,8 @@ export class Viewport {
     public readonly type = 'viewport';
 
     /**
-     * top-left position
+     * Position of the viewport.
+     * For positive {@link size}s, this refers to the upper left corner of the viewport, but during resizing, corners may be swapped.
      *
      * @deprecated Do not access directly, use helper methods from models/utils/position/position-helpers(-mutable) instead.
      */
@@ -29,6 +30,11 @@ export class Viewport {
     @IsPosition()
     public readonly position: Position;
 
+    /**
+     * Size of the viewport.
+     * The width of a viewport grows to the left, the height grows downwards.
+     * Negative sizes, referring to the opposite direction, are possible.
+     */
     @ValidateNested()
     @Type(() => Size)
     public readonly size: Size;


### PR DESCRIPTION
In #663 we've fixed a bug related to the position and size of viewports and simulated regions. To prevent similar bugs to occur again, this PR should improve the documentation of these values.