### PR TITLE
Enable source maps for backend

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -6,6 +6,7 @@
         "rootDir": ".",
         "types": ["jest", "node"],
         "baseUrl": "./src",
+        "sourceMap": true, // For debugging
         "emitDecoratorMetadata": true // For typeorm - See https://github.com/typeorm/typeorm/issues/2897
     },
     "references": [],


### PR DESCRIPTION
This PR enables source maps for the backend code when not in build mode. Without source maps, setting breakpoints from the debugger does not work.

### PR Checklist

Please make sure to fulfill the following conditions before marking this PR ready for review:

- ~~[ ] If this PR adds or changes features or fixes bugs, this has been added to the changelog~~ Not applicable
- ~~[ ] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/digital-fuesim-manv-public-test-scenarios) have been added~~ Not applicable
