### PR TITLE
fix: no longer transform import before sending it to the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+### Fixed
+
+- Imports of exercise once again can be performed in the frontend
+
 ## [0.8.0] - 2025-04-14
 
 ### Added

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3062,7 +3062,8 @@
         "node_modules/class-transformer": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
-            "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+            "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+            "license": "MIT"
         },
         "node_modules/class-validator": {
             "version": "0.14.1",

--- a/backend/src/utils/import-exercise.ts
+++ b/backend/src/utils/import-exercise.ts
@@ -1,9 +1,7 @@
-import { plainToInstance } from 'class-transformer';
-import type { ExerciseIds } from 'digital-fuesim-manv-shared';
+import type { ExerciseIds, StateExport } from 'digital-fuesim-manv-shared';
 import {
     migrateStateExport,
     ReducerError,
-    StateExport,
     validateExerciseExport,
 } from 'digital-fuesim-manv-shared';
 import type { DatabaseService } from '../database/services/database-service.js';
@@ -16,20 +14,7 @@ export async function importExercise(
     databaseService: DatabaseService
 ): Promise<ExerciseWrapper | HttpResponse<ExerciseIds>> {
     const migratedImportObject = migrateStateExport(importObject);
-    // console.log(
-    //     inspect(importObject.history, { depth: 2, colors: true })
-    // );
-    const importInstance = plainToInstance(
-        StateExport,
-        migratedImportObject
-        // TODO: verify that this is indeed not required
-        // // Workaround for https://github.com/typestack/class-transformer/issues/876
-        // { enableImplicitConversion: true }
-    );
-    // console.log(
-    //     inspect(importInstance.history, { depth: 2, colors: true })
-    // );
-    const validationErrors = validateExerciseExport(importInstance);
+    const validationErrors = validateExerciseExport(migratedImportObject);
     if (validationErrors.length > 0) {
         return {
             statusCode: 400,
@@ -41,7 +26,7 @@ export async function importExercise(
     try {
         return await ExerciseWrapper.importFromFile(
             databaseService,
-            importInstance,
+            migratedImportObject,
             {
                 participantId: ids.participantId,
                 trainerId: ids.trainerId,

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -156,7 +156,8 @@
                                 "@noble/hashes/sha256",
                                 "@noble/hashes/crypto",
                                 "rbush-knn",
-                                "tinyqueue"
+                                "tinyqueue",
+                                "class-transformer"
                             ]
                         }
                     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,6 @@
                 "bootstrap": "^5.3.3",
                 "bootstrap-icons": "^1.11.3",
                 "chart.js": "^4.4.8",
-                "class-transformer": "^0.5.1",
                 "class-validator": "^0.14.1",
                 "digital-fuesim-manv-shared": "file:../shared",
                 "immer": "^10.1.1",
@@ -6315,12 +6314,6 @@
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
             "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/class-transformer": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
-            "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
             "license": "MIT"
         },
         "node_modules/class-validator": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,6 @@
         "bootstrap": "^5.3.3",
         "bootstrap-icons": "^1.11.3",
         "chart.js": "^4.4.8",
-        "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "digital-fuesim-manv-shared": "file:../shared",
         "immer": "^10.1.1",

--- a/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { Store } from '@ngrx/store';
-import { plainToInstance } from 'class-transformer';
 import {
     Viewport,
     TransferPoint,
@@ -122,9 +121,7 @@ export class TrainerMapEditorComponent {
             ) as PartialExport;
             const migratedPartialExport =
                 migratePartialExport(importedPlainObject);
-            const validation = validateExerciseExport(
-                plainToInstance(PartialExport, migratedPartialExport)
-            );
+            const validation = validateExerciseExport(migratedPartialExport);
             if (validation.length > 0) {
                 throw Error(
                     `PartialExport is invalid:\n${validation.join('\n')}`

--- a/frontend/src/app/pages/landing-page/landing-page/landing-page.component.ts
+++ b/frontend/src/app/pages/landing-page/landing-page/landing-page.component.ts
@@ -1,8 +1,6 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
-import { plainToInstance } from 'class-transformer';
-import type { Constructor, ExportImportFile } from 'digital-fuesim-manv-shared';
-import { PartialExport, StateExport } from 'digital-fuesim-manv-shared';
+import type { ExportImportFile } from 'digital-fuesim-manv-shared';
 import { escapeRegExp } from 'lodash-es';
 import { ApiService } from 'src/app/core/api.service';
 import { MessageService } from 'src/app/core/messages/message.service';
@@ -68,18 +66,10 @@ export class LandingPageComponent {
             if (!['complete', 'partial'].includes(type)) {
                 throw new Error(`Ungültiger Dateityp: \`type === ${type}\``);
             }
-            const importInstance = plainToInstance(
-                (type === 'complete'
-                    ? StateExport
-                    : PartialExport) as Constructor<
-                    PartialExport | StateExport
-                >,
-                importPlain
-            );
-            switch (importInstance.type) {
+            switch (importPlain.type) {
                 case 'complete': {
                     const ids =
-                        await this.apiService.importExercise(importInstance);
+                        await this.apiService.importExercise(importPlain);
                     this.trainerId = ids.trainerId;
                     this.exerciseId = this.trainerId;
                     this.participantId = ids.participantId;

--- a/shared/src/store/validate-exercise-export.ts
+++ b/shared/src/store/validate-exercise-export.ts
@@ -12,12 +12,12 @@ import { defaultValidateOptions } from './validation-options.js';
 /**
  *
  * @param exportImportFile A json object that should be checked for validity.
- * @returns An array of errors validating {@link exportImportFile}. An empty array indicates a valid exportImport object.
+ * @returns An array of errors validating {@link exportImportFile}. An empty array indicates a valid `ExportImportFile` object.
  */
 export function validateExerciseExport(
     exportImportFile: ExportImportFile
 ): (ValidationError | string)[] {
-    // Be aware that `action` could be any json object. We need to program defensively here.
+    // Be aware that `exportImportFile` could be any json object. We need to program defensively here.
     if (typeof exportImportFile.type !== 'string') {
         return ['Export/import type is not a string.'];
     }
@@ -31,12 +31,12 @@ export function validateExerciseExport(
         return [`Unknown export/import type: ${exportImportFile.type}`];
     }
 
-    // This works - no idea about the type error though...
-    const validationErrors: (ValidationError | string)[] = validateSync(
-        plainToInstance(
-            exportImportClass as Constructor<ExportImportFile>,
-            exportImportFile
-        ),
+    const exportImportFileInstance = plainToInstance(
+        exportImportClass as Constructor<ExportImportFile>,
+        exportImportFile
+    );
+    const validationErrors = validateSync(
+        exportImportFileInstance,
         defaultValidateOptions
     );
     return validationErrors;


### PR DESCRIPTION
Previously, the frontend would convert the JSON import to an instance before sending it to the backend. This, however, lead to the backend rejecting the import as an instance is only meant to be used during validation. Now, only the backend validates the import, with the frontend just passing on the JSON.

This problem was introduced in #1055 as before that the conversion to an instance was faulty in a way that the backend still understood and accepted the imports.

Fixes #1065

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/digital-fuesim-manv-public-test-scenarios) have been added.
- [x] I have the right to license the code submitted with this Pull Request under the mentioned license in the file [LICENSE-README.md](LICENSE-README.md) (i.e., this is my
      own code or code licensed under a license compatible to AGPL v3.0 or later, for exceptions look into [LICENSE-README.md](LICENSE-README.md)) and
      hereby license the code in this Pull Request under it.
      I certify that by signing off my commits (see In case of using third party code, I have given appropriate credit.
      We are using DCO for that, see [here](https://github.com/dcoapp/app#how-it-works) for more information.
- [x] If I have used third party code and I mentioned it in the code, I also updated the [inspired-by-or-copied-from-list.html](inspired-by-or-copied-from-list.html) list to include the links.
