### PR TITLE
Implement `ClientRole` class

### DIFF
--- a/backend/src/exercise/client-wrapper.ts
+++ b/backend/src/exercise/client-wrapper.ts
@@ -33,7 +33,7 @@ export class ClientWrapper {
             clientName,
             ClientRole.create(
                 role,
-                role === 'trainer' ? 'trainer' : 'map-operator'
+                role === 'trainer' ? 'trainer' : 'mapOperator'
             ),
             undefined
         );

--- a/backend/src/exercise/client-wrapper.ts
+++ b/backend/src/exercise/client-wrapper.ts
@@ -33,7 +33,7 @@ export class ClientWrapper {
             clientName,
             ClientRole.create(
                 role,
-                role === 'participant' ? 'map-operator' : role
+                role === 'trainer' ? 'trainer' : 'map-operator'
             ),
             undefined
         );

--- a/backend/src/exercise/client-wrapper.ts
+++ b/backend/src/exercise/client-wrapper.ts
@@ -1,5 +1,5 @@
 import type { ExerciseAction, UUID } from 'digital-fuesim-manv-shared';
-import { Client } from 'digital-fuesim-manv-shared';
+import { Client, ClientRole } from 'digital-fuesim-manv-shared';
 import type { ExerciseSocket } from '../exercise-server.js';
 import { exerciseMap } from './exercise-map.js';
 import type { ExerciseWrapper } from './exercise-wrapper.js';
@@ -29,7 +29,14 @@ export class ClientWrapper {
         // as the provided id is guaranteed to be one of the ids of the exercise as the exercise
         // was fetched with this exact id from the exercise map.
         const role = this.chosenExercise.getRoleFromUsedId(exerciseId);
-        this.relatedExerciseClient = Client.create(clientName, role, undefined);
+        this.relatedExerciseClient = Client.create(
+            clientName,
+            ClientRole.create(
+                role,
+                role === 'participant' ? 'map-operator' : role
+            ),
+            undefined
+        );
         this.chosenExercise.addClient(this);
         return this.relatedExerciseClient.id;
     }

--- a/backend/src/exercise/client-wrapper.ts
+++ b/backend/src/exercise/client-wrapper.ts
@@ -35,6 +35,7 @@ export class ClientWrapper {
                 role,
                 role === 'trainer' ? 'trainer' : 'mapOperator'
             ),
+            role !== 'trainer',
             undefined
         );
         this.chosenExercise.addClient(this);

--- a/frontend/src/app/core/exercise.service.ts
+++ b/frontend/src/app/core/exercise.service.ts
@@ -34,7 +34,7 @@ import {
     selectExerciseState,
 } from '../state/application/selectors/exercise.selectors';
 import {
-    selectCurrentRole,
+    selectCurrentMainRole,
     selectOwnClient,
     selectVisibleVehicles,
 } from '../state/application/selectors/shared.selectors';
