### PR TITLE
Fix #795:   transfer points move upwards when a vehicle arrives

### DIFF
--- a/shared/src/store/action-reducers/transfer.ts
+++ b/shared/src/store/action-reducers/transfer.ts
@@ -53,7 +53,7 @@ export function letElementArrive(
         'transferPoint',
         currentTransferOf(element).targetTransferPointId
     );
-    const newPosition = targetTransferPoint.position;
+    const newPosition = cloneDeepMutable(targetTransferPoint.position);
     if (isPositionOnMap(newPosition)) {
         offsetMapPositionBy(newPosition as Mutable<MapPosition>, {
             x: 0,


### PR DESCRIPTION
We just had to clone the transfer point position before calculating the new vehicle position.