### PR TITLE
fix error with state-export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
-### Fixed
-
-- Exporting the history of an exercise no longer fails silently.
-
 ## [0.10.0] - 2025-12-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+### Fixed
+
+- Exporting the history of an exercise no longer fails silently.
+
 ## [0.10.0] - 2025-12-08
 
 ### Added

--- a/backend/src/database/services/exercise-service.ts
+++ b/backend/src/database/services/exercise-service.ts
@@ -179,7 +179,7 @@ export class ExerciseService {
             throw new UnknownExerciseError(exerciseKey);
         const completeHistory: ExerciseTimeline['actionsWrappers'] = [
             ...(
-                await this.actionRepository.getActionsForExerciseId(exerciseKey)
+                await this.actionRepository.getActionsForExerciseId(activeExercise.exerciseId)
             ).map((action) => ({
                 action: action.actionString,
                 emitterId: action.emitterId,

--- a/backend/src/database/services/exercise-service.ts
+++ b/backend/src/database/services/exercise-service.ts
@@ -179,7 +179,9 @@ export class ExerciseService {
             throw new UnknownExerciseError(exerciseKey);
         const completeHistory: ExerciseTimeline['actionsWrappers'] = [
             ...(
-                await this.actionRepository.getActionsForExerciseId(activeExercise.exerciseId)
+                await this.actionRepository.getActionsForExerciseId(
+                    activeExercise.exerciseId
+                )
             ).map((action) => ({
                 action: action.actionString,
                 emitterId: action.emitterId,

--- a/backend/test/http-exercise.spec.ts
+++ b/backend/test/http-exercise.spec.ts
@@ -106,20 +106,19 @@ describe('exercise', () => {
         });
     });
 
-    describe("GET /api/exercise/:exerciseId/history", () => {
-        it("returns history for existing exercise", async ()=> {
+    describe('GET /api/exercise/:exerciseId/history', () => {
+        it('returns history for existing exercise', async () => {
             const exerciseId = (await createExercise(environment)).trainerId;
             await environment
                 .httpRequest('get', `/api/exercise/${exerciseId}/history`)
                 .expect(200);
-        })
+        });
 
-        it("fails with 404 for non-existing exercise", async ()=> {
+        it('fails with 404 for non-existing exercise', async () => {
             const exerciseId = 'non-existing-id';
             await environment
                 .httpRequest('get', `/api/exercise/${exerciseId}/history`)
                 .expect(404);
-        })
-
+        });
     });
-})
+});

--- a/backend/test/http-exercise.spec.ts
+++ b/backend/test/http-exercise.spec.ts
@@ -105,4 +105,21 @@ describe('exercise', () => {
             });
         });
     });
-});
+
+    describe("GET /api/exercise/:exerciseId/history", () => {
+        it("returns history for existing exercise", async ()=> {
+            const exerciseId = (await createExercise(environment)).trainerId;
+            await environment
+                .httpRequest('get', `/api/exercise/${exerciseId}/history`)
+                .expect(200);
+        })
+
+        it("fails with 404 for non-existing exercise", async ()=> {
+            const exerciseId = 'non-existing-id';
+            await environment
+                .httpRequest('get', `/api/exercise/${exerciseId}/history`)
+                .expect(404);
+        })
+
+    });
+})

--- a/frontend/src/app/core/api.service.ts
+++ b/frontend/src/app/core/api.service.ts
@@ -22,7 +22,7 @@ export class ApiService {
         private readonly store: Store<AppState>,
         private readonly messageService: MessageService,
         private readonly httpClient: HttpClient
-    ) {}
+    ) { }
 
     public async createExercise() {
         return lastValueFrom(
@@ -48,7 +48,13 @@ export class ApiService {
             this.httpClient.get<ExerciseTimeline>(
                 `${httpOrigin}/api/exercise/${exerciseId}/history`
             )
-        ).then((value) => freeze(value, true));
+        ).then((value) => freeze(value, true)).catch((error) => {
+            this.messageService.postError({
+                title: 'Fehler beim Laden der Übungshistorie',
+                body: "Der Server konnte keine Übungshistorie bereitstellen.",
+            });
+            throw error;
+        });
     }
 
     public async deleteExercise(trainerId: string) {

--- a/frontend/src/app/core/api.service.ts
+++ b/frontend/src/app/core/api.service.ts
@@ -22,7 +22,7 @@ export class ApiService {
         private readonly store: Store<AppState>,
         private readonly messageService: MessageService,
         private readonly httpClient: HttpClient
-    ) { }
+    ) {}
 
     public async createExercise() {
         return lastValueFrom(
@@ -48,13 +48,15 @@ export class ApiService {
             this.httpClient.get<ExerciseTimeline>(
                 `${httpOrigin}/api/exercise/${exerciseId}/history`
             )
-        ).then((value) => freeze(value, true)).catch((error) => {
-            this.messageService.postError({
-                title: 'Fehler beim Laden der Übungshistorie',
-                body: "Der Server konnte keine Übungshistorie bereitstellen.",
+        )
+            .then((value) => freeze(value, true))
+            .catch((error) => {
+                this.messageService.postError({
+                    title: 'Fehler beim Laden der Übungshistorie',
+                    body: 'Der Server konnte keine Übungshistorie bereitstellen.',
+                });
+                throw error;
             });
-            throw error;
-        });
     }
 
     public async deleteExercise(trainerId: string) {


### PR DESCRIPTION
This PR fixes #1200 so that exercise history exports no longer fail.

- it also adds an error-toast-message to signal to the user that a history-export has failed
- and 2 new simple test cases for history exports


### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/digital-fuesim-manv-public-test-scenarios) have been added.
- [x] I have the right to license the code submitted with this Pull Request under the mentioned license in the file [LICENSE-README.md](LICENSE-README.md) (i.e., this is my
      own code or code licensed under a license compatible to AGPL v3.0 or later, for exceptions look into [LICENSE-README.md](LICENSE-README.md)) and
      hereby license the code in this Pull Request under it.
      I certify that by signing off my commits (see In case of using third party code, I have given appropriate credit.
      We are using DCO for that, see [here](https://github.com/dcoapp/app#how-it-works) for more information.
- [x] If I have used third party code and I mentioned it in the code, I also updated the [inspired-by-or-copied-from-list.html](inspired-by-or-copied-from-list.html) list to include the links.
