### PR TITLE
Allow triage of black patients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 -   The icon for `C` (transport priority) in a patient status code has been changed to a road sign to be distinguishable from the icon for `D` (complication)
 
+### Fixed
+
+-   Dead/Black patients can now be treated (for the automatic triage to work), but they won't be treated after triage.
+
 ## [0.3.0] - 2023-03-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 ### Changed
 
--   The icon for `C` (transport priority) in a patient status code has been changed to a road sign to be distinguishable from the icon for `D` (complication)
+-   The icon for `C` (transport priority) in a patient status code has been changed to a road sign to be distinguishable from the icon for `D` (complication).
+-   `ConditionParameters.minimumHealth` and `ConditionParameters.maximumHealth` are now inclusive.
 
 ### Fixed
 

--- a/backend/src/exercise/patient-ticking.ts
+++ b/backend/src/exercise/patient-ticking.ts
@@ -25,35 +25,32 @@ export function patientTick(
     state: ExerciseState,
     patientTickInterval: number
 ): PatientUpdate[] {
-    return (
-        Object.values(state.patients)
-            // Only look at patients that are alive and have a position, i.e. are not in a vehicle
-            .filter((patient) => Patient.canBeTreated(patient))
-            .map((patient) => {
-                // update the time a patient is being treated, to check for pretriage later
-                const treatmentTime = Patient.isTreatedByPersonnel(patient)
-                    ? patient.treatmentTime + patientTickInterval
-                    : patient.treatmentTime;
-                const nextHealthPoints = getNextPatientHealthPoints(
-                    patient,
-                    getDedicatedResources(state, patient),
-                    patientTickInterval
-                );
-                const nextStateId = getNextStateId(patient);
-                const nextStateTime =
-                    nextStateId === patient.currentHealthStateId
-                        ? patient.stateTime +
-                          patientTickInterval * patient.timeSpeed
-                        : 0;
-                return {
-                    id: patient.id,
-                    nextHealthPoints,
-                    nextStateId,
-                    nextStateTime,
-                    treatmentTime,
-                };
-            })
-    );
+    return Object.values(state.patients)
+        .filter((patient) => Patient.canBeTreated(patient))
+        .map((patient) => {
+            // update the time a patient is being treated, to check for pretriage later
+            const treatmentTime = Patient.isTreatedByPersonnel(patient)
+                ? patient.treatmentTime + patientTickInterval
+                : patient.treatmentTime;
+            const nextHealthPoints = getNextPatientHealthPoints(
+                patient,
+                getDedicatedResources(state, patient),
+                patientTickInterval
+            );
+            const nextStateId = getNextStateId(patient);
+            const nextStateTime =
+                nextStateId === patient.currentHealthStateId
+                    ? patient.stateTime +
+                      patientTickInterval * patient.timeSpeed
+                    : 0;
+            return {
+                id: patient.id,
+                nextHealthPoints,
+                nextStateId,
+                nextStateTime,
+                treatmentTime,
+            };
+        });
 }
 
 /**
@@ -155,9 +152,9 @@ function getNextStateId(patient: Patient) {
             (nextConditions.latestTime === undefined ||
                 patient.stateTime < nextConditions.latestTime) &&
             (nextConditions.minimumHealth === undefined ||
-                patient.health > nextConditions.minimumHealth) &&
+                patient.health >= nextConditions.minimumHealth) &&
             (nextConditions.maximumHealth === undefined ||
-                patient.health < nextConditions.maximumHealth) &&
+                patient.health <= nextConditions.maximumHealth) &&
             (nextConditions.isBeingTreated === undefined ||
                 Patient.isTreatedByPersonnel(patient) ===
                     nextConditions.isBeingTreated)

--- a/shared/src/models/patient.ts
+++ b/shared/src/models/patient.ts
@@ -28,7 +28,6 @@ import {
     healthPointsDefaults,
     HealthPoints,
     getCreate,
-    isAlive,
     isOnMap,
     isInSimulatedRegion,
 } from './utils';
@@ -199,9 +198,6 @@ export class Patient {
     }
 
     static canBeTreated(patient: Patient) {
-        return (
-            isAlive(patient.health) &&
-            (isOnMap(patient) || isInSimulatedRegion(patient))
-        );
+        return isOnMap(patient) || isInSimulatedRegion(patient);
     }
 }

--- a/shared/src/store/action-reducers/exercise.ts
+++ b/shared/src/store/action-reducers/exercise.ts
@@ -92,10 +92,7 @@ export namespace ExerciseActionReducers {
 
     export const exerciseTick: ActionReducer<ExerciseTickAction> = {
         action: ExerciseTickAction,
-        reducer: (
-            draftState,
-            { patientUpdates, refreshTreatments, tickInterval }
-        ) => {
+        reducer: (draftState, { patientUpdates, tickInterval }) => {
             // Refresh the current time
             draftState.currentTime += tickInterval;
 
@@ -124,7 +121,6 @@ export namespace ExerciseActionReducers {
                 currentPatient.visibleStatusChanged =
                     visibleStatusBefore !== visibleStatusAfter;
                 if (
-                    refreshTreatments &&
                     // We only want to do this expensive calculation, when it is really necessary
                     currentPatient.visibleStatusChanged
                 ) {


### PR DESCRIPTION
### PR Checklist

Please make sure to fulfill the following conditions before marking this PR ready for review:

-   [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
-   ~~[ ] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/digital-fuesim-manv-public-test-scenarios) have been added~~ Not applicable

### For Review

To be able to add dead patients to a scenario, temporarily apply the following patch:

```diff
diff --git a/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.ts b/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.ts
index 6e7d9a29..cd16ec93 100644
--- a/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.ts
@@ -32,7 +32,7 @@ import { openEditImageTemplateModal } from '../editor-panel/edit-image-template-
  */
 export class TrainerMapEditorComponent {
     public currentCategory: ColorCode = 'X';
-    public readonly categories = ['X', 'Y', 'Z'] as const;
+    public readonly categories = ['X', 'Y', 'Z', 'V'] as const;
 
     public readonly vehicleTemplates$ = this.store.select(
         selectVehicleTemplates
diff --git a/shared/src/data/default-state/patient-templates.ts b/shared/src/data/default-state/patient-templates.ts
index 13fe9f03..f7725316 100644
--- a/shared/src/data/default-state/patient-templates.ts
+++ b/shared/src/data/default-state/patient-templates.ts
@@ -810,6 +810,39 @@ const prioRedUntilPhase2State = PatientHealthState.create(
 );
 
 export const defaultPatientCategories: readonly PatientCategory[] = [
+    // Dead Patients
+    PatientCategory.create('VEVEVE', defaultPatientImage, [
+        PatientTemplate.create(
+            {
+                sex: 'female',
+                externalFeatures: 'blaue Augen, rothaarig, 1,69 m',
+                age: 16,
+            },
+            {
+                injuries:
+                    'Prellmarke an der Stirn; blutende Wunde am linken Unterarm',
+                bodyCheck:
+                    'leichte Schmerzen beim Auftreten im rechten Sprunggelenk; Schwanger; sonst o.B.',
+                breathing: 'unauffällig',
+                awareness: 'leicht verwirrt',
+                pulse: '79; gut tastbar',
+                skin: 'unauffällig',
+                pain: 'leichte',
+                pupils: 'isocor',
+                psyche: 'ängstlich',
+                hearing: 'unauffällig',
+                isWalkable: true,
+            },
+            {
+                [noChangesState.id]: noChangesState,
+                [redInstantTransportState.id]: redInstantTransportState,
+            },
+            defaultPatientImage,
+            healthPointsDefaults.blackMax,
+            redInstantTransportState.id
+        ),
+    ]),
+
     // XAXAXA Patients - Pregnant
     PatientCategory.create('XAXAXAP', defaultPatientImage, [
         PatientTemplate.create(
```