@@ -221,7 +221,7 @@ export class ExerciseService {
     private startNotifications() {
         // If the user is a trainer, display a message for each joined or disconnected client
         this.store
-            .select(selectCurrentRole)
+            .select(selectCurrentMainRole)
             .pipe(
                 filter((role) => role === 'trainer'),
                 switchMap(() => this.store.select(selectClients)),
@@ -233,7 +233,7 @@ export class ExerciseService {
                     createHandler: (newClient) => {
                         this.messageService.postMessage({
                             title: `${newClient.name} ist als ${
-                                newClient.role === 'trainer'
+                                newClient.role.mainRole === 'trainer'
                                     ? 'Trainer'
                                     : 'Teilnehmer'
                             } beigetreten.`,

--- a/frontend/src/app/pages/exercises/exercise/exercise/exercise.component.html
+++ b/frontend/src/app/pages/exercises/exercise/exercise/exercise.component.html
@@ -21,7 +21,9 @@
                     Teilnehmerlink teilen
                 </button>
                 <button
-                    *ngIf="(ownClient$ | async)?.role !== 'participant'"
+                    *ngIf="
+                        (ownClient$ | async)?.role?.mainRole !== 'participant'
+                    "
                     (click)="shareExercise('trainerId')"
                     class="btn btn-outline-warning ms-3"
                 >
@@ -139,11 +141,11 @@
                     *ngIf="!ownClient.isInWaitingRoom; else waitingRoomTemplate"
                 >
                     <app-exercise-map
-                        *ngIf="ownClient.role === 'participant'"
+                        *ngIf="ownClient.role.mainRole === 'participant'"
                         class="h-100 rounded overflow-hidden"
                     ></app-exercise-map>
                     <app-trainer-map-editor
-                        *ngIf="ownClient.role === 'trainer'"
+                        *ngIf="ownClient.role.mainRole === 'trainer'"
                     ></app-trainer-map-editor>
                 </ng-container>
                 <ng-template #waitingRoomTemplate>

--- a/frontend/src/app/pages/exercises/exercise/shared/client-overview/client-overview-table/client-overview-table.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/client-overview/client-overview-table/client-overview-table.component.html
@@ -18,7 +18,11 @@
                 {{ client.name }}
             </td>
             <td class="align-middle">
-                {{ client.role === 'trainer' ? 'Übungsleiter' : 'Teilnehmer' }}
+                {{
+                    client.role.mainRole === 'trainer'
+                        ? 'Übungsleiter'
+                        : 'Teilnehmer'
+                }}
             </td>
             <!-- Choose the viewport -->
             <td ngbDropdown>

--- a/frontend/src/app/pages/exercises/exercise/shared/core/statistics/statistics.service.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/core/statistics/statistics.service.ts
@@ -174,7 +174,8 @@ export class StatisticsService {
         return {
             numberOfActiveParticipants: clients.filter(
                 (client) =>
-                    !client.isInWaitingRoom && client.role === 'participant'
+                    !client.isInWaitingRoom &&
+                    client.role.mainRole === 'participant'
             ).length,
             patients: countBy(patients, (patient) => patient.realStatus),
             vehicles: countBy(vehicles, (vehicle) => vehicle.vehicleType),

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/exercise-map.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/exercise-map.component.ts
@@ -10,7 +10,7 @@ import { Subject } from 'rxjs';
 import { ExerciseService } from 'src/app/core/exercise.service';
 import type { AppState } from 'src/app/state/app.state';
 import {
-    selectCurrentRole,
+    selectCurrentMainRole,
     selectRestrictedViewport,
 } from 'src/app/state/application/selectors/shared.selectors';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
@@ -41,7 +41,7 @@ export class ExerciseMapComponent implements AfterViewInit, OnDestroy {
     public readonly restrictedToViewport$ = this.store.select(
         selectRestrictedViewport
     );
-    public readonly currentRole$ = this.store.select(selectCurrentRole);
+    public readonly currentRole$ = this.store.select(selectCurrentMainRole);
 
     constructor(
         private readonly store: Store<AppState>,

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/delete-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/delete-feature-manager.ts
@@ -12,7 +12,7 @@ import Style from 'ol/style/Style';
 import type { Subject } from 'rxjs';
 import type { ExerciseService } from 'src/app/core/exercise.service';
 import type { AppState } from 'src/app/state/app.state';
-import { selectCurrentRole } from 'src/app/state/application/selectors/shared.selectors';
+import { selectCurrentMainRole } from 'src/app/state/application/selectors/shared.selectors';
 import { selectStateSnapshot } from 'src/app/state/get-state-snapshot';
 // eslint-disable-next-line @typescript-eslint/no-shadow
 import type { Element } from 'digital-fuesim-manv-shared';
@@ -45,7 +45,9 @@ export class DeleteFeatureManager implements FeatureManager<Point> {
     ) {
         this.olMap.addLayer(this.layer);
         mapInteractionsManager.addFeatureLayer(this.layer);
-        if (selectStateSnapshot(selectCurrentRole, this.store) === 'trainer') {
+        if (
+            selectStateSnapshot(selectCurrentMainRole, this.store) === 'trainer'
+        ) {
             this.makeVisible();
         }
     }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/map-images-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/map-images-feature-manager.ts
@@ -7,7 +7,7 @@ import type { Subject } from 'rxjs';
 import type { ExerciseService } from 'src/app/core/exercise.service';
 import type { AppState } from 'src/app/state/app.state';
 import {
-    selectCurrentRole,
+    selectCurrentMainRole,
     selectVisibleMapImages,
 } from 'src/app/state/application/selectors/shared.selectors';
 import { selectStateSnapshot } from 'src/app/state/get-state-snapshot';
@@ -75,7 +75,9 @@ export class MapImageFeatureManager extends MoveableFeatureManager<MapImage> {
     ): void {
         super.onFeatureClicked(event, feature);
 
-        if (selectStateSnapshot(selectCurrentRole, this.store) !== 'trainer') {
+        if (
+            selectStateSnapshot(selectCurrentMainRole, this.store) !== 'trainer'
+        ) {
             return;
         }
         this.popupService.openPopup(
@@ -96,8 +98,8 @@ export class MapImageFeatureManager extends MoveableFeatureManager<MapImage> {
     override isFeatureTranslatable(feature: Feature<Point>): boolean {
         const mapImage = this.getElementFromFeature(feature) as MapImage;
         return (
-            selectStateSnapshot(selectCurrentRole, this.store) === 'trainer' &&
-            !mapImage.isLocked
+            selectStateSnapshot(selectCurrentMainRole, this.store) ===
+                'trainer' && !mapImage.isLocked
         );
     }
 }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/moveable-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/moveable-feature-manager.ts
@@ -8,7 +8,7 @@ import type { Observable, Subject } from 'rxjs';
 import type { Element, UUID } from 'digital-fuesim-manv-shared';
 import type { FeatureLike } from 'ol/Feature';
 import { selectStateSnapshot } from 'src/app/state/get-state-snapshot';
-import { selectCurrentRole } from 'src/app/state/application/selectors/shared.selectors';
+import { selectCurrentMainRole } from 'src/app/state/application/selectors/shared.selectors';
 import type Style from 'ol/style/Style';
 import type { FeatureManager } from '../utility/feature-manager';
 import type {
@@ -122,11 +122,13 @@ export abstract class MoveableFeatureManager<
             (popupService.currentPopup?.markedForTrainerUUIDs.includes(
                 feature.getId() as UUID
             ) &&
-                selectStateSnapshot(selectCurrentRole, store) === 'trainer') ||
+                selectStateSnapshot(selectCurrentMainRole, store) ===
+                    'trainer') ||
             (popupService.currentPopup?.markedForParticipantUUIDs.includes(
                 feature.getId() as UUID
             ) &&
-                selectStateSnapshot(selectCurrentRole, store) === 'participant')
+                selectStateSnapshot(selectCurrentMainRole, store) ===
+                    'participant')
         ) {
             styles.push(markingStyle);
         }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/simulated-region-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/simulated-region-feature-manager.ts
@@ -17,7 +17,7 @@ import type { Subject } from 'rxjs';
 import type { ExerciseService } from 'src/app/core/exercise.service';
 import type { AppState } from 'src/app/state/app.state';
 import {
-    selectCurrentRole,
+    selectCurrentMainRole,
     selectVisibleSimulatedRegions,
 } from 'src/app/state/application/selectors/shared.selectors';
 import { selectStateSnapshot } from 'src/app/state/get-state-snapshot';
@@ -189,7 +189,9 @@ export class SimulatedRegionFeatureManager
         feature: Feature<any>
     ): void {
         super.onFeatureClicked(event, feature);
-        if (selectStateSnapshot(selectCurrentRole, this.store) !== 'trainer') {
+        if (
+            selectStateSnapshot(selectCurrentMainRole, this.store) !== 'trainer'
+        ) {
             return;
         }
         const zoom = this.olMap.getView().getZoom()!;
@@ -218,6 +220,8 @@ export class SimulatedRegionFeatureManager
     }
 
     public override isFeatureTranslatable(feature: Feature<Polygon>): boolean {
-        return selectStateSnapshot(selectCurrentRole, this.store) === 'trainer';
+        return (
+            selectStateSnapshot(selectCurrentMainRole, this.store) === 'trainer'
+        );
     }
 }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-lines-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-lines-feature-manager.ts
@@ -13,7 +13,7 @@ import type { Subject } from 'rxjs';
 import type { TransferLine } from 'src/app/shared/types/transfer-line';
 import type { AppState } from 'src/app/state/app.state';
 import { selectTransferLines } from 'src/app/state/application/selectors/exercise.selectors';
-import { selectCurrentRole } from 'src/app/state/application/selectors/shared.selectors';
+import { selectCurrentMainRole } from 'src/app/state/application/selectors/shared.selectors';
 import { selectStateSnapshot } from 'src/app/state/get-state-snapshot';
 import type { TransferLinesService } from '../../core/transfer-lines.service';
 import type { FeatureManager } from '../utility/feature-manager';
@@ -48,7 +48,9 @@ export class TransferLinesFeatureManager
     ) {
         this.olMap.addLayer(this.layer);
         mapInteractionsManager.addFeatureLayer(this.layer);
-        if (selectStateSnapshot(selectCurrentRole, this.store) === 'trainer') {
+        if (
+            selectStateSnapshot(selectCurrentMainRole, this.store) === 'trainer'
+        ) {
             this.registerChangeHandlers(
                 this.store.select(selectTransferLines),
                 destroy$,

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-point-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-point-feature-manager.ts
@@ -10,7 +10,7 @@ import type { Subject } from 'rxjs';
 import type { ExerciseService } from 'src/app/core/exercise.service';
 import type { AppState } from 'src/app/state/app.state';
 import {
-    selectCurrentRole,
+    selectCurrentMainRole,
     selectVisibleTransferPoints,
 } from 'src/app/state/application/selectors/shared.selectors';
 import { selectStateSnapshot } from 'src/app/state/get-state-snapshot';
@@ -161,7 +161,9 @@ export class TransferPointFeatureManager extends MoveableFeatureManager<Transfer
     ): void {
         super.onFeatureClicked(event, feature);
 
-        if (selectStateSnapshot(selectCurrentRole, this.store) !== 'trainer') {
+        if (
+            selectStateSnapshot(selectCurrentMainRole, this.store) !== 'trainer'
+        ) {
             return;
         }
         this.popupService.openPopup(
@@ -180,6 +182,8 @@ export class TransferPointFeatureManager extends MoveableFeatureManager<Transfer
     }
 
     override isFeatureTranslatable(feature: Feature<Point>): boolean {
-        return selectStateSnapshot(selectCurrentRole, this.store) === 'trainer';
+        return (
+            selectStateSnapshot(selectCurrentMainRole, this.store) === 'trainer'
+        );
     }
 }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/viewport-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/viewport-feature-manager.ts
@@ -11,7 +11,7 @@ import type { Subject } from 'rxjs';
 import type { ExerciseService } from 'src/app/core/exercise.service';
 import type { AppState } from 'src/app/state/app.state';
 import {
-    selectCurrentRole,
+    selectCurrentMainRole,
     selectVisibleViewports,
 } from 'src/app/state/application/selectors/shared.selectors';
 import { selectStateSnapshot } from 'src/app/state/get-state-snapshot';
@@ -154,7 +154,9 @@ export class ViewportFeatureManager
         feature: Feature<any>
     ): void {
         super.onFeatureClicked(event, feature);
-        if (selectStateSnapshot(selectCurrentRole, this.store) !== 'trainer') {
+        if (
+            selectStateSnapshot(selectCurrentMainRole, this.store) !== 'trainer'
+        ) {
             return;
         }
         const zoom = this.olMap.getView().getZoom()!;
@@ -183,6 +185,8 @@ export class ViewportFeatureManager
     }
 
     public override isFeatureTranslatable(feature: Feature<Polygon>): boolean {
-        return selectStateSnapshot(selectCurrentRole, this.store) === 'trainer';
+        return (
+            selectStateSnapshot(selectCurrentMainRole, this.store) === 'trainer'
+        );
     }
 }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/map-image-popup/map-image-popup.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/map-image-popup/map-image-popup.component.ts
@@ -11,7 +11,7 @@ import { firstValueFrom } from 'rxjs';
 import { ExerciseService } from 'src/app/core/exercise.service';
 import type { AppState } from 'src/app/state/app.state';
 import { createSelectMapImage } from 'src/app/state/application/selectors/exercise.selectors';
-import { selectCurrentRole } from 'src/app/state/application/selectors/shared.selectors';
+import { selectCurrentMainRole } from 'src/app/state/application/selectors/shared.selectors';
 import { PopupService } from '../../utility/popup.service';
 
 @Component({
@@ -25,7 +25,7 @@ export class MapImagePopupComponent implements OnInit {
     public mapImageId!: UUID;
 
     public mapImage$?: Observable<MapImage>;
-    public readonly currentRole$ = this.store.select(selectCurrentRole);
+    public readonly currentRole$ = this.store.select(selectCurrentMainRole);
 
     public url?: string;
 

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/simulated-region-popup/simulated-region-popup.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/simulated-region-popup/simulated-region-popup.component.ts
@@ -6,7 +6,7 @@ import type { UUID, SimulatedRegion } from 'digital-fuesim-manv-shared';
 import type { Observable } from 'rxjs';
 import type { AppState } from 'src/app/state/app.state';
 import { createSelectSimulatedRegion } from 'src/app/state/application/selectors/exercise.selectors';
-import { selectCurrentRole } from 'src/app/state/application/selectors/shared.selectors';
+import { selectCurrentMainRole } from 'src/app/state/application/selectors/shared.selectors';
 import { openSimulationTrainerModal } from '../../../simulation/trainer-modal/open-simulation-trainer-modal';
 import { PopupService } from '../../utility/popup.service';
 
@@ -21,7 +21,7 @@ export class SimulatedRegionPopupComponent implements OnInit {
     public simulatedRegionId!: UUID;
 
     public simulatedRegion$?: Observable<SimulatedRegion>;
-    public readonly currentRole$ = this.store.select(selectCurrentRole);
+    public readonly currentRole$ = this.store.select(selectCurrentMainRole);
 
     constructor(
         private readonly store: Store<AppState>,

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/transfer-point-popup/transfer-point-popup.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/transfer-point-popup/transfer-point-popup.component.ts
@@ -6,7 +6,7 @@ import type { Observable } from 'rxjs';
 import { ExerciseService } from 'src/app/core/exercise.service';
 import type { AppState } from 'src/app/state/app.state';
 import { createSelectTransferPoint } from 'src/app/state/application/selectors/exercise.selectors';
-import { selectCurrentRole } from 'src/app/state/application/selectors/shared.selectors';
+import { selectCurrentMainRole } from 'src/app/state/application/selectors/shared.selectors';
 import { PopupService } from '../../utility/popup.service';
 
 type NavIds = 'hospitals' | 'names' | 'transferPoints';
@@ -28,7 +28,7 @@ export class TransferPointPopupComponent implements OnInit {
 
     public transferPoint$?: Observable<TransferPoint>;
 
-    public readonly currentRole$ = this.store.select(selectCurrentRole);
+    public readonly currentRole$ = this.store.select(selectCurrentMainRole);
 
     public get activeNavId() {
         return activeNavId;

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/vehicle-popup/vehicle-popup.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/vehicle-popup/vehicle-popup.component.ts
@@ -5,7 +5,7 @@ import type { Vehicle, UUID } from 'digital-fuesim-manv-shared';
 import type { Observable } from 'rxjs';
 import type { AppState } from 'src/app/state/app.state';
 import { createSelectVehicle } from 'src/app/state/application/selectors/exercise.selectors';
-import { selectCurrentRole } from 'src/app/state/application/selectors/shared.selectors';
+import { selectCurrentMainRole } from 'src/app/state/application/selectors/shared.selectors';
 import { PopupService } from '../../utility/popup.service';
 
 @Component({
@@ -19,7 +19,7 @@ export class VehiclePopupComponent implements OnInit {
     public vehicleId!: UUID;
 
     public vehicle$?: Observable<Vehicle>;
-    public readonly currentRole$ = this.store.select(selectCurrentRole);
+    public readonly currentRole$ = this.store.select(selectCurrentMainRole);
 
     constructor(
         private readonly store: Store<AppState>,

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/viewport-popup/viewport-popup.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/shared/viewport-popup/viewport-popup.component.ts
@@ -6,7 +6,7 @@ import type { Observable } from 'rxjs';
 import { ExerciseService } from 'src/app/core/exercise.service';
 import type { AppState } from 'src/app/state/app.state';
 import { createSelectViewport } from 'src/app/state/application/selectors/exercise.selectors';
-import { selectCurrentRole } from 'src/app/state/application/selectors/shared.selectors';
+import { selectCurrentMainRole } from 'src/app/state/application/selectors/shared.selectors';
 import { PopupService } from '../../utility/popup.service';
 
 @Component({
@@ -20,7 +20,7 @@ export class ViewportPopupComponent implements OnInit {
     public viewportId!: UUID;
 
     public viewport$?: Observable<Viewport>;
-    public readonly currentRole$ = this.store.select(selectCurrentRole);
+    public readonly currentRole$ = this.store.select(selectCurrentMainRole);
 
     constructor(
         private readonly store: Store<AppState>,

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-interactions-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-interactions-manager.ts
@@ -1,5 +1,5 @@
 import type VectorLayer from 'ol/layer/Vector';
-import { selectCurrentRole } from 'src/app/state/application/selectors/shared.selectors';
+import { selectCurrentMainRole } from 'src/app/state/application/selectors/shared.selectors';
 import type { Interaction } from 'ol/interaction';
 import { defaults as defaultInteractions } from 'ol/interaction';
 import type { Subject } from 'rxjs';
@@ -14,6 +14,7 @@ import { selectStateSnapshot } from 'src/app/state/get-state-snapshot';
 import type { ExerciseStatus, Role, UUID } from 'digital-fuesim-manv-shared';
 import type { TranslateEvent } from 'ol/interaction/Translate';
 import type { Pixel } from 'ol/pixel';
+import { selectExerciseStateMode } from 'src/app/state/application/selectors/application.selectors';
 import { featureElementKey } from '../feature-managers/element-manager';
 import { TranslateInteraction } from './translate-interaction';
 import type { PopupManager } from './popup-manager';
@@ -28,7 +29,8 @@ export class OlMapInteractionsManager {
     private interactions: Collection<Interaction> =
         new Collection<Interaction>();
     private lastStatus: ExerciseStatus | undefined;
-    private lastRole: Role | 'timeTravel' | undefined;
+    private lastRole: Role | undefined;
+    private lastExerciseStateMode: 'exercise' | 'timeTravel' | undefined;
 
     constructor(
         private readonly mapInteractions: Collection<Interaction>,
@@ -59,7 +61,11 @@ export class OlMapInteractionsManager {
         this.updateInteractions();
         this.registerDropHandler();
         this.applyInteractions();
-        this.updateInteractionEnablement(this.lastStatus, this.lastRole);
+        this.updateInteractionEnablement(
+            this.lastStatus,
+            this.lastRole,
+            this.lastExerciseStateMode
+        );
     }
 
     private updateTranslateInteraction() {
@@ -89,7 +95,7 @@ export class OlMapInteractionsManager {
             altShiftDragRotate: false,
             keyboard: true,
         }).extend(
-            selectStateSnapshot(selectCurrentRole, this.store) === 'trainer'
+            selectStateSnapshot(selectCurrentMainRole, this.store) === 'trainer'
                 ? [...this.participantInteractions, ...this.trainerInteractions]
                 : [...this.participantInteractions]
         );
@@ -106,25 +112,32 @@ export class OlMapInteractionsManager {
     private registerInteractionEnablementHandler() {
         combineLatest([
             this.store.select(selectExerciseStatus),
-            this.store.select(selectCurrentRole),
+            this.store.select(selectCurrentMainRole),
+            this.store.select(selectExerciseStateMode),
         ])
             .pipe(takeUntil(this.destroy$))
-            .subscribe(([status, currentRole]) => {
-                this.updateInteractionEnablement(status, currentRole);
+            .subscribe(([status, currentRole, exerciseStateMode]) => {
+                this.updateInteractionEnablement(
+                    status,
+                    currentRole,
+                    exerciseStateMode
+                );
             });
     }
 
     // this shows a paused overlay and disables interactions for participants when the exercise is paused
     private updateInteractionEnablement(
         status: ExerciseStatus | undefined,
-        currentRole: Role | 'timeTravel' | undefined
+        currentRole: Role | undefined,
+        exerciseStateMode: 'exercise' | 'timeTravel' | undefined
     ) {
         this.lastRole = currentRole;
         this.lastStatus = status;
+        this.lastExerciseStateMode = exerciseStateMode;
         const isPausedAndParticipant =
             status !== 'running' && currentRole === 'participant';
         const areInteractionsActive =
-            !isPausedAndParticipant && currentRole !== 'timeTravel';
+            !isPausedAndParticipant && exerciseStateMode !== 'timeTravel';
         this.participantInteractions.forEach((interaction) => {
             interaction.setActive(areInteractionsActive);
         });

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
@@ -15,7 +15,7 @@ import {
     selectViewports,
 } from 'src/app/state/application/selectors/exercise.selectors';
 import {
-    selectCurrentRole,
+    selectCurrentMainRole,
     selectRestrictedViewport,
 } from 'src/app/state/application/selectors/shared.selectors';
 import { selectStateSnapshot } from 'src/app/state/get-state-snapshot';
@@ -216,7 +216,7 @@ export class OlMapManager {
 
     public tryGoToCoordinates(latitude: number, longitude: number) {
         if (
-            selectStateSnapshot(selectCurrentRole, this.store) ===
+            selectStateSnapshot(selectCurrentMainRole, this.store) ===
                 'participant' &&
             selectStateSnapshot(selectRestrictedViewport, this.store) !==
                 undefined

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/radiogram-list/radiogram-card/radiogram-card.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/radiogram-list/radiogram-card/radiogram-card.component.ts
@@ -41,7 +41,7 @@ import { SelectSignallerRegionService } from '../../../signaller-modal/select-si
 // This is a fallback to show something useful in the UI
 const unavailableClient = Client.create(
     'Unbekannt',
-    ClientRole.create('participant', 'map-operator')
+    ClientRole.create('participant', 'mapOperator')
 );
 
 @Component({

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/radiogram-list/radiogram-card/radiogram-card.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/radiogram-list/radiogram-card/radiogram-card.component.ts
@@ -13,6 +13,7 @@ import type {
 } from 'digital-fuesim-manv-shared';
 import {
     Client,
+    ClientRole,
     currentParticipantIdOf,
     isAccepted,
     isDone,
@@ -38,7 +39,10 @@ import { SelectSignallerRegionService } from '../../../signaller-modal/select-si
 
 // Clients that leave are lost from the state but radiograms might point to them.
 // This is a fallback to show something useful in the UI
-const unavailableClient = Client.create('Unbekannt', 'participant');
+const unavailableClient = Client.create(
+    'Unbekannt',
+    ClientRole.create('participant', 'map-operator')
+);
 
 @Component({
     selector: 'app-radiogram-card',

--- a/frontend/src/app/shared/components/patient-health-point-display/patient-health-point-display.component.ts
+++ b/frontend/src/app/shared/components/patient-health-point-display/patient-health-point-display.component.ts
@@ -13,7 +13,7 @@ import {
     createSelectPatient,
     selectConfiguration,
 } from 'src/app/state/application/selectors/exercise.selectors';
-import { selectCurrentRole } from 'src/app/state/application/selectors/shared.selectors';
+import { selectCurrentMainRole } from 'src/app/state/application/selectors/shared.selectors';
 
 @Component({
     selector: 'app-patient-health-point-display',
@@ -30,7 +30,7 @@ export class PatientHealthPointDisplayComponent implements OnInit {
         health: number;
     }>;
 
-    public readonly currentRole$ = this.store.select(selectCurrentRole);
+    public readonly currentRole$ = this.store.select(selectCurrentMainRole);
 
     public readonly healthPointsDefaults = healthPointsDefaults;
 

--- a/frontend/src/app/shared/components/patients-details/patients-details.component.ts
+++ b/frontend/src/app/shared/components/patients-details/patients-details.component.ts
@@ -11,7 +11,7 @@ import {
     createSelectPatient,
     selectConfiguration,
 } from 'src/app/state/application/selectors/exercise.selectors';
-import { selectCurrentRole } from 'src/app/state/application/selectors/shared.selectors';
+import { selectCurrentMainRole } from 'src/app/state/application/selectors/shared.selectors';
 
 @Component({
     selector: 'app-patients-details',
@@ -22,7 +22,7 @@ import { selectCurrentRole } from 'src/app/state/application/selectors/shared.se
 export class PatientsDetailsComponent implements OnChanges {
     @Input() patientId!: UUID;
 
-    readonly currentRole$ = this.store.select(selectCurrentRole);
+    readonly currentRole$ = this.store.select(selectCurrentMainRole);
     configuration$ = this.store.select(selectConfiguration);
     patient$!: Observable<Patient>;
     visibleStatus$!: Observable<PatientStatus>;

--- a/frontend/src/app/shared/components/vehicle-load-unload-controls/vehicle-load-unload-controls.component.ts
+++ b/frontend/src/app/shared/components/vehicle-load-unload-controls/vehicle-load-unload-controls.component.ts
@@ -13,7 +13,7 @@ import {
     createSelectPersonnel,
     createSelectVehicle,
 } from 'src/app/state/application/selectors/exercise.selectors';
-import { selectCurrentRole } from 'src/app/state/application/selectors/shared.selectors';
+import { selectCurrentMainRole } from 'src/app/state/application/selectors/shared.selectors';
 
 @Component({
     selector: 'app-vehicle-load-unload-controls',
@@ -26,7 +26,7 @@ export class VehicleLoadUnloadControlsComponent implements OnChanges {
     vehicleId!: UUID;
 
     vehicleLoadState$?: Observable<{ loadable: boolean; unloadable: boolean }>;
-    currentRole$!: Observable<Role | 'timeTravel' | undefined>;
+    currentRole$!: Observable<Role | undefined>;
 
     constructor(
         private readonly store: Store<AppState>,
@@ -36,7 +36,7 @@ export class VehicleLoadUnloadControlsComponent implements OnChanges {
     ngOnChanges(): void {
         const vehicle$ = this.store.select(createSelectVehicle(this.vehicleId));
 
-        this.currentRole$ = this.store.select(selectCurrentRole);
+        this.currentRole$ = this.store.select(selectCurrentMainRole);
 
         this.vehicleLoadState$ = vehicle$.pipe(
             switchMap((vehicle) => {

--- a/frontend/src/app/state/application/selectors/shared.selectors.ts
+++ b/frontend/src/app/state/application/selectors/shared.selectors.ts
@@ -18,10 +18,7 @@ import {
 import { pickBy } from 'lodash-es';
 import type { CateringLine } from 'src/app/shared/types/catering-line';
 import type { AppState } from '../../app.state';
-import {
-    selectExerciseStateMode,
-    selectOwnClientId,
-} from './application.selectors';
+import { selectOwnClientId } from './application.selectors';
 import {
     selectClients,
     selectMapImages,
@@ -48,9 +45,13 @@ export const selectOwnClient = createSelector(
  * Do not use this to distinguish between the exerciseStateModes
  */
 export const selectCurrentRole = createSelector(
-    selectExerciseStateMode,
     selectOwnClient,
-    (mode, ownClient) => (mode === 'exercise' ? ownClient!.role : mode)
+    (ownClient) => ownClient!.role
+);
+
+export const selectCurrentMainRole = createSelector(
+    selectCurrentRole,
+    (currentRole) => currentRole.mainRole
 );
 
 export const selectRestrictedViewport = createSelector(

--- a/shared/src/models/client-role.ts
+++ b/shared/src/models/client-role.ts
@@ -1,0 +1,29 @@
+import { IsLiteralUnion, IsValue } from '../utils/validators/index.js';
+import type { Role } from './utils/index.js';
+import { getCreate } from './utils/index.js';
+import {
+    roleAllowedValues,
+    type SpecificRole,
+    specificRolesAllowedValues,
+} from './utils/role.js';
+
+export class ClientRole {
+    @IsValue('clientrole' as const)
+    public readonly type = 'clientrole';
+
+    @IsLiteralUnion(roleAllowedValues)
+    public readonly mainRole: Role;
+
+    @IsLiteralUnion(specificRolesAllowedValues)
+    public readonly specificRole: SpecificRole | null;
+
+    /**
+     * @deprecated Use {@link create} instead
+     */
+    constructor(mainRole: Role, specificRole: SpecificRole | null) {
+        this.mainRole = mainRole;
+        this.specificRole = specificRole;
+    }
+
+    static readonly create = getCreate(this);
+}

--- a/shared/src/models/client-role.ts
+++ b/shared/src/models/client-role.ts
@@ -15,12 +15,12 @@ export class ClientRole {
     public readonly mainRole: Role;
 
     @IsLiteralUnion(specificRolesAllowedValues)
-    public readonly specificRole: SpecificRole | null;
+    public readonly specificRole: SpecificRole;
 
     /**
      * @deprecated Use {@link create} instead
      */
-    constructor(mainRole: Role, specificRole: SpecificRole | null) {
+    constructor(mainRole: Role, specificRole: SpecificRole) {
         this.mainRole = mainRole;
         this.specificRole = specificRole;
     }

--- a/shared/src/models/client-role.ts
+++ b/shared/src/models/client-role.ts
@@ -4,17 +4,17 @@ import { getCreate } from './utils/index.js';
 import {
     roleAllowedValues,
     type SpecificRole,
-    specificRolesAllowedValues,
+    specificRoleAllowedValues,
 } from './utils/role.js';
 
 export class ClientRole {
-    @IsValue('clientrole' as const)
-    public readonly type = 'clientrole';
+    @IsValue('clientRole' as const)
+    public readonly type = 'clientRole';
 
     @IsLiteralUnion(roleAllowedValues)
     public readonly mainRole: Role;
 
-    @IsLiteralUnion(specificRolesAllowedValues)
+    @IsLiteralUnion(specificRoleAllowedValues)
     public readonly specificRole: SpecificRole;
 
     /**

--- a/shared/src/models/client.ts
+++ b/shared/src/models/client.ts
@@ -4,13 +4,14 @@ import {
     IsString,
     IsUUID,
     MaxLength,
+    ValidateNested,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 import type { UUID } from '../utils/index.js';
 import { uuid, uuidValidationOptions } from '../utils/index.js';
-import { IsLiteralUnion, IsValue } from '../utils/validators/index.js';
-import type { Role } from './utils/index.js';
+import { IsValue } from '../utils/validators/index.js';
 import { getCreate } from './utils/index.js';
-import { roleAllowedValues } from './utils/role.js';
+import { ClientRole } from './client-role.js';
 
 export class Client {
     @IsUUID(4, uuidValidationOptions)
@@ -24,8 +25,9 @@ export class Client {
     @MaxLength(255)
     public readonly name: string;
 
-    @IsLiteralUnion(roleAllowedValues)
-    public readonly role: Role;
+    @ValidateNested()
+    @Type(() => ClientRole)
+    public readonly role: ClientRole;
 
     @IsUUID(4, uuidValidationOptions)
     @IsOptional()
@@ -37,11 +39,15 @@ export class Client {
     /**
      * @deprecated Use {@link create} instead
      */
-    constructor(name: string, role: Role, viewRestrictedToViewportId?: UUID) {
+    constructor(
+        name: string,
+        role: ClientRole,
+        viewRestrictedToViewportId?: UUID
+    ) {
         this.name = name;
         this.role = role;
         this.viewRestrictedToViewportId = viewRestrictedToViewportId;
-        this.isInWaitingRoom = this.role === 'participant';
+        this.isInWaitingRoom = this.role.mainRole === 'participant';
     }
 
     static readonly create = getCreate(this);

--- a/shared/src/models/client.ts
+++ b/shared/src/models/client.ts
@@ -42,17 +42,13 @@ export class Client {
     constructor(
         name: string,
         role: ClientRole,
+        isInWaitingRoom?: boolean,
         viewRestrictedToViewportId?: UUID
     ) {
         this.name = name;
         this.role = role;
         this.viewRestrictedToViewportId = viewRestrictedToViewportId;
-        this.isInWaitingRoom =
-            // class-transformer likes to pass undefined here
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-            this.role !== undefined
-                ? this.role.mainRole === 'participant'
-                : true;
+        this.isInWaitingRoom = isInWaitingRoom ?? true;
     }
 
     static readonly create = getCreate(this);

--- a/shared/src/models/client.ts
+++ b/shared/src/models/client.ts
@@ -47,7 +47,12 @@ export class Client {
         this.name = name;
         this.role = role;
         this.viewRestrictedToViewportId = viewRestrictedToViewportId;
-        this.isInWaitingRoom = this.role.mainRole === 'participant';
+        this.isInWaitingRoom =
+            // class-transformer likes to pass undefined here
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            this.role !== undefined
+                ? this.role.mainRole === 'participant'
+                : true;
     }
 
     static readonly create = getCreate(this);

--- a/shared/src/models/index.ts
+++ b/shared/src/models/index.ts
@@ -9,6 +9,7 @@ export { Material } from './material.js';
 export { Patient } from './patient.js';
 export * from './patient-health-state.js';
 export { PatientTemplate } from './patient-template.js';
+export { ClientRole } from './client-role.js';
 export { Personnel } from './personnel.js';
 export { TransferPoint } from './transfer-point.js';
 export { Vehicle } from './vehicle.js';

--- a/shared/src/models/utils/role.ts
+++ b/shared/src/models/utils/role.ts
@@ -5,3 +5,9 @@ export const roleAllowedValues: AllowedValues<Role> = {
     participant: true,
     trainer: true,
 };
+export type SpecificRole = 'eoc' | 'map-operator' | 'trainer';
+export const specificRolesAllowedValues: AllowedValues<SpecificRole> = {
+    'map-operator': true,
+    eoc: true,
+    trainer: true,
+};

--- a/shared/src/models/utils/role.ts
+++ b/shared/src/models/utils/role.ts
@@ -5,9 +5,9 @@ export const roleAllowedValues: AllowedValues<Role> = {
     participant: true,
     trainer: true,
 };
-export type SpecificRole = 'eoc' | 'map-operator' | 'trainer';
-export const specificRolesAllowedValues: AllowedValues<SpecificRole> = {
-    'map-operator': true,
+export type SpecificRole = 'eoc' | 'mapOperator' | 'trainer';
+export const specificRoleAllowedValues: AllowedValues<SpecificRole> = {
+    mapOperator: true,
     eoc: true,
     trainer: true,
 };

--- a/shared/src/state-migrations/42-replace-clientroles.ts
+++ b/shared/src/state-migrations/42-replace-clientroles.ts
@@ -1,0 +1,43 @@
+import type { UUID } from '../utils/index.js';
+import type { Migration } from './migration-functions.js';
+
+type OldRole = 'participant' | 'trainer';
+
+interface ClientRole {
+    type: 'clientrole';
+    mainRole: 'participant' | 'trainer';
+    specificRole: 'map-operator' | 'trainer';
+}
+
+interface Client {
+    role: /* new */ ClientRole | /* old */ OldRole;
+}
+
+function migrateClientRole(oldRole: OldRole): ClientRole {
+    return {
+        type: 'clientrole',
+        mainRole: oldRole,
+        specificRole: oldRole === 'trainer' ? 'trainer' : 'map-operator',
+    };
+}
+
+export const addPatientTransportPriority41: Migration = {
+    action: (_, action) => {
+        if ((action as { type: string }).type === '[Client] Add client') {
+            const client = (action as { client: Client }).client;
+            client.role = migrateClientRole(client.role as OldRole);
+        }
+        return true;
+    },
+    state: (state) => {
+        const typedState = state as {
+            clients: {
+                [clientId: UUID]: Client;
+            };
+        };
+
+        Object.values(typedState.clients).forEach((client) => {
+            client.role = migrateClientRole(client.role as OldRole);
+        });
+    },
+};

--- a/shared/src/state-migrations/42-replace-clientroles.ts
+++ b/shared/src/state-migrations/42-replace-clientroles.ts
@@ -4,9 +4,9 @@ import type { Migration } from './migration-functions.js';
 type OldRole = 'participant' | 'trainer';
 
 interface ClientRole {
-    type: 'clientrole';
+    type: 'clientRole';
     mainRole: 'participant' | 'trainer';
-    specificRole: 'map-operator' | 'trainer';
+    specificRole: 'mapOperator' | 'trainer';
 }
 
 interface Client {
@@ -15,9 +15,9 @@ interface Client {
 
 function migrateClientRole(oldRole: OldRole): ClientRole {
     return {
-        type: 'clientrole',
+        type: 'clientRole',
         mainRole: oldRole,
-        specificRole: oldRole === 'trainer' ? 'trainer' : 'map-operator',
+        specificRole: oldRole === 'trainer' ? 'trainer' : 'mapOperator',
     };
 }
 

--- a/shared/src/state-migrations/42-replace-clientroles.ts
+++ b/shared/src/state-migrations/42-replace-clientroles.ts
@@ -21,7 +21,7 @@ function migrateClientRole(oldRole: OldRole): ClientRole {
     };
 }
 
-export const addPatientTransportPriority41: Migration = {
+export const replaceClientRoles42: Migration = {
     action: (_, action) => {
         if ((action as { type: string }).type === '[Client] Add client') {
             const client = (action as { client: Client }).client;

--- a/shared/src/state-migrations/migration-functions.ts
+++ b/shared/src/state-migrations/migration-functions.ts
@@ -38,6 +38,7 @@ import { treatmentSystemImprovements8 } from './8-treatment-system-improvements.
 import { removeIsBeingTreated9 } from './9-remove-is-being-treated.js';
 import { impossibleMigration } from './impossible-migration.js';
 import { addPatientTransportPriority41 } from './41-add-patient-transport-prio.js';
+import { replaceClientRoles42 } from './42-replace-clientroles.js';
 
 /**
  * Migrate a single action
@@ -105,4 +106,5 @@ export const migrations: {
     39: addCustomPatientQRCode39,
     40: adaptInterfaceSignallerUI40,
     41: addPatientTransportPriority41,
+    42: replaceClientRoles42,
 };

--- a/shared/src/state.ts
+++ b/shared/src/state.ts
@@ -188,5 +188,5 @@ export class ExerciseState {
      *
      * This number MUST be increased every time a change to any object (that is part of the state or the state itself) is made in a way that there may be states valid before that are no longer valid.
      */
-    static readonly currentStateVersion = 41;
+    static readonly currentStateVersion = 42;
 }

--- a/shared/src/store/action-reducer.ts
+++ b/shared/src/store/action-reducer.ts
@@ -1,11 +1,12 @@
 import type { Role } from '../models/utils/index.js';
+import type { SpecificRole } from '../models/utils/role.js';
 import type { ExerciseState } from '../state.js';
 import type { Constructor, Mutable } from '../utils/index.js';
 
 export interface ActionReducer<A extends Action = Action> {
     readonly action: Constructor<A>;
     readonly reducer: ReducerFunction<InstanceType<this['action']>>;
-    readonly rights: Role | 'server';
+    readonly rights: Role | SpecificRole | 'server';
 }
 
 /**

--- a/shared/src/store/action-reducers/client.ts
+++ b/shared/src/store/action-reducers/client.ts
@@ -6,7 +6,7 @@ import { cloneDeepMutable, uuidValidationOptions } from '../../utils/index.js';
 import { IsLiteralUnion, IsValue } from '../../utils/validators/index.js';
 import type { Action, ActionReducer } from '../action-reducer.js';
 import type { SpecificRole } from '../../models/utils/role.js';
-import { specificRolesAllowedValues } from '../../models/utils/role.js';
+import { specificRoleAllowedValues } from '../../models/utils/role.js';
 import { getElement } from './utils/get-element.js';
 
 export class AddClientAction implements Action {
@@ -48,7 +48,7 @@ export class ChangeSpecificClientRoleAction implements Action {
     public readonly type = '[Client] Change specific client role';
     @IsUUID(4, uuidValidationOptions)
     public readonly clientId!: UUID;
-    @IsLiteralUnion(specificRolesAllowedValues)
+    @IsLiteralUnion(specificRoleAllowedValues)
     public readonly newRole!: SpecificRole;
 }
 

--- a/shared/src/store/action-reducers/client.ts
+++ b/shared/src/store/action-reducers/client.ts
@@ -3,8 +3,10 @@ import { IsBoolean, IsOptional, IsUUID, ValidateNested } from 'class-validator';
 import { Client } from '../../models/client.js';
 import type { UUID } from '../../utils/index.js';
 import { cloneDeepMutable, uuidValidationOptions } from '../../utils/index.js';
-import { IsValue } from '../../utils/validators/index.js';
+import { IsLiteralUnion, IsValue } from '../../utils/validators/index.js';
 import type { Action, ActionReducer } from '../action-reducer.js';
+import type { SpecificRole } from '../../models/utils/role.js';
+import { specificRolesAllowedValues } from '../../models/utils/role.js';
 import { getElement } from './utils/get-element.js';
 
 export class AddClientAction implements Action {
@@ -39,6 +41,15 @@ export class SetWaitingRoomAction implements Action {
     public readonly clientId!: UUID;
     @IsBoolean()
     public readonly shouldBeInWaitingRoom!: boolean;
+}
+
+export class ChangeSpecificClientRoleAction implements Action {
+    @IsValue('[Client] Change specific client role' as const)
+    public readonly type = '[Client] Change specific client role';
+    @IsUUID(4, uuidValidationOptions)
+    public readonly clientId!: UUID;
+    @IsLiteralUnion(specificRolesAllowedValues)
+    public readonly newRole!: SpecificRole;
 }
 
 export namespace ClientActionReducers {
@@ -86,4 +97,15 @@ export namespace ClientActionReducers {
         },
         rights: 'trainer',
     };
+
+    export const changeSpecificClientRole: ActionReducer<ChangeSpecificClientRoleAction> =
+        {
+            action: ChangeSpecificClientRoleAction,
+            reducer: (draftState, { clientId, newRole }) => {
+                const client = getElement(draftState, 'client', clientId);
+                client.role.specificRole = newRole;
+                return draftState;
+            },
+            rights: 'trainer',
+        };
 }

--- a/shared/src/store/validate-permissions.ts
+++ b/shared/src/store/validate-permissions.ts
@@ -28,10 +28,7 @@ export function validatePermissions(
     ) {
         return true;
     }
-    if (
-        client.role.mainRole === 'trainer' ||
-        client.role.specificRole === rights
-    ) {
+    if (client.role.mainRole === rights) {
         return true;
     }
 

--- a/shared/src/store/validate-permissions.ts
+++ b/shared/src/store/validate-permissions.ts
@@ -18,13 +18,10 @@ export function validatePermissions(
     state: ExerciseState
 ) {
     const rights = exerciseActionTypeDictionary[action.type].rights;
-    // Check role permissions
-    if (
-        (client.role === 'participant' && rights !== 'participant') ||
-        rights === 'server'
-    ) {
-        return false;
-    }
-    // TODO: Validate e.g. only actions in own viewport
-    return true;
+
+    if (rights === 'server') return false;
+    if (rights === client.role.mainRole || rights === client.role.specificRole)
+        return true;
+
+    return false;
 }

--- a/shared/src/store/validate-permissions.ts
+++ b/shared/src/store/validate-permissions.ts
@@ -19,9 +19,21 @@ export function validatePermissions(
 ) {
     const rights = exerciseActionTypeDictionary[action.type].rights;
 
-    if (rights === 'server') return false;
-    if (rights === client.role.mainRole || rights === client.role.specificRole)
+    if (rights === 'server') {
+        return false;
+    }
+    if (
+        client.role.mainRole === 'participant' &&
+        (rights === 'participant' || rights === client.role.specificRole)
+    ) {
         return true;
+    }
+    if (
+        client.role.mainRole === 'trainer' ||
+        client.role.specificRole === rights
+    ) {
+        return true;
+    }
 
     return false;
 }

--- a/shared/src/store/validate-permissions.ts
+++ b/shared/src/store/validate-permissions.ts
@@ -28,7 +28,7 @@ export function validatePermissions(
     ) {
         return true;
     }
-    if (client.role.mainRole === rights) {
+    if (client.role.mainRole === 'trainer') {
         return true;
     }
 


### PR DESCRIPTION
This PR adds a `ClientRole` class which is used to replace and extend the current role-system.
It extends the binary `trainer | participant` to a `mainRole: 'trainer' | 'participant'`, and `specificRole` which can be used to differentiate between different participant types (EOC, interface signallers, ...) and to show different views/interfaces based on the `specificRole`.

See https://github.com/hpi-sam/digital-fuesim-manv/pull/1125#discussion_r2469943874

Test-Scenarios in https://github.com/hpi-sam/digital-fuesim-manv-public-test-scenarios/pull/20

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [X] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [X] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/digital-fuesim-manv-public-test-scenarios) have been added.
- [x] I have the right to license the code submitted with this Pull Request under the mentioned license in the file [LICENSE-README.md](LICENSE-README.md) (i.e., this is my
      own code or code licensed under a license compatible to AGPL v3.0 or later, for exceptions look into [LICENSE-README.md](LICENSE-README.md)) and
      hereby license the code in this Pull Request under it.
      I certify that by signing off my commits (see In case of using third party code, I have given appropriate credit.
      We are using DCO for that, see [here](https://github.com/dcoapp/app#how-it-works) for more information.
- [x] If I have used third party code and I mentioned it in the code, I also updated the [inspired-by-or-copied-from-list.html](inspired-by-or-copied-from-list.html) list to include the links.
