### PR TITLE
Add `onRemove` handler to behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
     -   There is a radiogram for displaying the vehicle count in a simulated region
     -   There is a radiogram for displaying the current treatment status in a simulated region
 -   In the large simulation overview modal, a column has been added to interact with radiograms.
--   Behaviors can screw up the state when they are removed from a simulated region.
+-   Behaviors can clean up the state when they are removed from a simulated region.
 
 ## [0.2.1] - 2023-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
     -   There is a radiogram for displaying the vehicle count in a simulated region
     -   There is a radiogram for displaying the current treatment status in a simulated region
 -   In the large simulation overview modal, a column has been added to interact with radiograms.
+-   Behaviors can screw up the state when they are removed from a simulated region.
 
 ## [0.2.1] - 2023-03-11
 

--- a/shared/src/simulation/behaviors/simulation-behavior.ts
+++ b/shared/src/simulation/behaviors/simulation-behavior.ts
@@ -16,4 +16,9 @@ export interface SimulationBehavior<S extends SimulationBehaviorState> {
         behaviorState: Mutable<S>,
         event: Mutable<ExerciseSimulationEvent>
     ) => void;
+    readonly onRemove?: (
+        draftState: Mutable<ExerciseState>,
+        simulatedRegion: Mutable<SimulatedRegion>,
+        behaviorState: Mutable<S>
+    ) => void;
 }

--- a/shared/src/store/action-reducers/simulated-region.ts
+++ b/shared/src/store/action-reducers/simulated-region.ts
@@ -19,6 +19,7 @@ import {
     PersonnelAvailableEvent,
     NewPatientEvent,
     MaterialAvailableEvent,
+    simulationBehaviorDictionary,
 } from '../../simulation';
 import { sendSimulationEvent } from '../../simulation/events/utils';
 import { cloneDeepMutable, UUID, uuidValidationOptions } from '../../utils';
@@ -337,6 +338,16 @@ export namespace SimulatedRegionActionReducers {
                         `The simulated region with id ${simulatedRegionId} has no behavior with id ${behaviorId}. Therefore it could not be removed.`
                     );
                 }
+
+                const behaviorState = simulatedRegion.behaviors[index]!;
+                if (simulationBehaviorDictionary[behaviorState.type].onRemove) {
+                    simulationBehaviorDictionary[behaviorState.type].onRemove!(
+                        draftState,
+                        simulatedRegion,
+                        behaviorState as any
+                    );
+                }
+
                 simulatedRegion.behaviors.splice(index, 1);
                 return draftState;
             },


### PR DESCRIPTION
With this new handler, behaviors can be informed when they're about to be removed from the state.

This allows cleaning up the state, e.g. removing activities spawned by the behavior that are still running.