### PR TITLE
Enforce running tests-done job even if needs fail

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -233,6 +233,7 @@ jobs:
 
     # Dummy step to gate until all test are complete
     tests-done:
+        if: always()
         needs:
             - test
             - cypress
@@ -240,7 +241,9 @@ jobs:
             - dependencies
         runs-on: ubuntu-latest
         steps:
-            - run: 'true'
+            - uses: matrix-org/done-action@v2
+              with:
+                  needs: ${{ toJSON (needs) }}
 
     deploy-dev:
         timeout-minutes: 10

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -238,7 +238,6 @@ jobs:
             - test
             - cypress
             - lint
-            - dependencies
         runs-on: ubuntu-latest
         steps:
             - uses: matrix-org/done-action@v2

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -28,3 +28,5 @@ export * from './state-helpers';
 export * from './data';
 export * from './store/action-reducers/utils';
 export * from './state-migrations';
+
+Some code that is invalid on purpose!

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -27,6 +27,4 @@ export * from './http-interfaces';
 export * from './state-helpers';
 export * from './data';
 export * from './store/action-reducers/utils';
-export * from './state-migrations';
-
-Some code that is invalid on purpose!
+export         * from './state-migrations';

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -27,4 +27,4 @@ export * from './http-interfaces';
 export * from './state-helpers';
 export * from './data';
 export * from './store/action-reducers/utils';
-export         * from './state-migrations';
+export * from './state-migrations';


### PR DESCRIPTION
Since jobs with dependencies are skipped when dependencies fail and skipped jobs count as successful, our `tests-done` guard can be circumvented.

Using `matrix-org/done-action` for our guard fixes this problem.