### PR TITLE
Populate the further information on the vehicle unload behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
     -   The _Transfers_ tab allows setting up transfer connections from/to other simulated regions and/or transfer points
     -   The _Behaviors_ tab allows adding and removing behaviors from simulated regions, inspect their current state and customize their settings
         -   For the assign leader behavior, the type of the currently assigned leader is shown
+        -   For the unload arrived vehicles behavior, the unload duration can be set and all currently unloading vehicles are listed with their remaining time
 -   Simulated Regions now act as transfer points, meaning that they can be start and destination of a transfer
     -   Connection lines will be shown for transfer connections from/to simulated regions, too
 

--- a/frontend/src/app/pages/exercises/exercise/shared/simulated-region-overview/tabs/behavior-tab/behaviors/unload-arriving-vehicles/simulated-region-overview-behavior-unload-arriving-vehicles.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulated-region-overview/tabs/behavior-tab/behaviors/unload-arriving-vehicles/simulated-region-overview-behavior-unload-arriving-vehicles.component.html
@@ -1,1 +1,51 @@
-<p>simulated-region-overview-behavior-unload-arriving-vehicles works!</p>
+<div class="h-100 mh-100 overflow-auto">
+    <h6>Aus eintreffenden Fahrzeugen aussteigen</h6>
+    <div
+        title="Zeit bis zur Ankunft"
+        class="input-group input-group-sm mb-3 ms-3"
+        style="width: 100px"
+    >
+        <label class="form-label">Aussteigedauer</label>
+        <input
+            #timeInput="ngModel"
+            [ngModel]="((unloadDuration$ | async) ?? 0) / 60 / 1000"
+            (appSaveOnTyping)="updateUnloadTime($event * 1000 * 60)"
+            min="0"
+            required
+            step="0.1"
+            type="number"
+            class="form-control form-control-sm d-inline-block no-validation"
+            placeholder="Dauer"
+            data-cy="unloadVehicleBehaviorPopupDurationInput"
+        />
+        <span class="input-group-text">Min</span>
+    </div>
+
+    <h6>Gerade aussteigend</h6>
+    <table
+        class="table table-striped"
+        *ngIf="(vehiclesStatus$ | async)?.length ?? 0; else noUnloadVehicles"
+    >
+        <thead>
+            <tr>
+                <th scope="col" class="text-center">Name</th>
+                <th scope="col" class="text-center">Verbleibende Zeit</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr *ngFor="let vehicleStatus of vehiclesStatus$ | async">
+                <td class="align-middle text-center">
+                    {{ vehicleStatus.vehicleName }}
+                </td>
+                <td class="align-middle text-center">
+                    {{ vehicleStatus.timeLeft | formatDuration }}
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <ng-template #noUnloadVehicles>
+        <span class="text-muted">
+            Im Moment steigt niemand aus eintreffenden Fahrzeugen aus
+        </span>
+    </ng-template>
+</div>

--- a/frontend/src/app/pages/exercises/exercise/shared/simulated-region-overview/tabs/behavior-tab/behaviors/unload-arriving-vehicles/simulated-region-overview-behavior-unload-arriving-vehicles.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulated-region-overview/tabs/behavior-tab/behaviors/unload-arriving-vehicles/simulated-region-overview-behavior-unload-arriving-vehicles.component.ts
@@ -1,4 +1,19 @@
-import { Component } from '@angular/core';
+import type { OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { createSelector, Store } from '@ngrx/store';
+import type {
+    UnloadArrivingVehiclesBehaviorState,
+    UnloadVehicleActivityState,
+} from 'digital-fuesim-manv-shared';
+import { UUID } from 'digital-fuesim-manv-shared';
+import type { Observable } from 'rxjs';
+import { ExerciseService } from 'src/app/core/exercise.service';
+import type { AppState } from 'src/app/state/app.state';
+import {
+    createSelectSimulatedRegion,
+    selectExerciseState,
+    selectVehicles,
+} from 'src/app/state/application/selectors/exercise.selectors';
 
 @Component({
     selector: 'app-simulated-region-overview-behavior-unload-arriving-vehicles',
@@ -8,4 +23,93 @@ import { Component } from '@angular/core';
         './simulated-region-overview-behavior-unload-arriving-vehicles.component.scss',
     ],
 })
