### PR TITLE
dependencies: update `tmp` in `frontend` to version 0.2.5 via `npm audit fix`

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2011,14 +2011,14 @@
             }
         },
         "node_modules/@inquirer/core": {
-            "version": "10.1.10",
-            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
-            "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+            "version": "10.1.15",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
+            "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/figures": "^1.0.11",
-                "@inquirer/type": "^3.0.6",
+                "@inquirer/figures": "^1.0.13",
+                "@inquirer/type": "^3.0.8",
                 "ansi-escapes": "^4.3.2",
                 "cli-width": "^4.1.0",
                 "mute-stream": "^2.0.0",
@@ -2039,15 +2039,15 @@
             }
         },
         "node_modules/@inquirer/editor": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.10.tgz",
-            "integrity": "sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw==",
+            "version": "4.2.16",
+            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.16.tgz",
+            "integrity": "sha512-iSzLjT4C6YKp2DU0fr8T7a97FnRRxMO6CushJnW5ktxLNM2iNeuyUuUA5255eOLPORoGYCrVnuDOEBdGkHGkpw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/core": "^10.1.10",
-                "@inquirer/type": "^3.0.6",
-                "external-editor": "^3.1.0"
+                "@inquirer/core": "^10.1.15",
+                "@inquirer/external-editor": "^1.0.0",
+                "@inquirer/type": "^3.0.8"
             },
             "engines": {
                 "node": ">=18"
@@ -2084,10 +2084,27 @@
                 }
             }
         },
+        "node_modules/@inquirer/external-editor": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.0.tgz",
+            "integrity": "sha512-5v3YXc5ZMfL6OJqXPrX9csb4l7NlQA2doO1yynUjpUChT9hg4JcuBVP0RbsEJ/3SL/sxWEyFjT2W69ZhtoBWqg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chardet": "^2.1.0",
+                "iconv-lite": "^0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            }
+        },
         "node_modules/@inquirer/figures": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
-            "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+            "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2264,9 +2281,9 @@
             }
         },
         "node_modules/@inquirer/type": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.6.tgz",
-            "integrity": "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==",
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+            "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6240,9 +6257,9 @@
             }
         },
         "node_modules/chardet": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+            "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
             "dev": true,
             "license": "MIT"
         },
@@ -7326,20 +7343,6 @@
                 "iconv-lite": "^0.6.2"
             }
         },
-        "node_modules/encoding/node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/end-of-stream": {
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -8288,34 +8291,6 @@
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/external-editor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chardet": "^0.7.0",
-                "iconv-lite": "^0.4.24",
-                "tmp": "^0.0.33"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/external-editor/node_modules/tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "os-tmpdir": "~1.0.2"
-            },
-            "engines": {
-                "node": ">=0.6.0"
-            }
         },
         "node_modules/extract-zip": {
             "version": "2.0.1",
@@ -9266,13 +9241,13 @@
             }
         },
         "node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
             "engines": {
                 "node": ">=0.10.0"
@@ -12450,16 +12425,6 @@
             "license": "MIT",
             "optional": true
         },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/ospath": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
@@ -14874,9 +14839,9 @@
             "license": "MIT"
         },
         "node_modules/tmp": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-            "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
             "dev": true,
             "license": "MIT",
             "engines": {


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-52f5-9888-hmc6.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/digital-fuesim-manv-public-test-scenarios) have been added.
- [x] I have the right to license the code submitted with this Pull Request under the mentioned license in the file [LICENSE-README.md](LICENSE-README.md) (i.e., this is my
      own code or code licensed under a license compatible to AGPL v3.0 or later, for exceptions look into [LICENSE-README.md](LICENSE-README.md)) and
      hereby license the code in this Pull Request under it.
      I certify that by signing off my commits (see In case of using third party code, I have given appropriate credit.
      We are using DCO for that, see [here](https://github.com/dcoapp/app#how-it-works) for more information.
- [x] If I have used third party code and I mentioned it in the code, I also updated the [inspired-by-or-copied-from-list.html](inspired-by-or-copied-from-list.html) list to include the links.
