### PR TITLE
Fixup Webstrom Configuration

### DIFF
--- a/.idea/digital-fuesim-manv.iml
+++ b/.idea/digital-fuesim-manv.iml
@@ -12,6 +12,8 @@
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.vscode" />
       <excludeFolder url="file://$MODULE_DIR$/backend/coverage" />
+      <excludeFolder url="file://$MODULE_DIR$/shared/coverage" />
+      <excludeFolder url="file://$MODULE_DIR$/frontend/coverage" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.idea/runConfigurations/test_backend.xml
+++ b/.idea/runConfigurations/test_backend.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="test-backend" type="JavaScriptTestRunnerJest">
+    <config-file value="$PROJECT_DIR$/backend/jest.config.js" />
+    <node-interpreter value="project" />
+    <node-options value="--experimental-vm-modules" />
+    <jest-package value="$PROJECT_DIR$/backend/node_modules/jest" />
+    <working-dir value="$PROJECT_DIR$/backend" />
+    <jest-options value="--runInBand --coverage --verbose" />
+    <envs />
+    <scope-kind value="ALL" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/test_frontend.xml
+++ b/.idea/runConfigurations/test_frontend.xml
@@ -2,6 +2,7 @@
   <configuration default="false" name="test-frontend" type="JavaScriptTestRunnerJest">
     <config-file value="$PROJECT_DIR$/frontend/jest.config.js" />
     <node-interpreter value="project" />
+    <node-options value="--experimental-vm-modules" />
     <jest-package value="$PROJECT_DIR$/frontend/node_modules/jest" />
     <working-dir value="$PROJECT_DIR$/frontend" />
     <jest-options value="--runInBand --coverage --verbose" />


### PR DESCRIPTION
This PR:

 - adds the missing run configuration for backend tests
 - fixes the run configuration for frontend tests (missing --experimental-vm-modules flag)
 - additionally ignores the shared & frontend "coverage" subdirectories to make searching easier