-export class SimulatedRegionOverviewBehaviorUnloadArrivingVehiclesComponent {}
+export class SimulatedRegionOverviewBehaviorUnloadArrivingVehiclesComponent
+    implements OnInit
+{
+    @Input()
+    simulatedRegionId!: UUID;
+
+    @Input()
+    behaviorId!: UUID;
+
+    unloadDuration$?: Observable<number>;
+    vehiclesStatus$?: Observable<VehicleUnloadStatus[]>;
+
+    constructor(
+        private readonly exerciseService: ExerciseService,
+        public readonly store: Store<AppState>
+    ) {}
+
+    ngOnInit(): void {
+        const simulatedRegionSelector = createSelectSimulatedRegion(
+            this.simulatedRegionId
+        );
+        const behaviorStateSelector = createSelector(
+            simulatedRegionSelector,
+            (simulatedRegion) =>
+                simulatedRegion?.behaviors.find(
+                    (behavior) => behavior.id === this.behaviorId
+                ) as UnloadArrivingVehiclesBehaviorState | undefined
+        );
+        this.unloadDuration$ = this.store.select(
+            createSelector(
+                behaviorStateSelector,
+                (behavior) => behavior?.unloadDelay ?? 0
+            )
+        );
+
+        const activityStateSelector = createSelector(
+            simulatedRegionSelector,
+            (simulatedRegion) =>
+                Object.values(simulatedRegion.activities).filter(
+                    (activity): activity is UnloadVehicleActivityState =>
+                        activity.type === 'unloadVehicleActivity'
+                )
+        );
+
+        const unloadingSelector = createSelector(
+            activityStateSelector,
+            selectVehicles,
+            (activities, vehicles) =>
+                activities.map((activity) => ({
+                    vehicle: vehicles[activity.vehicleId]!,
+                    endTime: activity.startTime + activity.duration,
+                }))
+        );
+
+        const currentTimeSelector = createSelector(
+            selectExerciseState,
+            (state) => state.currentTime
+        );
+
+        this.vehiclesStatus$ = this.store.select(
+            createSelector(
+                currentTimeSelector,
+                unloadingSelector,
+                (now, unloads) =>
+                    unloads.map(
+                        (unload): VehicleUnloadStatus => ({
+                            timeLeft: unload.endTime - now,
+                            vehicleName: unload.vehicle.name,
+                            vehicleId: unload.vehicle.id,
+                        })
+                    )
+            )
+        );
+    }
+
+    updateUnloadTime(duration: number) {
+        this.exerciseService.proposeAction({
+            type: '[UnloadArrivingVehiclesBehavior] Update UnloadDelay',
+            simulatedRegionId: this.simulatedRegionId,
+            behaviorId: this.behaviorId,
+            unloadDelay: duration,
+        });
+    }
+}
+
+interface VehicleUnloadStatus {
+    timeLeft: number;
+    vehicleName: string;
+    vehicleId: UUID;
+}

--- a/frontend/src/app/pages/exercises/exercise/shared/simulated-region-overview/tabs/behavior-tab/simulated-region-overview-behavior-tab.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulated-region-overview/tabs/behavior-tab/simulated-region-overview-behavior-tab.component.html
@@ -34,6 +34,8 @@
                 ></app-simulated-region-overview-behavior-treat-patients
                 ><app-simulated-region-overview-behavior-unload-arriving-vehicles
                     *ngSwitchCase="'unloadArrivingVehiclesBehavior'"
+                    [simulatedRegionId]="simulatedRegion.id"
+                    [behaviorId]="selectedBehavior!.id"
                 ></app-simulated-region-overview-behavior-unload-arriving-vehicles>
                 <p *ngSwitchDefault class="text-muted font-bold">
                     Es ist noch keine Verhaltensweise ausgewählt.

--- a/shared/src/simulation/behaviors/unload-arrived-vehicles.ts
+++ b/shared/src/simulation/behaviors/unload-arrived-vehicles.ts
@@ -26,7 +26,7 @@ export class UnloadArrivingVehiclesBehaviorState
     /**
      * @deprecated Use {@link create} instead
      */
