### PR TITLE
Use branded types for ids/keys in backend

### DIFF
--- a/backend/src/database/migrate-in-database.ts
+++ b/backend/src/database/migrate-in-database.ts
@@ -2,15 +2,15 @@ import type {
     ExerciseAction,
     ExerciseState,
     Mutable,
-    UUID,
 } from 'digital-fuesim-manv-shared';
 import { applyMigrations } from 'digital-fuesim-manv-shared';
 import { RestoreError } from '../utils/restore-error.js';
 import type { ExerciseRepository } from './repositories/exercise-repository.js';
 import type { ActionRepository } from './repositories/action-repository.js';
+import type { ExerciseId } from './schema.js';
 
 export async function migrateInDatabase(
-    exerciseId: UUID,
+    exerciseId: ExerciseId,
     exerciseRepository: ExerciseRepository,
     actionRepository: ActionRepository
 ): Promise<void> {

--- a/backend/src/database/repositories/action-repository.ts
+++ b/backend/src/database/repositories/action-repository.ts
@@ -1,12 +1,12 @@
 import { eq, asc, and, inArray } from 'drizzle-orm';
 import type { ExerciseAction } from 'digital-fuesim-manv-shared';
-import { actionTable } from '../schema.js';
+import { actionTable, type ExerciseId } from '../schema.js';
 import type { ActionWrapper } from '../../exercise/action-wrapper.js';
 import { BaseRepository } from './base-repository.js';
 import { DatabaseService } from './../services/database-service.js';
 
 export class ActionRepository extends BaseRepository {
-    public async getActionsForExerciseId(exerciseId: string) {
+    public async getActionsForExerciseId(exerciseId: ExerciseId) {
         return this.databaseConnection
             .select()
             .from(actionTable)
@@ -14,7 +14,7 @@ export class ActionRepository extends BaseRepository {
             .orderBy(asc(actionTable.index));
     }
 
-    public async deleteAllForExercise(exerciseId: string) {
+    public async deleteAllForExercise(exerciseId: ExerciseId) {
         await this.databaseConnection
             .delete(actionTable)
             .where(eq(actionTable.exerciseId, exerciseId));
@@ -67,7 +67,7 @@ export class ActionRepository extends BaseRepository {
     }
 
     public async updateActionIndex(
-        exerciseId: string,
+        exerciseId: ExerciseId,
         previousIndex: number,
         newIndex: number,
         actionString: ExerciseAction
@@ -87,7 +87,7 @@ export class ActionRepository extends BaseRepository {
     }
 
     public async deleteActionIndices(
-        exerciseId: string,
+        exerciseId: ExerciseId,
         indicesToRemove: number[]
     ) {
         return this.databaseConnection

--- a/backend/src/database/repositories/exercise-repository.ts
+++ b/backend/src/database/repositories/exercise-repository.ts
@@ -46,7 +46,7 @@ export class ExerciseRepository extends BaseRepository {
         return this.databaseConnection.select().from(exerciseTable);
     }
 
-    public deleteExerciseById(uuid: ExerciseId) {
+    public deleteExerciseById(id: ExerciseId) {
         return this.databaseConnection
             .delete(exerciseTable)
             .where(eq(exerciseTable.id, uuid));

--- a/backend/src/database/repositories/exercise-repository.ts
+++ b/backend/src/database/repositories/exercise-repository.ts
@@ -1,12 +1,13 @@
 import { ExerciseState } from 'digital-fuesim-manv-shared';
 import type { InferInsertModel } from 'drizzle-orm';
 import { eq, lt } from 'drizzle-orm';
+import type { ExerciseId} from '../schema.js';
 import { exerciseTable } from '../schema.js';
 import type { ActiveExercise } from '../../exercise/active-exercise.js';
 import { BaseRepository } from './base-repository.js';
 
 export class ExerciseRepository extends BaseRepository {
-    public getExerciseById(id: string) {
+    public getExerciseById(id: ExerciseId) {
         return this.databaseConnection
             .select()
             .from(exerciseTable)
@@ -41,7 +42,7 @@ export class ExerciseRepository extends BaseRepository {
         return this.databaseConnection.select().from(exerciseTable);
     }
 
-    public deleteExerciseById(uuid: string) {
+    public deleteExerciseById(uuid: ExerciseId) {
         return this.databaseConnection
             .delete(exerciseTable)
             .where(eq(exerciseTable.id, uuid));
@@ -63,7 +64,7 @@ export class ExerciseRepository extends BaseRepository {
     }
 
     public async saveExerciseState(
-        exerciseId: string,
+        exerciseId: ExerciseId,
         exercisePatch: InferInsertModel<typeof exerciseTable>
     ) {
         const exercisePatchWithId = {

--- a/backend/src/database/repositories/exercise-repository.ts
+++ b/backend/src/database/repositories/exercise-repository.ts
@@ -46,10 +46,10 @@ export class ExerciseRepository extends BaseRepository {
         return this.databaseConnection.select().from(exerciseTable);
     }
 
-    public deleteExerciseById(id: ExerciseId) {
+    public deleteExerciseById(exerciseId: ExerciseId) {
         return this.databaseConnection
             .delete(exerciseTable)
-            .where(eq(exerciseTable.id, uuid));
+            .where(eq(exerciseTable.id, exerciseId));
     }
 
     /**

--- a/backend/src/database/repositories/exercise-repository.ts
+++ b/backend/src/database/repositories/exercise-repository.ts
@@ -1,7 +1,7 @@
 import { ExerciseState } from 'digital-fuesim-manv-shared';
 import type { InferInsertModel } from 'drizzle-orm';
 import { eq, lt } from 'drizzle-orm';
-import type { ExerciseId} from '../schema.js';
+import type { ExerciseId } from '../schema.js';
 import { exerciseTable } from '../schema.js';
 import type { ActiveExercise } from '../../exercise/active-exercise.js';
 import { BaseRepository } from './base-repository.js';

--- a/backend/src/database/repositories/exercise-repository.ts
+++ b/backend/src/database/repositories/exercise-repository.ts
@@ -4,6 +4,10 @@ import { eq, lt } from 'drizzle-orm';
 import type { ExerciseId } from '../schema.js';
 import { exerciseTable } from '../schema.js';
 import type { ActiveExercise } from '../../exercise/active-exercise.js';
+import type {
+    ParticipantKey,
+    TrainerKey,
+} from '../../exercise/exercise-keys.js';
 import { BaseRepository } from './base-repository.js';
 
 export class ExerciseRepository extends BaseRepository {
@@ -17,7 +21,7 @@ export class ExerciseRepository extends BaseRepository {
     /**
      * Loads the exercise with the corresponding trainer key
      */
-    public async getExerciseByTrainerKey(trainerKey: string) {
+    public async getExerciseByTrainerKey(trainerKey: TrainerKey) {
         const dbResult = await this.databaseConnection
             .select()
             .from(exerciseTable)
@@ -29,7 +33,7 @@ export class ExerciseRepository extends BaseRepository {
     /**
      * Loads the exercise with the corresponding participant key
      */
-    public async getExerciseByParticipantKey(participantKey: string) {
+    public async getExerciseByParticipantKey(participantKey: ParticipantKey) {
         const dbResult = await this.databaseConnection
             .select()
             .from(exerciseTable)

--- a/backend/src/database/schema.ts
+++ b/backend/src/database/schema.ts
@@ -10,16 +10,27 @@ import {
     bigint,
     foreignKey,
 } from 'drizzle-orm/pg-core';
+import { z } from 'zod';
 
-const baseTable = {
-    id: uuid()
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const exerciseIdSchema = z.uuidv4().brand<'ExerciseId'>();
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const actionIdSchema = z.uuidv4().brand<'ActionId'>();
+
+export type ExerciseId = z.infer<typeof exerciseIdSchema>;
+export type ActionId = z.infer<typeof actionIdSchema>;
+
+const typedUUID = <T>() => uuid().$type<T>();
+
+const baseTable = <T>() => ({
+    id: typedUUID<T>()
         .default(sql`uuid_generate_v4()`)
         .primaryKey()
         .notNull(),
-};
+});
 
 export const exerciseTable = pgTable('exercise_entity', {
-    ...baseTable,
+    ...baseTable<ExerciseId>(),
     tickCounter: integer().default(0).notNull(),
     initialStateString: json().$type<ExerciseState>().notNull(),
     participantId: char({ length: 6 }).notNull(),
@@ -32,12 +43,12 @@ export type ExerciseEntry = InferSelectModel<typeof exerciseTable>;
 export const actionTable = pgTable(
     'action_entity',
     {
-        ...baseTable,
+        ...baseTable<ActionId>(),
         emitterId: uuid(),
         // You can use { mode: "bigint" } if numbers are exceeding js number limitations
         index: bigint({ mode: 'number' }).notNull(),
         actionString: json().$type<ExerciseAction>().notNull(),
-        exerciseId: uuid().notNull(),
+        exerciseId: typedUUID<ExerciseId>().notNull(),
     },
     (table) => [
         foreignKey({

--- a/backend/src/database/services/exercise-service.ts
+++ b/backend/src/database/services/exercise-service.ts
@@ -8,6 +8,7 @@ import { UserReadableIdGenerator } from '../../utils/user-readable-id-generator.
 import { migrateInDatabase } from '../migrate-in-database.js';
 import type { ActionRepository } from '../repositories/action-repository.js';
 import type { ExerciseRepository } from '../repositories/exercise-repository.js';
+import type { ExerciseKey } from '../../exercise/exercise-keys.js';
 
 export class ExerciseService {
     public constructor(
@@ -15,14 +16,14 @@ export class ExerciseService {
         private readonly actionRepository: ActionRepository
     ) {}
 
-    private readonly exerciseMap = new Map<string, ActiveExercise>();
+    private readonly exerciseMap = new Map<ExerciseKey, ActiveExercise>();
 
-    public hasExerciseKey(exerciseKey: string) {
+    public hasExerciseKey(exerciseKey: ExerciseKey) {
         return this.exerciseMap.has(exerciseKey);
     }
 
-    public getExerciseByKey(roleKey: string) {
-        return this.exerciseMap.get(roleKey);
+    public getExerciseByKey(exerciseKey: ExerciseKey) {
+        return this.exerciseMap.get(exerciseKey);
     }
 
     public getAllExercises() {
@@ -38,16 +39,15 @@ export class ExerciseService {
             activeExercise.setExerciseId(result[0].id);
         }
 
-        const exercise = activeExercise.getExercise();
-        this.exerciseMap.set(exercise.participantId, activeExercise);
-        this.exerciseMap.set(exercise.trainerId, activeExercise);
+        this.exerciseMap.set(activeExercise.participantKey, activeExercise);
+        this.exerciseMap.set(activeExercise.trainerKey, activeExercise);
         UserReadableIdGenerator.lock([
-            exercise.participantId,
-            exercise.trainerId,
+            activeExercise.participantKey,
+            activeExercise.trainerKey,
         ]);
     }
 
-    public leaveExercise(exerciseKey: string, client: ClientWrapper) {
+    public leaveExercise(exerciseKey: ExerciseKey, client: ClientWrapper) {
         this.getExerciseByKey(exerciseKey)?.removeClient(client);
     }
 
@@ -116,14 +116,8 @@ export class ExerciseService {
                     )
                 );
                 exercises.forEach((exercise) => {
-                    this.exerciseMap.set(
-                        exercise.getExercise().participantId,
-                        exercise
-                    );
-                    this.exerciseMap.set(
-                        exercise.getExercise().trainerId,
-                        exercise
-                    );
+                    this.exerciseMap.set(exercise.participantKey, exercise);
+                    this.exerciseMap.set(exercise.trainerKey, exercise);
                 });
                 UserReadableIdGenerator.lock([...this.exerciseMap.keys()]);
                 return exercises;
@@ -131,7 +125,7 @@ export class ExerciseService {
         );
     }
 
-    public async deleteExercise(exerciseKey: string) {
+    public async deleteExercise(exerciseKey: ExerciseKey) {
         const activeExercise = this.getExerciseByKey(exerciseKey);
         if (!activeExercise) {
             throw new UnknownExerciseError(exerciseKey);
@@ -139,9 +133,8 @@ export class ExerciseService {
 
         activeExercise.destroy();
 
-        const exercise = activeExercise.getExercise();
-        this.exerciseMap.delete(exercise.participantId);
-        this.exerciseMap.delete(exercise.trainerId);
+        this.exerciseMap.delete(activeExercise.participantKey);
+        this.exerciseMap.delete(activeExercise.trainerKey);
         if (activeExercise.exerciseId) {
             // only delete if exercise has been saved before in database
             await this.exerciseRepository.deleteExerciseById(
@@ -173,7 +166,9 @@ export class ExerciseService {
         });
     }
 
-    public async getTimeline(exerciseKey: string): Promise<ExerciseTimeline> {
+    public async getTimeline(
+        exerciseKey: ExerciseKey
+    ): Promise<ExerciseTimeline> {
         const activeExercise = this.getExerciseByKey(exerciseKey);
         if (activeExercise === undefined)
             throw new UnknownExerciseError(exerciseKey);
@@ -202,14 +197,14 @@ export class ExerciseService {
         };
     }
 
-    public getRoleFromKey(id: string): Role {
-        switch (id.length) {
+    public getRoleFromKey(key: string): Role {
+        switch (key.length) {
             case 6:
                 return 'participant';
             case 8:
                 return 'trainer';
             default:
-                throw new RangeError(`Incorrect id: ${id}`);
+                throw new RangeError(`Incorrect id: ${key}`);
         }
     }
 

--- a/backend/src/database/services/exercise-service.ts
+++ b/backend/src/database/services/exercise-service.ts
@@ -197,14 +197,14 @@ export class ExerciseService {
         };
     }
 
-    public getRoleFromKey(key: string): Role {
-        switch (key.length) {
+    public getRoleFromKey(exerciseKey: string): Role {
+        switch (exerciseKey.length) {
             case 6:
                 return 'participant';
             case 8:
                 return 'trainer';
             default:
-                throw new RangeError(`Incorrect id: ${key}`);
+                throw new RangeError(`Incorrect id: ${exerciseKey}`);
         }
     }
 

--- a/backend/src/database/services/exercise-service.ts
+++ b/backend/src/database/services/exercise-service.ts
@@ -17,8 +17,8 @@ export class ExerciseService {
 
     private readonly exerciseMap = new Map<string, ActiveExercise>();
 
-    public hasExerciseKey(exerciseId: string) {
-        return this.exerciseMap.has(exerciseId);
+    public hasExerciseKey(exerciseKey: string) {
+        return this.exerciseMap.has(exerciseKey);
     }
 
     public getExerciseByKey(roleKey: string) {
@@ -202,7 +202,7 @@ export class ExerciseService {
         };
     }
 
-    public getRoleFromId(id: string): Role {
+    public getRoleFromKey(id: string): Role {
         switch (id.length) {
             case 6:
                 return 'participant';

--- a/backend/src/exercise/action-wrapper.ts
+++ b/backend/src/exercise/action-wrapper.ts
@@ -1,5 +1,5 @@
 import type { ExerciseAction, UUID } from 'digital-fuesim-manv-shared';
-import type { ActionEntry } from '../database/schema.js';
+import type { ActionEntry, ActionId } from '../database/schema.js';
 import type { ActiveExercise } from './active-exercise.js';
 
 export class ActionWrapper {
@@ -22,7 +22,7 @@ export class ActionWrapper {
         emitterId: UUID | null,
         public readonly exercise: ActiveExercise,
         index?: number,
-        id?: UUID
+        id?: ActionId
     ) {
         this.action = {
             actionString: action,

--- a/backend/src/exercise/active-exercise.spec.ts
+++ b/backend/src/exercise/active-exercise.spec.ts
@@ -3,19 +3,31 @@ import { sleep } from 'digital-fuesim-manv-shared';
 import { createTestEnvironment } from '../../test/utils.js';
 import { clientMap } from './client-map.js';
 import { ActiveExercise } from './active-exercise.js';
+import type {
+    ExerciseKey,
+    ParticipantKey,
+    TrainerKey,
+} from './exercise-keys.js';
 
 describe('Active Exercise', () => {
     const environment = createTestEnvironment();
-    it('fails getting a role for the wrong id', () => {
-        const exercise = new ActiveExercise('123456', '12345678');
 
-        expect(() => exercise.getRoleFromUsedId('wrong id')).toThrow(
-            RangeError
+    it('fails getting a role for the wrong id', () => {
+        const exercise = new ActiveExercise(
+            '123456' as ParticipantKey,
+            '12345678' as TrainerKey
         );
+
+        expect(() =>
+            exercise.getRoleFromUsedKey('wrong key' as ExerciseKey)
+        ).toThrow(RangeError);
     });
 
     it('does nothing adding a client that is not set up', async () => {
-        const exercise = new ActiveExercise('123456', '12345678');
+        const exercise = new ActiveExercise(
+            '123456' as ParticipantKey,
+            '12345678' as TrainerKey
+        );
         // Use a websocket in order to have a ClientWrapper set up
         await environment.withWebsocket(async () => {
             // Sleep a bit to allow the socket to connect.
@@ -34,7 +46,10 @@ describe('Active Exercise', () => {
     });
 
     it('does nothing removing a client that is not joined', async () => {
-        const exercise = new ActiveExercise('123456', '12345678');
+        const exercise = new ActiveExercise(
+            '123456' as ParticipantKey,
+            '12345678' as TrainerKey
+        );
         // Use a websocket in order to have a ClientWrapper set up
         await environment.withWebsocket(async () => {
             // Sleep a bit to allow the socket to connect.
@@ -56,7 +71,10 @@ describe('Active Exercise', () => {
     describe('Started Exercise', () => {
         let exercise: ActiveExercise | undefined;
         beforeEach(() => {
-            exercise = new ActiveExercise('123456', '12345678');
+            exercise = new ActiveExercise(
+                '123456' as ParticipantKey,
+                '12345678' as TrainerKey
+            );
             exercise.start();
         });
         afterEach(() => {
@@ -82,7 +100,10 @@ describe('Active Exercise', () => {
 
     describe('Reactions to Actions', () => {
         it('calls start when matching action is sent', () => {
-            const exercise = new ActiveExercise('123456', '12345678');
+            const exercise = new ActiveExercise(
+                '123456' as ParticipantKey,
+                '12345678' as TrainerKey
+            );
 
             const startMock = jest.spyOn(ActiveExercise.prototype, 'start');
             startMock.mockImplementation(() => ({}));
@@ -95,7 +116,10 @@ describe('Active Exercise', () => {
         });
 
         it('calls pause when matching action is sent', () => {
-            const exercise = new ActiveExercise('123456', '12345678');
+            const exercise = new ActiveExercise(
+                '123456' as ParticipantKey,
+                '12345678' as TrainerKey
+            );
 
             const pause = jest.spyOn(ActiveExercise.prototype, 'pause');
             pause.mockImplementation(() => ({}));

--- a/backend/src/exercise/active-exercise.spec.ts
+++ b/backend/src/exercise/active-exercise.spec.ts
@@ -12,7 +12,7 @@ import type {
 describe('Active Exercise', () => {
     const environment = createTestEnvironment();
 
-    it('fails getting a role for the wrong id', () => {
+    it('fails getting a role for the wrong key', () => {
         const exercise = new ActiveExercise(
             '123456' as ParticipantKey,
             '12345678' as TrainerKey

--- a/backend/src/exercise/active-exercise.ts
+++ b/backend/src/exercise/active-exercise.ts
@@ -6,6 +6,11 @@ import { ActionWrapper } from './action-wrapper.js';
 import type { ClientWrapper } from './client-wrapper.js';
 import { patientTick } from './patient-ticking.js';
 import { PeriodicEventHandler } from './periodic-events/periodic-event-handler.js';
+import type {
+    ExerciseKey,
+    ParticipantKey,
+    TrainerKey,
+} from './exercise-keys.js';
 
 export class ActiveExercise {
     private readonly exercise: Omit<ExerciseEntry, 'id'>;
@@ -31,6 +36,16 @@ export class ActiveExercise {
 
     public getExercise() {
         return this.exercise;
+    }
+
+    public get participantKey(): ParticipantKey {
+        // This should always be valid, since we are creating all active exercises in the exercise factory which ensures valid keys
+        return this.exercise.participantId as ParticipantKey;
+    }
+
+    public get trainerKey(): TrainerKey {
+        // This should always be valid, since we are creating all active exercises in the exercise factory which ensures valid keys
+        return this.exercise.trainerId as TrainerKey;
     }
 
     private _changedSinceSave = true;
@@ -136,8 +151,8 @@ export class ActiveExercise {
     public readonly incrementIdGenerator = new IncrementIdGenerator();
 
     public constructor(
-        participantKey: string,
-        trainerKey: string,
+        participantKey: ParticipantKey,
+        trainerKey: TrainerKey,
         public readonly temporaryActionHistory: ActionWrapper[] = [],
         stateVersion: number = ExerciseState.currentStateVersion,
         initialState = ExerciseState.create(participantKey),
@@ -159,7 +174,7 @@ export class ActiveExercise {
      * @returns The role of the client, determined by the id.
      * @throws {@link RangeError} in case the provided {@link id} is not part of this exercise.
      */
-    public getRoleFromUsedId(id: string): Role {
+    public getRoleFromUsedKey(id: ExerciseKey): Role {
         switch (id) {
             case this.exercise.participantId:
                 return 'participant';

--- a/backend/src/exercise/active-exercise.ts
+++ b/backend/src/exercise/active-exercise.ts
@@ -1,6 +1,6 @@
 import type { ExerciseAction, Role, UUID } from 'digital-fuesim-manv-shared';
 import { ExerciseState, reduceExerciseState } from 'digital-fuesim-manv-shared';
-import type { ExerciseEntry } from '../database/schema.js';
+import type { ExerciseEntry, ExerciseId } from '../database/schema.js';
 import { IncrementIdGenerator } from '../utils/increment-id-generator.js';
 import { ActionWrapper } from './action-wrapper.js';
 import type { ClientWrapper } from './client-wrapper.js';
@@ -14,13 +14,13 @@ export class ActiveExercise {
     // the ExerciseService when creating/loading
     // the exercise or the ExerciseFactory when
     // restoring an exercise
-    private _exerciseId!: string;
+    private _exerciseId!: ExerciseId;
 
-    public get exerciseId(): string {
+    public get exerciseId(): ExerciseId {
         return this._exerciseId;
     }
 
-    public setExerciseId(value: string) {
+    public setExerciseId(value: ExerciseId) {
         // the strictness is only valid, if the id is immediately set
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (this._exerciseId !== undefined) {

--- a/backend/src/exercise/client-wrapper.ts
+++ b/backend/src/exercise/client-wrapper.ts
@@ -3,6 +3,7 @@ import { Client, ClientRole } from 'digital-fuesim-manv-shared';
 import type { ExerciseSocket } from '../exercise-server.js';
 import type { ExerciseService } from '../database/services/exercise-service.js';
 import type { ActiveExercise } from './active-exercise.js';
+import type { ExerciseKey } from './exercise-keys.js';
 
 export class ClientWrapper {
     public constructor(
@@ -20,10 +21,10 @@ export class ClientWrapper {
      * @returns The joined client's id, or undefined when the exercise doesn't exists.
      */
     public joinExercise(
-        exerciseId: string,
+        exerciseKey: ExerciseKey,
         clientName: string
     ): UUID | undefined {
-        const exercise = this.exerciseService.getExerciseByKey(exerciseId);
+        const exercise = this.exerciseService.getExerciseByKey(exerciseKey);
         if (!exercise) {
             return undefined;
         }
@@ -31,7 +32,7 @@ export class ClientWrapper {
         // Although getRoleFromUsedId may throw an error, this should never happen here
         // as the provided id is guaranteed to be one of the ids of the exercise as the exercise
         // was fetched with this exact id from the exercise map.
-        const role = this.chosenExercise.getRoleFromUsedId(exerciseId);
+        const role = this.chosenExercise.getRoleFromUsedKey(exerciseKey);
         this.relatedExerciseClient = Client.create(
             clientName,
             ClientRole.create(
@@ -55,7 +56,7 @@ export class ClientWrapper {
         }
 
         this.exerciseService.leaveExercise(
-            this.chosenExercise.getExercise().participantId,
+            this.chosenExercise.participantKey,
             this
         );
     }

--- a/backend/src/exercise/exercise-factory.ts
+++ b/backend/src/exercise/exercise-factory.ts
@@ -21,9 +21,17 @@ import { RestoreError } from '../utils/restore-error.js';
 import { ValidationErrorWrapper } from '../utils/validation-error-wrapper.js';
 import { ActionWrapper } from './action-wrapper.js';
 import { ActiveExercise } from './active-exercise.js';
+import { isParticipantKey, isTrainerKey } from './exercise-keys.js';
 
 export class ExerciseFactory {
     public static fromBlank(exerciseKeys: ExerciseKeys) {
+        if (
+            !isParticipantKey(exerciseKeys.participantKey) ||
+            !isTrainerKey(exerciseKeys.trainerKey)
+        ) {
+            throw new Error('Invalid exercise keys provided');
+        }
+
         return new ActiveExercise(
             exerciseKeys.participantKey,
             exerciseKeys.trainerKey
@@ -37,6 +45,13 @@ export class ExerciseFactory {
         file: StateExport,
         exerciseKeys: ExerciseKeys
     ): ActiveExercise {
+        if (
+            !isParticipantKey(exerciseKeys.participantKey) ||
+            !isTrainerKey(exerciseKeys.trainerKey)
+        ) {
+            throw new Error('Invalid exercise keys provided');
+        }
+
         const migratedImportObject = migrateStateExport(file);
         const validationErrors = validateExerciseExport(migratedImportObject);
         if (validationErrors.length > 0) {
@@ -89,10 +104,18 @@ export class ExerciseFactory {
         actions: InferSelectModel<typeof actionTable>[],
         exerciseKeys?: ExerciseKeys
     ): ActiveExercise {
+        const participantKey =
+            exerciseKeys?.participantKey ?? dbEntry.participantId;
+        const trainerKey = exerciseKeys?.trainerKey ?? dbEntry.trainerId;
+
+        if (!isParticipantKey(participantKey) || !isTrainerKey(trainerKey)) {
+            throw new Error('Invalid exercise keys provided');
+        }
+
         const actionsInWrapper: ActionWrapper[] = [];
         const exercise = new ActiveExercise(
-            exerciseKeys?.participantKey ?? dbEntry.participantId,
-            exerciseKeys?.trainerKey ?? dbEntry.trainerId,
+            participantKey,
+            trainerKey,
             actionsInWrapper,
             dbEntry.stateVersion,
             dbEntry.initialStateString,

--- a/backend/src/exercise/exercise-keys.ts
+++ b/backend/src/exercise/exercise-keys.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+const participantKeySchema = z
+    .string()
+    .min(6)
+    .max(6)
+    .regex(/^\d{6}$/u)
+    .brand<'ParticipantKey'>();
+const trainerKeySchema = z
+    .string()
+    .min(8)
+    .max(8)
+    .regex(/^\d{8}$/u)
+    .brand<'TrainerKey'>();
+
+export type ParticipantKey = z.infer<typeof participantKeySchema>;
+export type TrainerKey = z.infer<typeof trainerKeySchema>;
+// z.union doesn't work well with branded types
+export type ExerciseKey = ParticipantKey | TrainerKey;
+
+export function isParticipantKey(key: string): key is ParticipantKey {
+    return participantKeySchema.safeParse(key).success;
+}
+
+export function isTrainerKey(key: string): key is TrainerKey {
+    return trainerKeySchema.safeParse(key).success;
+}
+
+export function isExerciseKey(key: string): key is ExerciseKey {
+    return isParticipantKey(key) || isTrainerKey(key);
+}

--- a/backend/src/exercise/exercise-keys.ts
+++ b/backend/src/exercise/exercise-keys.ts
@@ -2,14 +2,10 @@ import { z } from 'zod';
 
 const participantKeySchema = z
     .string()
-    .min(6)
-    .max(6)
     .regex(/^\d{6}$/u)
     .brand<'ParticipantKey'>();
 const trainerKeySchema = z
     .string()
-    .min(8)
-    .max(8)
     .regex(/^\d{8}$/u)
     .brand<'TrainerKey'>();
 

--- a/backend/src/exercise/http-handler/api/exercise.ts
+++ b/backend/src/exercise/http-handler/api/exercise.ts
@@ -52,10 +52,10 @@ export async function postExercise(
 }
 
 export function getExercise(
-    exerciseId: string,
+    exerciseKey: string,
     exerciseService: ExerciseService
 ): HttpResponse {
-    const exerciseExists = exerciseService.hasExerciseKey(exerciseId);
+    const exerciseExists = exerciseService.hasExerciseKey(exerciseKey);
     return {
         statusCode: exerciseExists ? 200 : 404,
         body: undefined,
@@ -63,10 +63,10 @@ export function getExercise(
 }
 
 export async function deleteExercise(
-    exerciseId: string,
+    exerciseKey: string,
     exerciseService: ExerciseService
 ): Promise<HttpResponse> {
-    if (exerciseService.getRoleFromId(exerciseId) !== 'trainer') {
+    if (exerciseService.getRoleFromKey(exerciseKey) !== 'trainer') {
         return {
             statusCode: 403,
             body: {
@@ -76,7 +76,7 @@ export async function deleteExercise(
         };
     }
     try {
-        await exerciseService.deleteExercise(exerciseId);
+        await exerciseService.deleteExercise(exerciseKey);
         return {
             statusCode: 204,
             body: undefined,
@@ -86,7 +86,7 @@ export async function deleteExercise(
             return {
                 statusCode: 404,
                 body: {
-                    message: `Exercise with id '${exerciseId}' was not found`,
+                    message: `Exercise with id '${exerciseKey}' was not found`,
                 },
             };
         }
@@ -96,11 +96,11 @@ export async function deleteExercise(
 }
 
 export async function getExerciseHistory(
-    exerciseId: string,
+    exerciseKey: string,
     exerciseService: ExerciseService
 ): Promise<HttpResponse<ExerciseTimeline>> {
     try {
-        const timeline = await exerciseService.getTimeline(exerciseId);
+        const timeline = await exerciseService.getTimeline(exerciseKey);
         return {
             statusCode: 200,
             body: timeline,
@@ -110,7 +110,7 @@ export async function getExerciseHistory(
             return {
                 statusCode: 404,
                 body: {
-                    message: `Exercise with id '${exerciseId}' was not found`,
+                    message: `Exercise with id '${exerciseKey}' was not found`,
                 },
             };
         }

--- a/backend/src/exercise/http-handler/api/exercise.ts
+++ b/backend/src/exercise/http-handler/api/exercise.ts
@@ -4,6 +4,7 @@ import { UserReadableIdGenerator } from '../../../utils/user-readable-id-generat
 import { ActiveExercise } from '../../active-exercise.js';
 import type { HttpErrorMessage, HttpResponse } from '../utils.js';
 import { importExercise } from '../../../utils/import-exercise.js';
+import { isExerciseKey, isTrainerKey } from '../../exercise-keys.js';
 import { UnknownExerciseError } from './../../../database/services/exercise-service.js';
 import type { ExerciseService } from './../../../database/services/exercise-service.js';
 import { ExerciseFactory } from './../../../exercise/exercise-factory.js';
@@ -55,6 +56,15 @@ export function getExercise(
     exerciseKey: string,
     exerciseService: ExerciseService
 ): HttpResponse {
+    if (!isExerciseKey(exerciseKey)) {
+        return {
+            statusCode: 400,
+            body: {
+                message: `The provided exercise key '${exerciseKey}' is invalid.`,
+            },
+        };
+    }
+
     const exerciseExists = exerciseService.hasExerciseKey(exerciseKey);
     return {
         statusCode: exerciseExists ? 200 : 404,
@@ -66,7 +76,7 @@ export async function deleteExercise(
     exerciseKey: string,
     exerciseService: ExerciseService
 ): Promise<HttpResponse> {
-    if (exerciseService.getRoleFromKey(exerciseKey) !== 'trainer') {
+    if (!isTrainerKey(exerciseKey)) {
         return {
             statusCode: 403,
             body: {
@@ -99,6 +109,15 @@ export async function getExerciseHistory(
     exerciseKey: string,
     exerciseService: ExerciseService
 ): Promise<HttpResponse<ExerciseTimeline>> {
+    if (!isExerciseKey(exerciseKey)) {
+        return {
+            statusCode: 400,
+            body: {
+                message: `The provided exercise key '${exerciseKey}' is invalid.`,
+            },
+        };
+    }
+
     try {
         const timeline = await exerciseService.getTimeline(exerciseKey);
         return {

--- a/backend/src/exercise/http-server.ts
+++ b/backend/src/exercise/http-server.ts
@@ -42,25 +42,25 @@ export class ExerciseHttpServer {
                 res
             )
         );
-        app.get('/api/exercise/:exerciseId', async (req, res) =>
+        app.get('/api/exercise/:exerciseKey', async (req, res) =>
             secureHttp(
-                () => getExercise(req.params.exerciseId, exerciseService),
+                () => getExercise(req.params.exerciseKey, exerciseService),
                 req,
                 res
             )
         );
-        app.delete('/api/exercise/:exerciseId', async (req, res) =>
+        app.delete('/api/exercise/:exerciseKey', async (req, res) =>
             secureHttp(
                 async () =>
-                    deleteExercise(req.params.exerciseId, exerciseService),
+                    deleteExercise(req.params.exerciseKey, exerciseService),
                 req,
                 res
             )
         );
-        app.get('/api/exercise/:exerciseId/history', async (req, res) =>
+        app.get('/api/exercise/:exerciseKey/history', async (req, res) =>
             secureHttp(
                 async () =>
-                    getExerciseHistory(req.params.exerciseId, exerciseService),
+                    getExerciseHistory(req.params.exerciseKey, exerciseService),
                 req,
                 res
             )

--- a/backend/src/exercise/websocket-handler/join-exercise-handler.ts
+++ b/backend/src/exercise/websocket-handler/join-exercise-handler.ts
@@ -2,6 +2,7 @@ import type { UUID } from 'digital-fuesim-manv-shared';
 import { ValidationErrorWrapper } from '../../utils/validation-error-wrapper.js';
 import type { ExerciseServer, ExerciseSocket } from '../../exercise-server.js';
 import { clientMap } from '../client-map.js';
+import { isExerciseKey } from '../exercise-keys.js';
 import { secureOn } from './secure-on.js';
 
 export const registerJoinExerciseHandler = (
@@ -11,7 +12,7 @@ export const registerJoinExerciseHandler = (
     secureOn(
         client,
         'joinExercise',
-        (exerciseId: string, clientName: string, callback): void => {
+        (exerciseKey: string, clientName: string, callback): void => {
             // When this listener is registered the socket is in the map.
             const clientWrapper = clientMap.get(client)!;
             if (clientWrapper.exercise) {
@@ -24,9 +25,12 @@ export const registerJoinExerciseHandler = (
             }
             let clientId: UUID | undefined;
             try {
+                if (!isExerciseKey(exerciseKey)) {
+                    throw new ValidationErrorWrapper(['Invalid exercise key']);
+                }
                 clientId = clientMap
                     .get(client)
-                    ?.joinExercise(exerciseId, clientName);
+                    ?.joinExercise(exerciseKey, clientName);
             } catch (e: unknown) {
                 if (e instanceof ValidationErrorWrapper) {
                     callback({

--- a/backend/test/http-exercise.spec.ts
+++ b/backend/test/http-exercise.spec.ts
@@ -29,7 +29,7 @@ describe('exercise', () => {
         });
     });
 
-    describe('GET /api/exercise/:exerciseId', () => {
+    describe('GET /api/exercise/:exerciseKey', () => {
         it('succeeds returning true for participant id', async () => {
             const participantKey = (await createExercise(environment))
                 .participantId;
@@ -52,7 +52,7 @@ describe('exercise', () => {
         });
     });
 
-    describe('DELETE /api/exercise/:exerciseId', () => {
+    describe('DELETE /api/exercise/:exerciseKey', () => {
         it('succeeds deleting an exercise', async () => {
             const exerciseId = (await createExercise(environment)).trainerId;
             await environment
@@ -106,7 +106,7 @@ describe('exercise', () => {
         });
     });
 
-    describe('GET /api/exercise/:exerciseId/history', () => {
+    describe('GET /api/exercise/:exerciseKey/history', () => {
         it('returns history for existing exercise', async () => {
             const exerciseId = (await createExercise(environment)).trainerId;
             await environment

--- a/backend/test/http-exercise.spec.ts
+++ b/backend/test/http-exercise.spec.ts
@@ -45,9 +45,17 @@ describe('exercise', () => {
                 .expect(200);
         });
 
+        it('succeeds returning 400 for abitrary id string', async () => {
+            await environment
+                .httpRequest('get', `/api/exercise/anyString`)
+                .expect(400);
+        });
         it('succeeds returning false for not existing id', async () => {
             await environment
-                .httpRequest('get', `/api/exercise/trainerId`)
+                .httpRequest(
+                    'get',
+                    `/api/exercise/${UserReadableIdGenerator.generateId()}`
+                )
                 .expect(404);
         });
     });
@@ -67,7 +75,7 @@ describe('exercise', () => {
         it('fails deleting an arbitrary exercise id string', async () => {
             await environment
                 .httpRequest('delete', '/api/exercise/anyNumber')
-                .expect(500);
+                .expect(403);
         });
 
         it('fails deleting a not existing exercise', async () => {
@@ -114,8 +122,15 @@ describe('exercise', () => {
                 .expect(200);
         });
 
-        it('fails with 404 for non-existing exercise', async () => {
+        it('fails with 400 for abitrary exercise id string', async () => {
             const exerciseId = 'non-existing-id';
+            await environment
+                .httpRequest('get', `/api/exercise/${exerciseId}/history`)
+                .expect(400);
+        });
+
+        it('fails with 404 for non-existing exercise', async () => {
+            const exerciseId = UserReadableIdGenerator.generateId();
             await environment
                 .httpRequest('get', `/api/exercise/${exerciseId}/history`)
                 .expect(404);

--- a/backend/test/http-exercise.spec.ts
+++ b/backend/test/http-exercise.spec.ts
@@ -10,7 +10,7 @@ describe('exercise', () => {
         environment.exerciseService.TESTING_getExerciseMap().clear();
     });
     describe('POST /api/exercise', () => {
-        it('returns an exercise id', async () => {
+        it('returns an exercise key', async () => {
             const response = await environment
                 .httpRequest('post', '/api/exercise')
                 .expect(201);
@@ -21,7 +21,7 @@ describe('exercise', () => {
             expect(exerciseCreationResponse.trainerId).toBeDefined();
         });
 
-        it('fails when no ids are left', async () => {
+        it('fails when no keys are left', async () => {
             for (let i = 0; i < 10_000; i++) {
                 UserReadableIdGenerator.generateId();
             }
@@ -30,7 +30,7 @@ describe('exercise', () => {
     });
 
     describe('GET /api/exercise/:exerciseKey', () => {
-        it('succeeds returning true for participant id', async () => {
+        it('succeeds with 200 with a valid participant key', async () => {
             const participantKey = (await createExercise(environment))
                 .participantId;
             await environment
@@ -38,19 +38,24 @@ describe('exercise', () => {
                 .expect(200);
         });
 
-        it('succeeds returning true for trainer id', async () => {
+        it('succeeds returning true for trainer key', async () => {
             const trainerKey = (await createExercise(environment)).trainerId;
             await environment
                 .httpRequest('get', `/api/exercise/${trainerKey}`)
                 .expect(200);
         });
 
-        it('succeeds returning 400 for abitrary id string', async () => {
-            await environment
-                .httpRequest('get', `/api/exercise/anyString`)
-                .expect(400);
+        it('fails with 400 for arbitrary keys', async () => {
+            await Promise.all(
+                ['12345', '1234567', '123456789'].map((invalidKey) =>
+                    environment
+                        .httpRequest('get', `/api/exercise/${invalidKey}`)
+                        .expect(400)
+                )
+            );
         });
-        it('succeeds returning false for not existing id', async () => {
+
+        it('fails with 404 for non-existing key', async () => {
             await environment
                 .httpRequest(
                     'get',
@@ -62,9 +67,9 @@ describe('exercise', () => {
 
     describe('DELETE /api/exercise/:exerciseKey', () => {
         it('succeeds deleting an exercise', async () => {
-            const exerciseId = (await createExercise(environment)).trainerId;
+            const exerciseKey = (await createExercise(environment)).trainerId;
             await environment
-                .httpRequest('delete', `/api/exercise/${exerciseId}`)
+                .httpRequest('delete', `/api/exercise/${exerciseKey}`)
                 .expect(204);
 
             expect(
@@ -72,7 +77,7 @@ describe('exercise', () => {
             ).toBe(0);
         });
 
-        it('fails deleting an arbitrary exercise id string', async () => {
+        it('fails deleting an arbitrary exercise key string', async () => {
             await environment
                 .httpRequest('delete', '/api/exercise/anyNumber')
                 .expect(403);
@@ -84,20 +89,20 @@ describe('exercise', () => {
                 .expect(404);
         });
 
-        it('fails deleting an exercise by its participant id', async () => {
-            const exerciseId = (await createExercise(environment))
+        it('fails deleting an exercise by its participant key', async () => {
+            const exerciseKey = (await createExercise(environment))
                 .participantId;
             await environment
-                .httpRequest('delete', `/api/exercise/${exerciseId}`)
+                .httpRequest('delete', `/api/exercise/${exerciseKey}`)
                 .expect(403);
         });
 
         it('disconnects clients of the removed exercise', async () => {
-            const exerciseId = (await createExercise(environment)).trainerId;
+            const exerciseKey = (await createExercise(environment)).trainerId;
             await environment.withWebsocket(async (socket) => {
                 const joinExercise = await socket.emit(
                     'joinExercise',
-                    exerciseId,
+                    exerciseKey,
                     ''
                 );
 
@@ -106,7 +111,7 @@ describe('exercise', () => {
                 socket.spyOn('disconnect');
 
                 await environment
-                    .httpRequest('delete', `/api/exercise/${exerciseId}`)
+                    .httpRequest('delete', `/api/exercise/${exerciseKey}`)
                     .expect(204);
 
                 expect(socket.getTimesCalled('disconnect')).toBe(1);
@@ -116,23 +121,23 @@ describe('exercise', () => {
 
     describe('GET /api/exercise/:exerciseKey/history', () => {
         it('returns history for existing exercise', async () => {
-            const exerciseId = (await createExercise(environment)).trainerId;
+            const exerciseKey = (await createExercise(environment)).trainerId;
             await environment
-                .httpRequest('get', `/api/exercise/${exerciseId}/history`)
+                .httpRequest('get', `/api/exercise/${exerciseKey}/history`)
                 .expect(200);
         });
 
-        it('fails with 400 for abitrary exercise id string', async () => {
-            const exerciseId = 'non-existing-id';
+        it('fails with 400 for abitrary exercise key string', async () => {
+            const exerciseKey = 'non-existing-key';
             await environment
-                .httpRequest('get', `/api/exercise/${exerciseId}/history`)
+                .httpRequest('get', `/api/exercise/${exerciseKey}/history`)
                 .expect(400);
         });
 
         it('fails with 404 for non-existing exercise', async () => {
-            const exerciseId = UserReadableIdGenerator.generateId();
+            const exerciseKey = UserReadableIdGenerator.generateId();
             await environment
-                .httpRequest('get', `/api/exercise/${exerciseId}/history`)
+                .httpRequest('get', `/api/exercise/${exerciseKey}/history`)
                 .expect(404);
         });
     });

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -40,13 +40,15 @@ paths:
                                 $ref: '#/components/schemas/ErrorResponse'
     /api/exercise/{exerciseId}:
         parameters:
-            - $ref: '#/components/parameters/ExerciseId'
+            - $ref: '#/components/parameters/ExerciseKey'
         get:
-            summary: Check whether an exercise id exists
+            summary: Check whether an exercise key exists
             operationId: getExercise
             responses:
                 200:
                     description: Exercise exists
+                400:
+                    description: Invalid exercise key supplied
                 404:
                     description: Exercise does not exist
         delete:
@@ -69,13 +71,15 @@ paths:
                                 $ref: '#/components/schemas/ErrorResponse'
     /api/exercise/{exerciseId}/history:
         parameters:
-            - $ref: '#/components/parameters/ExerciseId'
+            - $ref: '#/components/parameters/ExerciseKey'
         get:
             summary: Get the history of the exercise
             operationId: getExerciseHistory
             responses:
                 200:
                     description: Exercise history in the payload (TODO:)
+                400:
+                    description: Invalid exercise key supplied
                 404:
                     description: Exercise does not exist
 components:
@@ -86,15 +90,16 @@ components:
                 status:
                     type: string
                     description: Current status of the server
+        # the frontend still expects participantId and trainerId (whereas the backend uses -key)
         ExerciseIdResponse:
             type: object
             properties:
                 participantId:
                     type: string
-                    description: Participant id of the exercise
+                    description: Participant key of the exercise
                 trainerId:
                     type: string
-                    description: Trainer id of the exercise
+                    description: Trainer key of the exercise
         ErrorResponse:
             type: object
             properties:
@@ -102,10 +107,10 @@ components:
                     type: string
                     description: Error message
     parameters:
-        ExerciseId:
-            name: exerciseId
+        ExerciseKey:
+            name: exerciseKey
             in: path
-            description: The exercise id
+            description: The exercise key
             required: true
             schema:
                 type: string


### PR DESCRIPTION
This PR closes #1204 

This is based on this discussion: https://github.com/hpi-sam/digital-fuesim-manv/pull/1202#issuecomment-3755274355

- Adding branded types of ExerciseId, ActionId, ExerciseKey, ParticipantKey and TrainerKey
  - this allows us to differentiate between string types and typescript warning us about errors like in #1200 
- renamed some more code to use `key` instead of `id` 

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/digital-fuesim-manv-public-test-scenarios) have been added.
- [x] I have the right to license the code submitted with this Pull Request under the mentioned license in the file [LICENSE-README.md](LICENSE-README.md) (i.e., this is my
      own code or code licensed under a license compatible to AGPL v3.0 or later, for exceptions look into [LICENSE-README.md](LICENSE-README.md)) and
      hereby license the code in this Pull Request under it.
      I certify that by signing off my commits (see In case of using third party code, I have given appropriate credit.
      We are using DCO for that, see [here](https://github.com/dcoapp/app#how-it-works) for more information.
- [x] If I have used third party code and I mentioned it in the code, I also updated the [inspired-by-or-copied-from-list.html](inspired-by-or-copied-from-list.html) list to include the links.
