### PR TITLE
Handle new treatment progress type noTreatment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+### Fixed
+
+-   Queries for the current number of patients and the current treatment progress won't be answered by the treat patients behavior if there is no leader of the requested simulated region.
+-   The frontend for the treat patients behavior hides the "assigned personnel" column no only in the `unknown` but also the `noTreatment` phase.
+
 ## [0.5.0] - 2023-05-08
 
 ### Added

--- a/frontend/src/app/pages/exercises/exercise/shared/simulated-region-overview/tabs/behavior-tab/behaviors/treat-patients/simulated-region-overview-behavior-treat-patients.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulated-region-overview/tabs/behavior-tab/behaviors/treat-patients/simulated-region-overview-behavior-treat-patients.component.html
@@ -86,7 +86,11 @@
             <h6 class="text-center">Verlauf</h6>
         </div>
         <div
-            *ngIf="treatPatientsBehaviorState.treatmentProgress !== 'unknown'"
+            *ngIf="
+                treatPatientsBehaviorState.treatmentProgress !==
+                    'noTreatment' &&
+                treatPatientsBehaviorState.treatmentProgress !== 'unknown'
+            "
             class="col-sm justify-content-center"
         >
             <h6 class="text-center">Zugeteiltes Personal</h6>
@@ -102,6 +106,8 @@
             <app-simulated-region-overview-behavior-treat-patients-patient-details
                 [patientId]="patientId"
                 [cateringsActive]="
+                    treatPatientsBehaviorState.treatmentProgress !==
+                        'noTreatment' &&
                     treatPatientsBehaviorState.treatmentProgress !== 'unknown'
                 "
                 (click)="selectPatientService.selectPatient(patientId)"

--- a/shared/src/simulation/behaviors/report.ts
+++ b/shared/src/simulation/behaviors/report.ts
@@ -69,6 +69,12 @@ export const reportBehavior: SimulationBehavior<ReportBehaviorState> = {
             case 'treatmentProgressChangedEvent': {
                 if (!behaviorState.reportTreatmentProgressChanges) return;
 
+                if (event.newProgress === 'noTreatment') {
+                    // No treatment indicates that there is no leader
+                    // Therefore, the radiogram can't be sent
+                    return;
+                }
+
                 const radiogram = cloneDeepMutable(
                     TreatmentStatusRadiogram.create(
                         nextUUID(draftState),

--- a/shared/src/simulation/behaviors/treat-patients.ts
+++ b/shared/src/simulation/behaviors/treat-patients.ts
@@ -193,6 +193,12 @@ export const treatPatientsBehavior: SimulationBehavior<TreatPatientsBehaviorStat
                     break;
                 }
                 case 'collectInformationEvent': {
+                    if (behaviorState.treatmentProgress === 'noTreatment') {
+                        // noTreatment indicated that there is no leader
+                        // Therefore, queries should not be answered
+                        return;
+                    }
+
                     const collectInformationEvent = event;
 
                     const radiogram = getActivityById(
@@ -206,6 +212,7 @@ export const treatPatientsBehavior: SimulationBehavior<TreatPatientsBehaviorStat
                         // This behavior answerers this query because the treating personnel has the knowledge of how many patients are in a given category
                         case 'patientCount': {
                             if (behaviorState.treatmentProgress === 'unknown') {
+                                // The patients haven't been counted yet
                                 return;
                             }
 


### PR DESCRIPTION
By merging this PR, there won't be any radiograms informing the trainees that a simulated region lost it's leader, since the treatment status `noTreatment` is not reported. However, this radiogram carried the information about a missing leader implicitly only. For a reliable report of the leader leaving their region, the reports behavior should handle leader change events instead.

### PR Checklist

Please make sure to fulfill the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- ~~[ ] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/digital-fuesim-manv-public-test-scenarios) have been added~~ Not applicable