-    constructor(unloadDelay: number = 0) {
+    constructor(unloadDelay: number = 2 * 60 * 1000) {
         this.unloadDelay = unloadDelay;
     }
 

--- a/shared/src/store/action-reducers/action-reducers.ts
+++ b/shared/src/store/action-reducers/action-reducers.ts
@@ -14,6 +14,7 @@ import { VehicleActionReducers } from './vehicle';
 import { ViewportActionReducers } from './viewport';
 import { EmergencyOperationCenterActionReducers } from './emergency-operation-center';
 import { SimulatedRegionActionReducers } from './simulated-region';
+import { SimulationActionReducers } from './simulation';
 
 /**
  * All action reducers of the exercise must be registered here
@@ -35,6 +36,7 @@ const actionReducers = {
     ...HospitalActionReducers,
     ...EmergencyOperationCenterActionReducers,
     ...SimulatedRegionActionReducers,
+    ...SimulationActionReducers,
 };
 
 type ExerciseActionReducer =

--- a/shared/src/store/action-reducers/simulation.ts
+++ b/shared/src/store/action-reducers/simulation.ts
@@ -1,0 +1,88 @@
+import { IsNumber, IsUUID, Min } from 'class-validator';
+import type { TreatPatientsBehaviorState } from '../../simulation';
+import type { Mutable } from '../../utils';
+import { UUID, uuidValidationOptions } from '../../utils';
+import { IsValue } from '../../utils/validators';
+import type { Action, ActionReducer } from '../action-reducer';
+import { getElement } from './utils';
+
+export class UpdateTreatPatientsIntervalsAction implements Action {
+    @IsValue('[Simulation] Update TreatPatientsIntervals' as const)
+    public readonly type = '[Simulation] Update TreatPatientsIntervals';
+
+    @IsUUID(4, uuidValidationOptions)
+    public readonly simulatedRegionId!: UUID;
+
+    @IsUUID(4, uuidValidationOptions)
+    public readonly behaviorStateId!: UUID;
+
+    @IsNumber()
+    @Min(-1)
+    public readonly unknown!: number;
+
+    @IsNumber()
+    @Min(-1)
+    public readonly counted!: number;
+
+    @IsNumber()
+    @Min(-1)
+    public readonly triaged!: number;
+
+    @IsNumber()
+    @Min(-1)
+    public readonly secured!: number;
+
+    @IsNumber()
+    @Min(-1)
+    public readonly countingTimePerPatient!: number;
+}
+
+export namespace SimulationActionReducers {
+    export const updateTreatPatientsIntervals: ActionReducer<UpdateTreatPatientsIntervalsAction> =
+        {
+            action: UpdateTreatPatientsIntervalsAction,
+            /*
+             *   unknown, counted, triaged, secured, countingTimePerPatient stay the same when -1
+             */
+            reducer: (
+                draftState,
+                {
+                    simulatedRegionId,
+                    behaviorStateId,
+                    unknown,
+                    counted,
+                    triaged,
+                    secured,
+                    countingTimePerPatient,
+                }
+            ) => {
+                const simulatedRegion = getElement(
+                    draftState,
+                    'simulatedRegion',
+                    simulatedRegionId
+                );
+                const behaviorStates = simulatedRegion.behaviors;
+                const treatPatientsBehaviorState = behaviorStates.find(
+                    (behaviorState) => behaviorState.id === behaviorStateId
+                ) as Mutable<TreatPatientsBehaviorState>;
+                if (unknown >= 0) {
+                    treatPatientsBehaviorState.intervals.unknown = unknown;
+                }
+                if (counted >= 0) {
+                    treatPatientsBehaviorState.intervals.counted = counted;
+                }
+                if (triaged >= 0) {
+                    treatPatientsBehaviorState.intervals.triaged = triaged;
+                }
+                if (secured >= 0) {
+                    treatPatientsBehaviorState.intervals.secured = secured;
+                }
+                if (countingTimePerPatient >= 0) {
+                    treatPatientsBehaviorState.intervals.countingTimePerPatient =
+                        countingTimePerPatient;
+                }
+                return draftState;
+            },
+            rights: 'trainer',
+        };
+}


### PR DESCRIPTION
### Acceptance Criteria:

- [x] The unload duration for new vehicles can be configured
- [x] Think about how to best display the vehicles
- [x] Display the vehicles when the more information button for the behaviour is pressed (not for all behaviours)
- [x] Update the display if the currently unloading vehicles change for any reason
