### PR TITLE
Show connecting lines for transfers from/to simulated regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
     -   The _Behaviors_ tab allows adding and removing behaviors from simulated regions, inspect their current state and customize their settings
         -   For the assign leader behavior, the type of the currently assigned leader is shown
 -   Simulated Regions now act as transfer points, meaning that they can be start and destination of a transfer
+    -   Connection lines will be shown for transfer connections from/to simulated regions, too
 
 ### Fixed
 

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
@@ -293,9 +293,9 @@ export class OlMapManager {
 
         this.featureManagers = [
             deleteFeatureManager,
+            transferLinesFeatureManager,
             simulatedRegionFeatureManager,
             mapImageFeatureManager,
-            transferLinesFeatureManager,
             transferPointFeatureManager,
             vehicleFeatureManager,
             cateringLinesFeatureManager,

--- a/frontend/src/app/state/application/selectors/exercise.selectors.ts
+++ b/frontend/src/app/state/application/selectors/exercise.selectors.ts
@@ -8,9 +8,9 @@ import type {
     WithPosition,
 } from 'digital-fuesim-manv-shared';
 import {
-    currentCoordinatesOf,
     isInSpecificSimulatedRegion,
     isInTransfer,
+    nestedCoordinatesOf,
 } from 'digital-fuesim-manv-shared';
 import type { TransferLine } from 'src/app/shared/types/transfer-line';
 import type { AppState } from '../../app.state';
@@ -118,16 +118,21 @@ export const selectTileMapProperties = createSelector(
 );
 
 export const selectTransferLines = createSelector(
+    selectExerciseState,
     selectTransferPoints,
-    (transferPoints) =>
+    (state, transferPoints) =>
         Object.values(transferPoints)
             .flatMap((transferPoint) =>
                 Object.entries(transferPoint.reachableTransferPoints).map(
                     ([connectedId, { duration }]) => ({
                         id: `${transferPoint.id}:${connectedId}` as const,
-                        startPosition: currentCoordinatesOf(transferPoint),
-                        endPosition: currentCoordinatesOf(
-                            transferPoints[connectedId]!
+                        startPosition: nestedCoordinatesOf(
+                            transferPoint,
+                            state
+                        ),
+                        endPosition: nestedCoordinatesOf(
+                            transferPoints[connectedId]!,
+                            state
                         ),
                         duration,
                     })

--- a/shared/src/models/utils/position/position-helpers.ts
+++ b/shared/src/models/utils/position/position-helpers.ts
@@ -1,3 +1,4 @@
+import { ExerciseState } from '../../../state';
 import type { UUID } from '../../../utils';
 import type { Transfer } from '../transfer';
 import { MapCoordinates } from './map-coordinates';
@@ -179,4 +180,36 @@ export function lowerRightCornerOf(element: WithExtent): MapCoordinates {
     }
 
     return MapCoordinates.create(corner.x, corner.y);
+}
+
+export function nestedCoordinatesOf(
+    withPosition: WithPosition,
+    state: ExerciseState
+): MapCoordinates {
+    if (isOnMap(withPosition)) {
+        return currentCoordinatesOf(withPosition);
+    }
+    if (isInVehicle(withPosition)) {
+        const vehicleId = currentVehicleIdOf(withPosition);
+        const vehicle = state.vehicles[vehicleId];
+        if (!vehicle) {
+            throw new Error(
+                `The vehicle with the id ${vehicleId} could not be found`
+            );
+        }
+        return nestedCoordinatesOf(vehicle, state);
+    }
+    if (isInSimulatedRegion(withPosition)) {
+        const simulatedRegionId = currentSimulatedRegionIdOf(withPosition);
+        const simulatedRegion = state.simulatedRegions[simulatedRegionId];
+        if (!simulatedRegion) {
+            throw new Error(
+                `The simulated region with the id ${simulatedRegionId} could not be found`
+            );
+        }
+        return currentCoordinatesOf(simulatedRegion);
+    }
+    throw new Error(
+        `Expected element to have (nested) map position, but position was of type ${withPosition.position.type}`
+    );
 }

--- a/shared/src/models/utils/position/position-helpers.ts
+++ b/shared/src/models/utils/position/position-helpers.ts
@@ -1,4 +1,4 @@
-import { ExerciseState } from '../../../state';
+import type { ExerciseState } from '../../../state';
 import type { UUID } from '../../../utils';
 import type { Transfer } from '../transfer';
 import { MapCoordinates } from './map-coordinates';

--- a/shared/src/store/action-reducers/transfer-point.ts
+++ b/shared/src/store/action-reducers/transfer-point.ts
@@ -7,7 +7,7 @@ import {
     ValidateNested,
 } from 'class-validator';
 import { TransferPoint } from '../../models';
-import type { WithPosition } from '../../models/utils';
+import { nestedCoordinatesOf, WithPosition } from '../../models/utils';
 import {
     currentCoordinatesOf,
     isInTransfer,
@@ -364,32 +364,4 @@ function estimateDuration(
             1000;
     const multipleOf = 1000 * 60 * 0.1;
     return Math.round(estimateTime / multipleOf) * multipleOf;
-}
-
-function nestedCoordinatesOf(
-    withPosition: WithPosition,
-    draftState: ExerciseState
-): MapCoordinates {
-    if (isOnMap(withPosition)) {
-        return currentCoordinatesOf(withPosition);
-    }
-    if (isInVehicle(withPosition)) {
-        const vehicle = getElement(
-            draftState,
-            'vehicle',
-            currentVehicleIdOf(withPosition)
-        );
-        return nestedCoordinatesOf(vehicle, draftState);
-    }
-    if (isInSimulatedRegion(withPosition)) {
-        const simulatedRegion = getElement(
-            draftState,
-            'simulatedRegion',
-            currentSimulatedRegionIdOf(withPosition)
-        );
-        return currentCoordinatesOf(simulatedRegion);
-    }
-    throw new ReducerError(
-        `Expected element to have (nested) map position, but position was of type ${withPosition.position.type}`
-    );
 }

--- a/shared/src/store/action-reducers/transfer-point.ts
+++ b/shared/src/store/action-reducers/transfer-point.ts
@@ -7,21 +7,14 @@ import {
     ValidateNested,
 } from 'class-validator';
 import { TransferPoint } from '../../models';
-import { nestedCoordinatesOf, WithPosition } from '../../models/utils';
 import {
-    currentCoordinatesOf,
+    currentTransferOf,
     isInTransfer,
     MapCoordinates,
     MapPosition,
-    currentTransferOf,
-    isInSimulatedRegion,
-    currentSimulatedRegionIdOf,
-    isOnMap,
-    isInVehicle,
-    currentVehicleIdOf,
+    nestedCoordinatesOf,
 } from '../../models/utils';
 import { changePositionWithId } from '../../models/utils/position/position-helpers-mutable';
-import type { ExerciseState } from '../../state';
 import { cloneDeepMutable, UUID, uuidValidationOptions } from '../../utils';
 import { IsValue } from '../../utils/validators';
 import type { Action, ActionReducer } from '../action-reducer';


### PR DESCRIPTION
This PR adds transfer lines for connections between a simulated region and a transfer point and fixes that lines are not shown at all if any simulated region was start/destination of a transfer.

Transfer lines are currently attached to the upper left corner of a simulated region (if its not flipped), this will be changed by #675.