### PR TITLE
Display section titles in map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
     -   When the leader is removed, a new one gets selected
 -   The trainer editor now offers pre-configured templates for different kinds of simulated regions.
     -   These templates come with different border colors.
--   Simulated regions display their names on the map.
+-   Simulated regions and viewports display their names on the map.
 -   Vehicles now have a property to indicate their current occupation.
 -   The "Leitstelle" now has an option to select a different destination for a specified amount of vehicles.
 -   Treatment falls back to no treatment when a leader is missing in the region.

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/simulated-region-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/simulated-region-feature-manager.ts
@@ -6,7 +6,7 @@ import type {
     // eslint-disable-next-line @typescript-eslint/no-shadow
     Element,
 } from 'digital-fuesim-manv-shared';
-import { normalZoom, MapCoordinates, Size } from 'digital-fuesim-manv-shared';
+import { MapCoordinates, Size } from 'digital-fuesim-manv-shared';
 import type { Feature, MapBrowserEvent } from 'ol';
 import type { Polygon } from 'ol/geom';
 import type { TranslateEvent } from 'ol/interaction/Translate';
@@ -93,11 +93,11 @@ export class SimulatedRegionFeatureManager
             ) as SimulatedRegion;
             return {
                 name: region.name,
-                offsetY: region.size.height / 2 / normalZoom,
-                offsetX: region.size.width / 2 / normalZoom,
+                // The offset ist based on the center of the position, not the regions position (which refers to a corner)
+                offsetY: 0,
             };
         },
-        0.5,
+        0.75,
         'middle'
     );
 

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/viewport-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/viewport-feature-manager.ts
@@ -88,12 +88,13 @@ export class ViewportFeatureManager
     private readonly nameStyleHelper = new NameStyleHelper(
         (feature) => {
             const viewport = this.getElementFromFeature(feature) as Viewport;
+            const extent = (feature as Feature<Polygon>)
+                .getGeometry()!
+                .getExtent() as [number, number, number, number];
             return {
                 name: viewport.name,
-                // The offset ist based on the center of the viewports, not the viewports position (which refers to a corner), so we have to divide by 2.
-                // The hight can be negative if the corners have been swapped ("inside out"), but the text should always be below the center.
-                // Therefore, we have to use `Math.abs`.
-                offsetY: Math.abs(viewport.size.height) / 2,
+                // The offset is based on the center of the viewports, not the viewports position (which refers to a corner), so we have to divide by 2.
+                offsetY: (extent[3] - extent[1]) / 2,
             };
         },
         0.75,


### PR DESCRIPTION
With this PR, the names of viewports are shown on the map. Opposite to simulated regions, that do not have any *visible* content, viewports usually contain lots of elements, so the name has been placed below the viewport and not in its center.

Additionally, the font size for viewports as well as simulated regions has been increased slightly to achieve a better overview even in large scenarios with a low zoom level and a small bug in the style for simulated regions has been fixed.

### PR Checklist

Please make sure to fulfill the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- ~~[ ] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/digital-fuesim-manv-public-test-scenarios) have been added~~ Not applicable
