### PR TITLE
Improve vehicle load and unload behavior

### DIFF
--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/vehicle-popup/vehicle-popup.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/vehicle-popup/vehicle-popup.component.html
@@ -39,13 +39,30 @@
             </span>
         </div>
 
-        <button
-            (click)="unloadVehicle()"
-            [disabled]="vehicleIsCompletelyUnloaded$ | async"
-            class="btn btn-outline-primary"
-        >
-            <i class="bi-box-arrow-left"></i>
-            Alle aussteigen
-        </button>
+        <div class="btn-group">
+            <button
+                (click)="unloadVehicle()"
+                [disabled]="
+                    (vehicleLoadState$ | async) === 'completelyUnloaded'
+                "
+                class="btn btn-outline-primary"
+            >
+                <i class="bi-box-arrow-left"></i>
+                Alle aussteigen
+            </button>
+            <button
+                (click)="loadVehicle()"
+                [disabled]="(vehicleLoadState$ | async) === 'completelyLoaded'"
+                class="btn btn-outline-primary"
+            >
+                <i class="bi-box-arrow-in-right"></i>
+                Alle einsteigen
+            </button>
+        </div>
+
+        <p>
+            Personal, das sich gerade im Transfer befindet, kann nicht
+            einsteigen.
+        </p>
     </div>
 </ng-container>

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/vehicle-popup/vehicle-popup.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/vehicle-popup/vehicle-popup.component.ts
@@ -28,7 +28,9 @@ export class VehiclePopupComponent implements PopupComponent, OnInit {
     @Output() readonly closePopup = new EventEmitter<void>();
 
     public vehicle$?: Observable<Vehicle>;
-    public vehicleIsCompletelyUnloaded$?: Observable<boolean>;
+    public vehicleLoadState$?: Observable<
+        'completelyLoaded' | 'completelyUnloaded' | 'partiallyLoaded'
+    >;
     public readonly currentRole$ = this.store.select(selectCurrentRole);
 
     constructor(
@@ -38,7 +40,7 @@ export class VehiclePopupComponent implements PopupComponent, OnInit {
 
     async ngOnInit() {
         this.vehicle$ = this.store.select(createSelectVehicle(this.vehicleId));
-        this.vehicleIsCompletelyUnloaded$ = this.vehicle$.pipe(
+        this.vehicleLoadState$ = this.vehicle$.pipe(
             switchMap((_vehicle) => {
                 const materialsAreInVehicle$ = Object.keys(
                     _vehicle.materialIds
@@ -67,9 +69,17 @@ export class VehiclePopupComponent implements PopupComponent, OnInit {
                     ...patientsAreInVehicle$,
                 ]);
             }),
-            map((areInVehicle) =>
-                areInVehicle.every((isInAVehicle) => !isInAVehicle)
-            )
+            map((areInVehicle) => {
+                if (areInVehicle.every((isInAVehicle) => isInAVehicle)) {
+                    return 'completelyLoaded';
+                } else if (
+                    areInVehicle.every((isInAVehicle) => !isInAVehicle)
+                ) {
+                    return 'completelyUnloaded';
+                }
+
+                return 'partiallyLoaded';
+            })
         );
     }
 
@@ -84,6 +94,14 @@ export class VehiclePopupComponent implements PopupComponent, OnInit {
     public unloadVehicle() {
         this.exerciseService.proposeAction({
             type: '[Vehicle] Unload vehicle',
+            vehicleId: this.vehicleId,
+        });
+        this.closePopup.emit();
+    }
+
+    public loadVehicle() {
+        this.exerciseService.proposeAction({
+            type: '[Vehicle] Completely load vehicle',
             vehicleId: this.vehicleId,
         });
         this.closePopup.emit();

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/vehicle-popup/vehicle-popup.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/vehicle-popup/vehicle-popup.component.ts
@@ -1,8 +1,8 @@
 import type { OnInit } from '@angular/core';
 import { Component, EventEmitter, Output } from '@angular/core';
 import { Store } from '@ngrx/store';
-import type { UUID, Vehicle } from 'digital-fuesim-manv-shared';
-import { isInVehicle } from 'digital-fuesim-manv-shared';
+import type { UUID } from 'digital-fuesim-manv-shared';
+import { Vehicle } from 'digital-fuesim-manv-shared';
 import type { Observable } from 'rxjs';
 import { combineLatest, map, switchMap } from 'rxjs';
 import { ExerciseService } from 'src/app/core/exercise.service';
@@ -47,21 +47,33 @@ export class VehiclePopupComponent implements PopupComponent, OnInit {
                 ).map((materialId) =>
                     this.store
                         .select(createSelectMaterial(materialId))
-                        .pipe(map((material) => isInVehicle(material)))
+                        .pipe(
+                            map((material) =>
+                                Vehicle.isInVehicle(_vehicle, material)
+                            )
+                        )
                 );
                 const personnelAreInVehicle$ = Object.keys(
                     _vehicle.personnelIds
                 ).map((personnelId) =>
                     this.store
                         .select(createSelectPersonnel(personnelId))
-                        .pipe(map((personnel) => isInVehicle(personnel)))
+                        .pipe(
+                            map((personnel) =>
+                                Vehicle.isInVehicle(_vehicle, personnel)
+                            )
+                        )
                 );
                 const patientsAreInVehicle$ = Object.keys(
                     _vehicle.patientIds
                 ).map((patientId) =>
                     this.store
                         .select(createSelectPatient(patientId))
-                        .pipe(map((patient) => isInVehicle(patient)))
+                        .pipe(
+                            map((patient) =>
+                                Vehicle.isInVehicle(_vehicle, patient)
+                            )
+                        )
                 );
                 return combineLatest([
                     ...materialsAreInVehicle$,

--- a/shared/src/store/action-reducers/hospital.ts
+++ b/shared/src/store/action-reducers/hospital.ts
@@ -11,6 +11,8 @@ import { HospitalPatient } from '../../models/hospital-patient';
 import { cloneDeepMutable, UUID, uuidValidationOptions } from '../../utils';
 import { IsValue } from '../../utils/validators';
 import type { Action, ActionReducer } from '../action-reducer';
+import { ReducerError } from '../reducer-error';
+import { isCompletelyLoaded } from './utils/completely-load-vehicle';
 import { getElement } from './utils/get-element';
 import { deleteVehicle } from './vehicle';
 
@@ -116,7 +118,13 @@ export namespace HospitalActionReducers {
             reducer: (draftState, { hospitalId, vehicleId }) => {
                 const hospital = getElement(draftState, 'hospital', hospitalId);
                 const vehicle = getElement(draftState, 'vehicle', vehicleId);
-                // TODO: Block vehicles whose material and personnel are unloaded
+
+                if (!isCompletelyLoaded(draftState, vehicle)) {
+                    throw new ReducerError(
+                        'Das Fahrzeug kann nur ein Krankenhaus anfahren, wenn Personal und Material eingestiegen sind.'
+                    );
+                }
+
                 for (const patientId of Object.keys(vehicle.patientIds)) {
                     const patient = getElement(
                         draftState,

--- a/shared/src/store/action-reducers/simulated-region.ts
+++ b/shared/src/store/action-reducers/simulated-region.ts
@@ -2,12 +2,10 @@ import { Type } from 'class-transformer';
 import { IsString, IsUUID, ValidateNested } from 'class-validator';
 import { SimulatedRegion } from '../../models';
 import {
-    isNotInVehicle,
     MapCoordinates,
     MapPosition,
     SimulatedRegionPosition,
     Size,
-    VehiclePosition,
 } from '../../models/utils';
 import {
     changePosition,

--- a/shared/src/store/action-reducers/utils/completely-load-vehicle.ts
+++ b/shared/src/store/action-reducers/utils/completely-load-vehicle.ts
@@ -1,0 +1,66 @@
+import type { Vehicle } from '../../../models';
+import {
+    isInVehicle,
+    isNotInTransfer,
+    VehiclePosition,
+} from '../../../models/utils';
+import { changePosition } from '../../../models/utils/position/position-helpers-mutable';
+import type { ExerciseState } from '../../../state';
+import type { Mutable } from '../../../utils';
+import { getElement } from './get-element';
+
+/**
+ * Checks whether all materials and personnel belonging to a vehicle are in it.
+ *
+ * @param draftState The state to operate in
+ * @param vehicle The vehicle to check
+ * @returns `true` if everything is in the vehicle, `false` otherwise
+ */
+export function isCompletelyLoaded(
+    draftState: Mutable<ExerciseState>,
+    vehicle: Mutable<Vehicle>
+) {
+    const materialsLoaded = Object.keys(vehicle.materialIds).map((materialId) =>
+        isInVehicle(getElement(draftState, 'material', materialId))
+    );
+
+    const personnelLoaded = Object.keys(vehicle.personnelIds).map(
+        (personnelId) =>
+            isInVehicle(getElement(draftState, 'personnel', personnelId))
+    );
+
+    return (
+        materialsLoaded.every((loaded) => loaded) &&
+        personnelLoaded.every((loaded) => loaded)
+    );
+}
+
+/**
+ * Loads all materials and personnel belonging to a vehicle into it.
+ * Personnel that is currently in transfer won't be loaded.
+ *
+ * @param draftState The state to operate in
+ * @param vehicle The vehicle to load
+ */
+export function completelyLoadVehicle(
+    draftState: Mutable<ExerciseState>,
+    vehicle: Mutable<Vehicle>
+) {
+    const vehiclePosition = VehiclePosition.create(vehicle.id);
+
+    Object.keys(vehicle.materialIds).forEach((materialId) => {
+        changePosition(
+            getElement(draftState, 'material', materialId),
+            vehiclePosition,
+            draftState
+        );
+    });
+
+    Object.keys(vehicle.personnelIds).forEach((personnelId) => {
+        const personnel = getElement(draftState, 'personnel', personnelId);
+
+        if (isNotInTransfer(personnel)) {
+            changePosition(personnel, vehiclePosition, draftState);
+        }
+    });
+}

--- a/shared/src/store/action-reducers/utils/completely-load-vehicle.ts
+++ b/shared/src/store/action-reducers/utils/completely-load-vehicle.ts
@@ -4,7 +4,10 @@ import {
     isNotInTransfer,
     VehiclePosition,
 } from '../../../models/utils';
-import { changePosition } from '../../../models/utils/position/position-helpers-mutable';
+import {
+    changePosition,
+    changePositionWithId,
+} from '../../../models/utils/position/position-helpers-mutable';
 import type { ExerciseState } from '../../../state';
 import type { Mutable } from '../../../utils';
 import { getElement } from './get-element';
@@ -49,9 +52,10 @@ export function completelyLoadVehicle(
     const vehiclePosition = VehiclePosition.create(vehicle.id);
 
     Object.keys(vehicle.materialIds).forEach((materialId) => {
-        changePosition(
-            getElement(draftState, 'material', materialId),
+        changePositionWithId(
+            materialId,
             vehiclePosition,
+            'material',
             draftState
         );
     });

--- a/shared/src/store/action-reducers/utils/completely-load-vehicle.ts
+++ b/shared/src/store/action-reducers/utils/completely-load-vehicle.ts
@@ -1,9 +1,5 @@
-import type { Vehicle } from '../../../models';
-import {
-    isInVehicle,
-    isNotInTransfer,
-    VehiclePosition,
-} from '../../../models/utils';
+import { Vehicle } from '../../../models';
+import { isNotInTransfer, VehiclePosition } from '../../../models/utils';
 import {
     changePosition,
     changePositionWithId,
@@ -24,12 +20,18 @@ export function isCompletelyLoaded(
     vehicle: Mutable<Vehicle>
 ) {
     const materialsLoaded = Object.keys(vehicle.materialIds).map((materialId) =>
-        isInVehicle(getElement(draftState, 'material', materialId))
+        Vehicle.isInVehicle(
+            vehicle,
+            getElement(draftState, 'material', materialId)
+        )
     );
 
     const personnelLoaded = Object.keys(vehicle.personnelIds).map(
         (personnelId) =>
-            isInVehicle(getElement(draftState, 'personnel', personnelId))
+            Vehicle.isInVehicle(
+                vehicle,
+                getElement(draftState, 'personnel', personnelId)
+            )
     );
 
     return (

--- a/shared/src/store/action-reducers/vehicle.ts
+++ b/shared/src/store/action-reducers/vehicle.ts
@@ -5,7 +5,6 @@ import {
     currentCoordinatesOf,
     isInTransfer,
     isInVehicle,
-    isNotInTransfer,
     isNotOnMap,
     MapCoordinates,
     MapPosition,


### PR DESCRIPTION
This PR adds the feature requested in #660 that personnel will stay near their vehicle, meaning that when moving it into a simulated region, the personnel will be added to this region, too.

We've decided that the personnel should be on the vehicle rather than being added to the simulated region separately. To avoid personnel being removed from the map suddenly, the action reducer refuses to add vehicles to a simulated region if they're not fully loaded. In this case, a `ReducerError` is thrown, resulting in a toast shown to the user (which was fixed in #676).

For consistency with the previous behavior, adding a patient to a vehicle still automatically adds the personnel and material to the vehicle, too.

To prevent making it harder to add a vehicle to a simulated region than it was before, a load vehicle button has been added to the vehicle, that makes all personnel enter the vehicle automatically. This can be used to ensure the vehicle can be added to the region.

This RP introduces a breaking change due to fixing the todo: *Block vehicles whose material and personnel are unloaded* in the `transportPatientToHospital` action reducer. Importing an exercise in which a vehicle was transferred to a hospital without it's personnel and material on board will fail. However, this case is not likely to occur since adding a patient to a vehicle forcefully adds the personnel and material, too. The only case in which the error can occur is if the patient was added while a personnel of the vehicle was in transfer and therefore could not be added to the vehicle.