### PR TITLE
Change priority icon and display tooltips in patient status display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+### Added
+
+-   The patient status display that visualizes the progression of a patient explains its icons via a tooltip
+
+### Changed
+
+-   The icon for `C` (transport priority) in a patient status code has been changed to a road sign to be distinguishable from the icon for `D` (complication)
+
 ## [0.3.0] - 2023-03-27
 
 ### Added

--- a/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.html
@@ -138,7 +138,9 @@
                                 ngbDropdownToggle
                             >
                                 <app-patient-status-badge
-                                    [status]="colorCodeMap[currentCategory]"
+                                    [status]="
+                                        currentCategory | patientStatusColor
+                                    "
                                 >
                                 </app-patient-status-badge>
                             </button>
@@ -154,7 +156,7 @@
                                     class="btn-outline-secondary"
                                 >
                                     <app-patient-status-badge
-                                        [status]="colorCodeMap[category]"
+                                        [status]="category | patientStatusColor"
                                         class="float-end"
                                     >
                                     </app-patient-status-badge>

--- a/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.ts
@@ -1,9 +1,12 @@
 import { Component } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { Store } from '@ngrx/store';
-import type { UUID, VehicleTemplate } from 'digital-fuesim-manv-shared';
+import type {
+    ColorCode,
+    UUID,
+    VehicleTemplate,
+} from 'digital-fuesim-manv-shared';
 import {
-    colorCodeMap,
     TransferPoint,
     Viewport,
     SimulatedRegion,
@@ -28,8 +31,7 @@ import { openEditImageTemplateModal } from '../editor-panel/edit-image-template-
  * A wrapper around the map that provides trainers with more options and tools.
  */
 export class TrainerMapEditorComponent {
-    public currentCategory: keyof typeof colorCodeMap = 'X';
-    public readonly colorCodeMap = colorCodeMap;
+    public currentCategory: ColorCode = 'X';
     public readonly categories = ['X', 'Y', 'Z'] as const;
 
     public readonly vehicleTemplates$ = this.store.select(
@@ -75,7 +77,7 @@ export class TrainerMapEditorComponent {
         openEditImageTemplateModal(this.ngbModalService, mapImageTemplateId);
     }
 
-    public setCurrentCategory(category: keyof typeof colorCodeMap) {
+    public setCurrentCategory(category: ColorCode) {
         this.currentCategory = category;
     }
     public async vehicleOnMouseDown(

--- a/frontend/src/app/shared/components/patient-status-displayl/patient-status-data-field/patient-status-data-field.component.html
+++ b/frontend/src/app/shared/components/patient-status-displayl/patient-status-data-field/patient-status-data-field.component.html
@@ -1,10 +1,13 @@
 <span>
     <i
-        [ngClass]="behaviourCodeMap[patientStatusDataField.behaviourCode]"
+        [ngClass]="patientStatusDataField.behaviourCode | patientBehaviorIcon"
         [ngStyle]="{
             color: rgbColorPalette[
-                colorCodeMap[patientStatusDataField.colorCode]
+                patientStatusDataField.colorCode | patientStatusColor
             ]
         }"
+        [ngbTooltip]="
+            patientStatusDataField.behaviourCode | patientBehaviorDescription
+        "
     ></i>
 </span>

--- a/frontend/src/app/shared/components/patient-status-displayl/patient-status-data-field/patient-status-data-field.component.ts
+++ b/frontend/src/app/shared/components/patient-status-displayl/patient-status-data-field/patient-status-data-field.component.ts
@@ -1,9 +1,5 @@
 import { Component, Input } from '@angular/core';
-import {
-    PatientStatusDataField,
-    colorCodeMap,
-    behaviourCodeMap,
-} from 'digital-fuesim-manv-shared';
+import { PatientStatusDataField } from 'digital-fuesim-manv-shared';
 import { rgbColorPalette } from 'src/app/shared/functions/colors';
 
 @Component({
@@ -13,14 +9,6 @@ import { rgbColorPalette } from 'src/app/shared/functions/colors';
 })
 export class PatientStatusDataFieldComponent {
     @Input() patientStatusDataField!: PatientStatusDataField;
-
-    public get colorCodeMap() {
-        return colorCodeMap;
-    }
-
-    public get behaviourCodeMap() {
-        return behaviourCodeMap;
-    }
 
     public get rgbColorPalette() {
         return rgbColorPalette;

--- a/frontend/src/app/shared/pipes/patient-behavior-description.pipe.ts
+++ b/frontend/src/app/shared/pipes/patient-behavior-description.pipe.ts
@@ -1,0 +1,20 @@
+import type { PipeTransform } from '@angular/core';
+import { Pipe } from '@angular/core';
+import type { BehaviourCode } from 'digital-fuesim-manv-shared';
+
+const behaviorDescriptionMap: { [Key in BehaviourCode]: string } = {
+    A: 'Stabil',
+    B: 'Lebensrettende Maßnahme erforderlich',
+    C: 'Transportpriorität',
+    D: 'Komplikation',
+    E: 'Verstorben',
+};
+
+@Pipe({
+    name: 'patientBehaviorDescription',
+})
+export class PatientBehaviorDescriptionPipe implements PipeTransform {
+    transform(value: BehaviourCode): string {
+        return behaviorDescriptionMap[value];
+    }
+}

--- a/frontend/src/app/shared/pipes/patient-behavior-icon.pipe.ts
+++ b/frontend/src/app/shared/pipes/patient-behavior-icon.pipe.ts
@@ -1,0 +1,20 @@
+import type { PipeTransform } from '@angular/core';
+import { Pipe } from '@angular/core';
+import type { BehaviourCode } from 'digital-fuesim-manv-shared';
+
+const behaviorIconMap: { [Key in BehaviourCode]: string } = {
+    A: 'bi-arrow-right-square-fill',
+    B: 'bi-heartbreak-fill',
+    C: 'bi-signpost-fill',
+    D: 'bi-exclamation-triangle-fill',
+    E: 'bi-x-circle-fill',
+};
+
+@Pipe({
+    name: 'patientBehaviorIcon',
+})
+export class PatientBehaviorIconPipe implements PipeTransform {
+    transform(value: BehaviourCode): string {
+        return behaviorIconMap[value];
+    }
+}

--- a/frontend/src/app/shared/pipes/patient-status-color.pipe.ts
+++ b/frontend/src/app/shared/pipes/patient-status-color.pipe.ts
@@ -1,0 +1,20 @@
+import type { PipeTransform } from '@angular/core';
+import { Pipe } from '@angular/core';
+import type { ColorCode } from 'digital-fuesim-manv-shared';
+
+const colorCodeMap = {
+    V: 'black',
+    W: 'blue',
+    X: 'green',
+    Y: 'yellow',
+    Z: 'red',
+} as const satisfies { readonly [Key in ColorCode]: string };
+
+@Pipe({
+    name: 'patientStatusColor',
+})
+export class PatientStatusColorPipe implements PipeTransform {
+    transform(value: ColorCode): (typeof colorCodeMap)[ColorCode] {
+        return colorCodeMap[value];
+    }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -1,7 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { NgbDropdownModule, NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
+import {
+    NgbDropdownModule,
+    NgbNavModule,
+    NgbTooltip,
+} from '@ng-bootstrap/ng-bootstrap';
 import { FormsModule } from '@angular/forms';
 import { HospitalNameComponent } from './components/hospital-name/hospital-name.component';
 import { PatientStatusDataFieldComponent } from './components/patient-status-displayl/patient-status-data-field/patient-status-data-field.component';
@@ -30,6 +34,9 @@ import { CaterCapacityCountPipe } from './pipes/cater-capacity-count.pipe';
 import { FooterComponent } from './components/footer/footer.component';
 import { PatientHealthPointDisplayComponent } from './components/patient-health-point-display/patient-health-point-display.component';
 import { PatientsDetailsComponent } from './components/patients-details/patients-details.component';
+import { PatientStatusColorPipe } from './pipes/patient-status-color.pipe';
+import { PatientBehaviorIconPipe } from './pipes/patient-behavior-icon.pipe';
+import { PatientBehaviorDescriptionPipe } from './pipes/patient-behavior-description.pipe';
 
 @NgModule({
     declarations: [
@@ -60,6 +67,9 @@ import { PatientsDetailsComponent } from './components/patients-details/patients
         FooterComponent,
         PatientHealthPointDisplayComponent,
         PatientsDetailsComponent,
+        PatientStatusColorPipe,
+        PatientBehaviorIconPipe,
+        PatientBehaviorDescriptionPipe,
     ],
     imports: [
         CommonModule,
@@ -67,6 +77,7 @@ import { PatientsDetailsComponent } from './components/patients-details/patients
         RouterModule,
         NgbDropdownModule,
         NgbNavModule,
+        NgbTooltip,
     ],
     exports: [
         AutofocusDirective,
@@ -95,6 +106,7 @@ import { PatientsDetailsComponent } from './components/patients-details/patients
         FooterComponent,
         PatientHealthPointDisplayComponent,
         PatientsDetailsComponent,
+        PatientStatusColorPipe,
     ],
 })
 export class SharedModule {}

--- a/shared/src/models/utils/patient-status-code.ts
+++ b/shared/src/models/utils/patient-status-code.ts
@@ -4,7 +4,15 @@ import type { AllowedValues } from '../../utils/validators';
 import { IsLiteralUnion } from '../../utils/validators';
 import { getCreate } from './get-create';
 
-type ColorCode = 'V' | 'W' | 'X' | 'Y' | 'Z';
+/**
+ * A letter that defines the color of a patient in a patient status.
+ * * `V`: ex (black)
+ * * `W`: SK IV (blue)
+ * * `X`: SK III (green)
+ * * `Y`: SK II (yellow)
+ * * `Z`: SK I (red)
+ */
+export type ColorCode = 'V' | 'W' | 'X' | 'Y' | 'Z';
 const colorCodeAllowedValues: AllowedValues<ColorCode> = {
     V: true,
     W: true,
@@ -12,29 +20,22 @@ const colorCodeAllowedValues: AllowedValues<ColorCode> = {
     Y: true,
     Z: true,
 };
-type BehaviourCode = 'A' | 'B' | 'C' | 'D' | 'E';
+
+/**
+ * A letter that defines how a patients changes
+ * * `A`: stable
+ * * `B`: treatment required
+ * * `C`: transport priority
+ * * `D`: complication
+ * * `E`: dead
+ */
+export type BehaviourCode = 'A' | 'B' | 'C' | 'D' | 'E';
 const behaviourCodeAllowedValues: AllowedValues<BehaviourCode> = {
     A: true,
     B: true,
     C: true,
     D: true,
     E: true,
-};
-
-export const colorCodeMap = {
-    V: 'black',
-    W: 'blue',
-    X: 'green',
-    Y: 'yellow',
-    Z: 'red',
-} as const satisfies { readonly [Key in ColorCode]: string };
-
-export const behaviourCodeMap: { [Key in BehaviourCode]: string } = {
-    A: 'bi-arrow-right-square-fill',
-    B: 'bi-heartbreak-fill',
-    C: 'bi-exclamation-circle-fill',
-    D: 'bi-exclamation-triangle-fill',
-    E: 'bi-x-circle-fill',
 };
 
 export class PatientStatusDataField {


### PR DESCRIPTION
This PR adds a tooltip to the icons of the patient status display that explains the meaning of each icon according to the mapping named in #818.

Additionally, the icon for category `C` (transport priority) has been changed to avoid confusion between the icons for `C` and `D`.

The screenshot below shown an example of the new icon and tooltip. Although the screenshot only shows the trainer map editor, the icons and tooltips are also used in all other places where the patient status display is used (e.g. the patient popup or the patients tab of a simulated region).

![Screenshot from 2023-03-28 14-26-52](https://user-images.githubusercontent.com/49586507/228236294-f41cacc0-044e-4fd1-9dbe-7a23187fe1bc.png)
