### PR TITLE
Run OpenLayers inside zone

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -77,7 +77,7 @@ We call Angular components, pipes, directives, services, and modules "Angular el
 
 In [src/app/state](./src/app/state) are all actions, reducers, selectors and state that are used by [NGRX](https://ngrx.io/).
 
-In `src/app` and every descending folder the following guidelines apply:
+In `src/app` and every descending folder, the following guidelines apply:
 
 -   `/core`:
     -   Singleton-services and route guards that can be used by all other Angular elements that are direct or indirect children of the `core`'s parent-folder
@@ -98,6 +98,7 @@ If you want to modify the exercise state, do not do it via [reducers](https://ng
 If you want to switch between time travel, live exercise and no exercise (e.g. on the landing page), use the [ApplicationService](./src/app/core/application.service.ts).
 
 By default, we don't use `ChangeDetectionStrategy.OnPush` because it complicates the code and increases the skill level needed to work with the code while providing a mostly negligible performance benefit.
+For the same reason, there are also no optimizations made regarding how often the change detection is triggered by zones. E.g. OpenLayers runs inside the zone and therefore triggers the change detection on every `pointermove`- and `requestAnimationFrame`-event ([which are also patched by zone.js](frontend\src\polyfills.ts)). Read the angular documentation [regarding change detection](https://angular.io/guide/change-detection) for more information.
 
 ### Exercise map
 

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/catering-lines-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/catering-lines-feature-manager.ts
@@ -1,17 +1,17 @@
-import type { Type, NgZone } from '@angular/core';
+import type { Type } from '@angular/core';
 import type { Store } from '@ngrx/store';
 import type { MapBrowserEvent } from 'ol';
 import { Feature } from 'ol';
 import LineString from 'ol/geom/LineString';
 import type { TranslateEvent } from 'ol/interaction/Translate';
 import type VectorLayer from 'ol/layer/Vector';
+import type OlMap from 'ol/Map';
 import type VectorSource from 'ol/source/Vector';
 import type { Subject } from 'rxjs';
 import { rgbColorPalette } from 'src/app/shared/functions/colors';
 import type { CateringLine } from 'src/app/shared/types/catering-line';
 import type { AppState } from 'src/app/state/app.state';
 import { selectVisibleCateringLines } from 'src/app/state/application/selectors/shared.selectors';
-import type OlMap from 'ol/Map';
 // eslint-disable-next-line @typescript-eslint/no-shadow
 import type { Element } from 'digital-fuesim-manv-shared';
 import type { FeatureManager } from '../utility/feature-manager';
@@ -46,7 +46,6 @@ export class CateringLinesFeatureManager
     register(
         changePopup$: Subject<OpenPopupOptions<any, Type<any>> | undefined>,
         destroy$: Subject<void>,
-        ngZone: NgZone,
         mapInteractionsManager: OlMapInteractionsManager
     ) {
         this.olMap.addLayer(this.layer);
@@ -56,7 +55,6 @@ export class CateringLinesFeatureManager
         this.registerChangeHandlers(
             this.store.select(selectVisibleCateringLines),
             destroy$,
-            ngZone,
             (element) => this.onElementCreated(element),
             (element) => this.onElementDeleted(element),
             (oldElement, newElement) =>

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/delete-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/delete-feature-manager.ts
@@ -1,4 +1,4 @@
-import type { Type, NgZone } from '@angular/core';
+import type { Type } from '@angular/core';
 import type { Store } from '@ngrx/store';
 import type { MapBrowserEvent, View } from 'ol';
 import { Feature } from 'ol';
@@ -45,7 +45,6 @@ export class DeleteFeatureManager implements FeatureManager<Point> {
     register(
         changePopup$: Subject<OpenPopupOptions<any, Type<any>> | undefined>,
         destroy$: Subject<void>,
-        ngZone: NgZone,
         mapInteractionsManager: OlMapInteractionsManager
     ) {
         this.olMap.addLayer(this.layer);

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/element-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/element-manager.ts
@@ -1,4 +1,3 @@
-import type { NgZone } from '@angular/core';
 import type { ImmutableJsonObject } from 'digital-fuesim-manv-shared';
 import type { Feature } from 'ol';
 import type { Geometry, Point } from 'ol/geom';
@@ -111,7 +110,6 @@ export abstract class ElementManager<
     protected registerChangeHandlers(
         elementDictionary$: Observable<{ [id: string]: Element }>,
         destroy$: Subject<void>,
-        ngZone: NgZone,
         createHandler?: (newElement: Element) => void,
         deleteHandler?: (deletedElement: Element) => void,
         changeHandler?: (oldElement: Element, newElement: Element) => void
@@ -119,13 +117,10 @@ export abstract class ElementManager<
         elementDictionary$
             .pipe(startWith({}), pairwise(), takeUntil(destroy$))
             .subscribe(([oldElementDictionary, newElementDictionary]) => {
-                // run outside angular zone for better performance
-                ngZone.runOutsideAngular(() => {
-                    handleChanges(oldElementDictionary, newElementDictionary, {
-                        createHandler,
-                        deleteHandler,
-                        changeHandler,
-                    });
+                handleChanges(oldElementDictionary, newElementDictionary, {
+                    createHandler,
+                    deleteHandler,
+                    changeHandler,
                 });
             });
     }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/map-images-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/map-images-feature-manager.ts
@@ -1,4 +1,4 @@
-import type { Type, NgZone } from '@angular/core';
+import type { Type } from '@angular/core';
 import type { Store } from '@ngrx/store';
 import type { MapImage, UUID } from 'digital-fuesim-manv-shared';
 import type { Feature, MapBrowserEvent } from 'ol';
@@ -24,14 +24,12 @@ export class MapImageFeatureManager extends MoveableFeatureManager<MapImage> {
     public register(
         changePopup$: Subject<OpenPopupOptions<any, Type<any>> | undefined>,
         destroy$: Subject<void>,
-        ngZone: NgZone,
         mapInteractionsManager: OlMapInteractionsManager
     ): void {
         super.registerFeatureElementManager(
             this.store.select(selectVisibleMapImages),
             changePopup$,
             destroy$,
-            ngZone,
             mapInteractionsManager
         );
     }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/material-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/material-feature-manager.ts
@@ -1,4 +1,4 @@
-import type { Type, NgZone } from '@angular/core';
+import type { Type } from '@angular/core';
 import type { Store } from '@ngrx/store';
 import type { Material, UUID } from 'digital-fuesim-manv-shared';
 import { normalZoom } from 'digital-fuesim-manv-shared';
@@ -21,14 +21,12 @@ export class MaterialFeatureManager extends MoveableFeatureManager<Material> {
     public register(
         changePopup$: Subject<OpenPopupOptions<any, Type<any>> | undefined>,
         destroy$: Subject<void>,
-        ngZone: NgZone,
         mapInteractionsManager: OlMapInteractionsManager
     ): void {
         super.registerFeatureElementManager(
             this.store.select(selectVisibleMaterials),
             changePopup$,
             destroy$,
-            ngZone,
             mapInteractionsManager
         );
     }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/moveable-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/moveable-feature-manager.ts
@@ -1,4 +1,5 @@
-import type { MapBrowserEvent, Feature } from 'ol';
+import type { UUID } from 'digital-fuesim-manv-shared';
+import type { Feature, MapBrowserEvent } from 'ol';
 import type Point from 'ol/geom/Point';
 import type { TranslateEvent } from 'ol/interaction/Translate';
 import type VectorLayer from 'ol/layer/Vector';
@@ -6,20 +7,19 @@ import type OlMap from 'ol/Map';
 import type VectorSource from 'ol/source/Vector';
 import type { Observable } from 'rxjs';
 import { Subject } from 'rxjs';
-import type { NgZone } from '@angular/core';
 // eslint-disable-next-line @typescript-eslint/no-shadow
-import type { UUID, Element } from 'digital-fuesim-manv-shared';
+import type { Element } from 'digital-fuesim-manv-shared';
 import type { FeatureManager } from '../utility/feature-manager';
-import { MovementAnimator } from '../utility/movement-animator';
 import type {
     GeometryHelper,
     GeometryWithCoordinates,
     PositionableElement,
     Positions,
 } from '../utility/geometry-helper';
+import { MovementAnimator } from '../utility/movement-animator';
+import type { OlMapInteractionsManager } from '../utility/ol-map-interactions-manager';
 import type { OpenPopupOptions } from '../utility/popup-manager';
 import { TranslateInteraction } from '../utility/translate-interaction';
-import type { OlMapInteractionsManager } from '../utility/ol-map-interactions-manager';
 import { ElementManager } from './element-manager';
 
 /**
@@ -137,7 +137,6 @@ export abstract class MoveableFeatureManager<
     public abstract register(
         changePopup$: Subject<OpenPopupOptions<any> | undefined>,
         destroy$: Subject<void>,
-        ngZone: NgZone,
         mapInteractionsManager: OlMapInteractionsManager
     ): void;
 
@@ -145,7 +144,6 @@ export abstract class MoveableFeatureManager<
         elementDictionary$: Observable<{ [id: UUID]: ManagedElement }>,
         changePopup$: Subject<OpenPopupOptions<any> | undefined>,
         destroy$: Subject<void>,
-        ngZone: NgZone,
         mapInteractionsManager: OlMapInteractionsManager
     ) {
         this.olMap.addLayer(this.layer);
@@ -154,7 +152,6 @@ export abstract class MoveableFeatureManager<
         this.registerChangeHandlers(
             elementDictionary$,
             destroy$,
-            ngZone,
             (element) => this.onElementCreated(element),
             (element) => this.onElementDeleted(element),
             (oldElement, newElement) =>

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/moveable-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/moveable-feature-manager.ts
@@ -1,4 +1,3 @@
-import type { UUID } from 'digital-fuesim-manv-shared';
 import type { Feature, MapBrowserEvent } from 'ol';
 import type Point from 'ol/geom/Point';
 import type { TranslateEvent } from 'ol/interaction/Translate';
@@ -8,7 +7,7 @@ import type VectorSource from 'ol/source/Vector';
 import type { Observable } from 'rxjs';
 import { Subject } from 'rxjs';
 // eslint-disable-next-line @typescript-eslint/no-shadow
-import type { Element } from 'digital-fuesim-manv-shared';
+import type { Element, UUID } from 'digital-fuesim-manv-shared';
 import type { FeatureManager } from '../utility/feature-manager';
 import type {
     GeometryHelper,

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/patient-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/patient-feature-manager.ts
@@ -1,4 +1,4 @@
-import type { Type, NgZone } from '@angular/core';
+import type { Type } from '@angular/core';
 import type { Store } from '@ngrx/store';
 import type { UUID } from 'digital-fuesim-manv-shared';
 import { Patient } from 'digital-fuesim-manv-shared';
@@ -24,14 +24,12 @@ export class PatientFeatureManager extends MoveableFeatureManager<Patient> {
     public register(
         changePopup$: Subject<OpenPopupOptions<any, Type<any>> | undefined>,
         destroy$: Subject<void>,
-        ngZone: NgZone,
         mapInteractionsManager: OlMapInteractionsManager
     ): void {
         super.registerFeatureElementManager(
             this.store.select(selectVisiblePatients),
             changePopup$,
             destroy$,
-            ngZone,
             mapInteractionsManager
         );
     }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/personnel-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/personnel-feature-manager.ts
@@ -1,4 +1,4 @@
-import type { Type, NgZone } from '@angular/core';
+import type { Type } from '@angular/core';
 import type { Store } from '@ngrx/store';
 import type { Personnel, UUID } from 'digital-fuesim-manv-shared';
 import { normalZoom } from 'digital-fuesim-manv-shared';
@@ -21,14 +21,12 @@ export class PersonnelFeatureManager extends MoveableFeatureManager<Personnel> {
     public register(
         changePopup$: Subject<OpenPopupOptions<any, Type<any>> | undefined>,
         destroy$: Subject<void>,
-        ngZone: NgZone,
         mapInteractionsManager: OlMapInteractionsManager
     ): void {
         super.registerFeatureElementManager(
             this.store.select(selectVisiblePersonnel),
             changePopup$,
             destroy$,
-            ngZone,
             mapInteractionsManager
         );
     }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/simulated-region-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/simulated-region-feature-manager.ts
@@ -1,3 +1,4 @@
+import type { Type } from '@angular/core';
 import type { Store } from '@ngrx/store';
 import type {
     UUID,
@@ -8,12 +9,13 @@ import type {
 
 import { MapCoordinates, Size } from 'digital-fuesim-manv-shared';
 import type { Feature, MapBrowserEvent } from 'ol';
-import type { TranslateEvent } from 'ol/interaction/Translate';
 import type { Polygon } from 'ol/geom';
+import type { TranslateEvent } from 'ol/interaction/Translate';
 import type OlMap from 'ol/Map';
 import { Fill } from 'ol/style';
 import Stroke from 'ol/style/Stroke';
 import Style from 'ol/style/Style';
+import type { Subject } from 'rxjs';
 import type { ExerciseService } from 'src/app/core/exercise.service';
 import type { AppState } from 'src/app/state/app.state';
 import {
@@ -21,15 +23,13 @@ import {
     selectVisibleSimulatedRegions,
 } from 'src/app/state/application/selectors/shared.selectors';
 import { selectStateSnapshot } from 'src/app/state/get-state-snapshot';
-import type { Type, NgZone } from '@angular/core';
-import type { Subject } from 'rxjs';
 import { SimulatedRegionPopupComponent } from '../shared/simulated-region-popup/simulated-region-popup.component';
 import { calculatePopupPositioning } from '../utility/calculate-popup-positioning';
 import type { FeatureManager } from '../utility/feature-manager';
-import { PolygonGeometryHelper } from '../utility/polygon-geometry-helper';
-import { ResizeRectangleInteraction } from '../utility/resize-rectangle-interaction';
-import type { OpenPopupOptions } from '../utility/popup-manager';
 import type { OlMapInteractionsManager } from '../utility/ol-map-interactions-manager';
+import { PolygonGeometryHelper } from '../utility/polygon-geometry-helper';
+import type { OpenPopupOptions } from '../utility/popup-manager';
+import { ResizeRectangleInteraction } from '../utility/resize-rectangle-interaction';
 import { MoveableFeatureManager } from './moveable-feature-manager';
 
 export class SimulatedRegionFeatureManager
@@ -39,14 +39,12 @@ export class SimulatedRegionFeatureManager
     public register(
         changePopup$: Subject<OpenPopupOptions<any, Type<any>> | undefined>,
         destroy$: Subject<void>,
-        ngZone: NgZone,
         mapInteractionsManager: OlMapInteractionsManager
     ): void {
         super.registerFeatureElementManager(
             this.store.select(selectVisibleSimulatedRegions),
             changePopup$,
             destroy$,
-            ngZone,
             mapInteractionsManager
         );
         mapInteractionsManager.addTrainerInteraction(

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-lines-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-lines-feature-manager.ts
@@ -1,6 +1,7 @@
 import type { Type } from '@angular/core';
 import type { Store } from '@ngrx/store';
-import { Element } from 'digital-fuesim-manv-shared';
+// eslint-disable-next-line @typescript-eslint/no-shadow
+import type { Element } from 'digital-fuesim-manv-shared';
 import type { MapBrowserEvent } from 'ol';
 import { Feature } from 'ol';
 import LineString from 'ol/geom/LineString';

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-lines-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-lines-feature-manager.ts
@@ -1,10 +1,12 @@
-import type { Type, NgZone } from '@angular/core';
+import type { Type } from '@angular/core';
 import type { Store } from '@ngrx/store';
+import { Element } from 'digital-fuesim-manv-shared';
 import type { MapBrowserEvent } from 'ol';
 import { Feature } from 'ol';
 import LineString from 'ol/geom/LineString';
 import type { TranslateEvent } from 'ol/interaction/Translate';
 import type VectorLayer from 'ol/layer/Vector';
+import type OlMap from 'ol/Map';
 import type VectorSource from 'ol/source/Vector';
 import Stroke from 'ol/style/Stroke';
 import Style from 'ol/style/Style';
@@ -14,9 +16,6 @@ import type { AppState } from 'src/app/state/app.state';
 import { selectTransferLines } from 'src/app/state/application/selectors/exercise.selectors';
 import { selectCurrentRole } from 'src/app/state/application/selectors/shared.selectors';
 import { selectStateSnapshot } from 'src/app/state/get-state-snapshot';
-import type OlMap from 'ol/Map';
-// eslint-disable-next-line @typescript-eslint/no-shadow
-import type { Element } from 'digital-fuesim-manv-shared';
 import type { TransferLinesService } from '../../core/transfer-lines.service';
 import type { FeatureManager } from '../utility/feature-manager';
 import type { OlMapInteractionsManager } from '../utility/ol-map-interactions-manager';
@@ -49,7 +48,6 @@ export class TransferLinesFeatureManager
     register(
         changePopup$: Subject<OpenPopupOptions<any, Type<any>> | undefined>,
         destroy$: Subject<void>,
-        ngZone: NgZone,
         mapInteractionsManager: OlMapInteractionsManager
     ) {
         this.olMap.addLayer(this.layer);
@@ -59,7 +57,6 @@ export class TransferLinesFeatureManager
             this.registerChangeHandlers(
                 this.store.select(selectTransferLines),
                 destroy$,
-                ngZone,
                 (element) => this.onElementCreated(element),
                 (element) => this.onElementDeleted(element),
                 (oldElement, newElement) =>

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-point-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-point-feature-manager.ts
@@ -1,4 +1,3 @@
-import type { NgZone } from '@angular/core';
 import type { Store } from '@ngrx/store';
 // eslint-disable-next-line @typescript-eslint/no-shadow
 import type { UUID, Element } from 'digital-fuesim-manv-shared';
@@ -60,14 +59,12 @@ export class TransferPointFeatureManager extends MoveableFeatureManager<Transfer
     public register(
         changePopup$: Subject<OpenPopupOptions<any> | undefined>,
         destroy$: Subject<void>,
-        ngZone: NgZone,
         mapInteractionsManager: OlMapInteractionsManager
     ) {
         super.registerFeatureElementManager(
             this.store.select(selectVisibleTransferPoints),
             changePopup$,
             destroy$,
-            ngZone,
             mapInteractionsManager
         );
     }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/vehicle-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/vehicle-feature-manager.ts
@@ -1,4 +1,4 @@
-import type { Type, NgZone } from '@angular/core';
+import type { Type } from '@angular/core';
 import type { Store } from '@ngrx/store';
 import type {
     UUID,
@@ -28,14 +28,12 @@ export class VehicleFeatureManager extends MoveableFeatureManager<Vehicle> {
     public register(
         changePopup$: Subject<OpenPopupOptions<any, Type<any>> | undefined>,
         destroy$: Subject<void>,
-        ngZone: NgZone,
         mapInteractionsManager: OlMapInteractionsManager
     ): void {
         super.registerFeatureElementManager(
             this.store.select(selectVisibleVehicles),
             changePopup$,
             destroy$,
-            ngZone,
             mapInteractionsManager
         );
     }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/viewport-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/viewport-feature-manager.ts
@@ -1,4 +1,4 @@
-import type { Type, NgZone } from '@angular/core';
+import type { Type } from '@angular/core';
 import type { Store } from '@ngrx/store';
 import type { UUID } from 'digital-fuesim-manv-shared';
 import { MapCoordinates, Size, Viewport } from 'digital-fuesim-manv-shared';
@@ -42,14 +42,12 @@ export class ViewportFeatureManager
     public register(
         changePopup$: Subject<OpenPopupOptions<any, Type<any>> | undefined>,
         destroy$: Subject<void>,
-        ngZone: NgZone,
         mapInteractionsManager: OlMapInteractionsManager
     ): void {
         super.registerFeatureElementManager(
             this.store.select(selectVisibleViewports),
             changePopup$,
             destroy$,
-            ngZone,
             mapInteractionsManager
         );
         mapInteractionsManager.addTrainerInteraction(

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/feature-manager.ts
@@ -1,4 +1,3 @@
-import type { NgZone } from '@angular/core';
 import type { Feature, MapBrowserEvent } from 'ol';
 import type { Geometry } from 'ol/geom';
 import type { TranslateEvent } from 'ol/interaction/Translate';
@@ -51,7 +50,6 @@ export interface FeatureManager<T extends Geometry> {
     register: (
         changePopup$: Subject<OpenPopupOptions<any> | undefined>,
         destroy$: Subject<void>,
-        ngZone: NgZone,
         mapInteractionsManager: OlMapInteractionsManager
     ) => void;
 }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
@@ -1,4 +1,3 @@
-import type { NgZone } from '@angular/core';
 import type { Store } from '@ngrx/store';
 import {
     upperLeftCornerOf,
@@ -39,10 +38,6 @@ import type { PopupManager } from './popup-manager';
 import { OlMapInteractionsManager } from './ol-map-interactions-manager';
 import { SatelliteLayerManager } from './satellite-layer-manager';
 
-/**
- * This class should run outside the Angular zone for performance reasons.
- */
-
 export class OlMapManager {
     private readonly _olMap: OlMap;
     private featureManagers: FeatureManager<any>[];
@@ -67,7 +62,6 @@ export class OlMapManager {
         private readonly store: Store<AppState>,
         private readonly exerciseService: ExerciseService,
         private readonly openLayersContainer: HTMLDivElement,
-        private readonly ngZone: NgZone,
         private readonly transferLinesService: TransferLinesService,
         private readonly popupManager: PopupManager
     ) {
@@ -231,7 +225,6 @@ export class OlMapManager {
             featureManager.register(
                 this.popupManager.changePopup$,
                 this.destroy$,
-                this.ngZone,
                 this.mapInteractionsManager
             );
         });


### PR DESCRIPTION
The error that led to this PR was originally noticed by @lukasrad02.

## Original Error

When a featureManager proposes an action that is rejected, the error message toast only gets shown if the exercise is running or the user interacts with something else on the webpage.

This can be replicated by adding following code to `shared\src\store\action-reducers\simulated-region.ts`:

in `addElementToSimulatedRegion.reducer`
```ts
                throw new ReducerError('Test');
```

To trigger it, drop something in a simulatedRegion.

## The Underlying Problem

The whole OpenLayers stuff was meant to run outside the angular zone to improve performance. See [here](https://angular.io/guide/change-detection-zone-pollution) for the official documentation for this optimization.

The error was caused by calling `exerciseService.proposeAction()` in a featureManager outside the angular zone.
Therefore the change detection wasn't triggered, and the DOM was not updated.
On this note: there were also seemingly also leaks from ngZone into OpenLayers as OpenLayers should be the only thing that listened to `requestAnimationFrame`, `pointermove`, and `scroll` events. These events are also automatically patched by zone.js.

## Possible Solutions

I could think of two solutions:
1. Run OpenLayers inside the zone
2. Quick and dirty: `MessageService.postError()` should ensure that it is in the NgZone.
3. Add an explicit API between OpenLayers outside the zone and the rest of the application inside it. This could, e.g., be done by passing an `ApplicationWrapper` object to the `OlMapManager` and all subsequent `FeatureManagers`. This Wrapper could have looked something like this:
```ts
class ApplicationWrapper {
    constructor(
        private readonly exerciseService: ExerciseService,
        private readonly store: Store,
        private readonly ngZone: NgZone,
    ) {}

    public select(...args) {
        // TODO: Run outside of ngZone
        return this.store.select(...args);
    }
    public selectSnapshot();
    public proposeAction();
    public openPopover()
}
```

## Benchmark

### Test Setup

My machine:
System Information:
```
  OS:       Windows 10 Pro 10.0.22621
  CPUs:     12 × AMD Ryzen 5 5600X 6-Core Processor
  RAM:      16309MB
  Chrome: 109.0.5414.120 
```

Angular was built in production mode by changing in `frontend\angular.json` at `projects.digital-fuesim-manv.architect.serve`
from `"defaultConfiguration": "development"` to `"defaultConfiguration": "production"`.
I'd expect the results in `development` mode to be worse, as not only the code isn't optimized, but also there is an [additional change detection check](https://angular.io/errors/NG0100#ng0100-expression-has-changed-after-it-was-checked).

I ran two tests:
A) The current `dev` - so OpenLayers is mostly run outside the zone (apart from `requestAnimationFrame`, ...).
B) I removed all ngZone stuff

For each test, I 
* imported `exercise-state-2022-07-27-workshop-malteser-großes-szenario`
* Joined the exercise
* Zoomed  in
* Started the Chrome-Performance profiler
* Moved some elements on the map around
* Moved around a bit on the map by dragging it

### Results

I couldn't spot any obvious differences regarding the change detection between the two tests. 
The change detection function calls I could identify were between 0.1 and 0.01 ms and weren't called more than once every 16.6ms (60fps).

|   |    |
|  --  | --   |
|  ![image](https://user-images.githubusercontent.com/18506183/219875456-690639ef-4eee-4bf2-a9b9-81d1c8e85063.png) |   ![image](https://user-images.githubusercontent.com/18506183/219875508-d01d7a5c-02e8-4b58-8755-26e1399a0466.png) |

## Conclusion

The `runOutsideAngularZone()` for OpenLayers was a premature optimization. It doesn't provide any measurable benefit and can lead to (for developers unfamiliar with Angular) very confusing behavior. Therefore I removed it, and we now run OpenLayers inside the zone.