### PR TITLE
Fix trigger for release PR pipelines

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,6 +6,10 @@ on:
             - main
             - dev
     pull_request:
+        # The first three types are the default value (see https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request).
+        # `ready_for_review` is needed since actions from pipelines (such as the PRs created by the release pipeline) don't trigger additional pipelines.
+        # Hence, we let the release pipeline create draft PRs that we then can mark as ready manually.
+        types: [opened, synchronize, reopened, ready_for_review]
 
 env:
     POSTGRES_USER: dfm


### PR DESCRIPTION
GitHub actions (using the default `GITHUB_TOKEN` from the pipeline env) don't trigger any subsequent actions ([docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow)). Thus, the PR pipeline in our release PRs (created by our release pipeline) don't run and we don't have a way to trigger them.

By adding the `ready_for_review` trigger, we can manually mark the PRs as ready, which should trigger the pipeline.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/digital-fuesim-manv-public-test-scenarios) have been added.
- [x] I have the right to license the code submitted with this Pull Request under the mentioned license in the file [LICENSE-README.md](LICENSE-README.md) (i.e., this is my
      own code or code licensed under a license compatible to AGPL v3.0 or later, for exceptions look into [LICENSE-README.md](LICENSE-README.md)) and
      hereby license the code in this Pull Request under it.
      I certify that by signing off my commits (see In case of using third party code, I have given appropriate credit.
      We are using DCO for that, see [here](https://github.com/dcoapp/app#how-it-works) for more information.
- [x] If I have used third party code and I mentioned it in the code, I also updated the [inspired-by-or-copied-from-list.html](inspired-by-or-copied-from-list.html) list to include the links.
