### PR TITLE
Use npm 11 and ensure up-to-date lockfiles

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -44,7 +44,7 @@
             },
             "engines": {
                 "node": ">=22",
-                "npm": ">=10"
+                "npm": ">=11"
             }
         },
         "../shared": {
@@ -81,7 +81,7 @@
             },
             "engines": {
                 "node": ">=22",
-                "npm": ">=10"
+                "npm": ">=11"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -115,6 +115,7 @@
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,7 +32,7 @@
     "private": true,
     "engines": {
         "node": ">=22",
-        "npm": ">=10"
+        "npm": ">=11"
     },
     "dependencies": {
         "class-transformer": "^0.5.1",

--- a/benchmark/package-lock.json
+++ b/benchmark/package-lock.json
@@ -28,7 +28,7 @@
             },
             "engines": {
                 "node": ">=22",
-                "npm": ">=10"
+                "npm": ">=11"
             }
         },
         "../shared": {
@@ -65,7 +65,7 @@
             },
             "engines": {
                 "node": ">=22",
-                "npm": ">=10"
+                "npm": ">=11"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -12,7 +12,7 @@
     "private": true,
     "engines": {
         "node": ">=22",
-        "npm": ">=10"
+        "npm": ">=11"
     },
     "dependencies": {
         "digital-fuesim-manv-shared": "file:../shared",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -61,7 +61,7 @@
             },
             "engines": {
                 "node": ">=22",
-                "npm": ">=10"
+                "npm": ">=11"
             }
         },
         "../shared": {
@@ -98,7 +98,7 @@
             },
             "engines": {
                 "node": ">=22",
-                "npm": ">=10"
+                "npm": ">=11"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -792,6 +792,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
             "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.26.2",
@@ -5090,6 +5091,7 @@
             "integrity": "sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.33.1",
                 "@typescript-eslint/types": "8.33.1",
@@ -15835,6 +15837,7 @@
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "private": true,
     "engines": {
         "node": ">=22",
-        "npm": ">=10"
+        "npm": ">=11"
     },
     "dependencies": {
         "@angular/animations": "~19.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
             },
             "engines": {
                 "node": ">=22",
-                "npm": ">=10"
+                "npm": ">=11"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "private": true,
     "engines": {
         "node": ">=22",
-        "npm": ">=10"
+        "npm": ">=11"
     },
     "devDependencies": {
         "@weichwarenprojekt/license-reporter": "^1.0.0",

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -38,7 +38,7 @@
             },
             "engines": {
                 "node": ">=22",
-                "npm": ">=10"
+                "npm": ">=11"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -72,6 +72,7 @@
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",

--- a/shared/package.json
+++ b/shared/package.json
@@ -22,7 +22,7 @@
     "private": true,
     "engines": {
         "node": ">=22",
-        "npm": ">=10"
+        "npm": ">=11"
     },
     "dependencies": {
         "@noble/hashes": "^1.7.1",


### PR DESCRIPTION
After #1158, the lockfiles were not up-to-date and running `npm run install:all` caused changes to them.

Since the changes were different depending on the `npm` version used, I've also updated the required npm version to ensure consistent lockfiles.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/digital-fuesim-manv-public-test-scenarios) have been added.
- [x] I have the right to license the code submitted with this Pull Request under the mentioned license in the file [LICENSE-README.md](LICENSE-README.md) (i.e., this is my
      own code or code licensed under a license compatible to AGPL v3.0 or later, for exceptions look into [LICENSE-README.md](LICENSE-README.md)) and
      hereby license the code in this Pull Request under it.
      I certify that by signing off my commits (see In case of using third party code, I have given appropriate credit.
      We are using DCO for that, see [here](https://github.com/dcoapp/app#how-it-works) for more information.
- [x] If I have used third party code and I mentioned it in the code, I also updated the [inspired-by-or-copied-from-list.html](inspired-by-or-copied-from-list.html) list to include the links.
