### PR TITLE
Fixup npm install order for `install:all`-task

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -79,7 +79,6 @@
                 "jest": "^30.2.0",
                 "jest-extended": "^4.0.2",
                 "ts-jest": "^29.4.5",
-                "ts-node": "^10.9.2",
                 "typescript": "~5.8.2",
                 "typescript-eslint": "^8.45.0"
             },

--- a/benchmark/package-lock.json
+++ b/benchmark/package-lock.json
@@ -59,7 +59,6 @@
                 "jest": "^30.2.0",
                 "jest-extended": "^4.0.2",
                 "ts-jest": "^29.4.5",
-                "ts-node": "^10.9.2",
                 "typescript": "~5.8.2",
                 "typescript-eslint": "^8.45.0"
             },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -93,7 +93,6 @@
                 "jest": "^30.2.0",
                 "jest-extended": "^4.0.2",
                 "ts-jest": "^29.4.5",
-                "ts-node": "^10.9.2",
                 "typescript": "~5.8.2",
                 "typescript-eslint": "^8.45.0"
             },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "cy:ci": "cd frontend && npm run cy:run",
         "cy:install": "cd frontend && npm run cy:install",
         "benchmark": "cd benchmark && npm run benchmark",
-        "install:all": "npm i && concurrently \"cd shared && npm i \" \"cd frontend && npm i \" \"cd backend && npm i \" \"cd benchmark && npm i \"",
+        "install:all": "npm i && (cd shared && npm i) && concurrently \"cd frontend && npm i \" \"cd backend && npm i \" \"cd benchmark && npm i \"",
         "setup": "npm i && cd shared && npm i && npm run build && cd .. && concurrently \"cd frontend && npm i \" \"cd backend && npm i \" \"cd benchmark && npm i \"",
         "setup:package-lock-only": "npm i --package-lock-only && cd shared && npm i --package-lock-only && cd ../frontend && npm i --package-lock-only && cd ../backend && npm i --package-lock-only && cd ../benchmark && npm i --package-lock-only",
         "prune": "npm prune && cd shared && npm prune && cd ../frontend && npm prune && cd ../backend && npm prune",


### PR DESCRIPTION
After merging #1207 there were still lingering references to `ts-node` as second-level dependencies of `shared` for the other modules.

To prevent this from happening in the future, this PR changes the `install:all` script to sequentially install `shared`'s dependencies, before the other modules.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/digital-fuesim-manv-public-test-scenarios) have been added.
- [x] I have the right to license the code submitted with this Pull Request under the mentioned license in the file [LICENSE-README.md](LICENSE-README.md) (i.e., this is my
      own code or code licensed under a license compatible to AGPL v3.0 or later, for exceptions look into [LICENSE-README.md](LICENSE-README.md)) and
      hereby license the code in this Pull Request under it.
      I certify that by signing off my commits (see In case of using third party code, I have given appropriate credit.
      We are using DCO for that, see [here](https://github.com/dcoapp/app#how-it-works) for more information.
- [x] If I have used third party code and I mentioned it in the code, I also updated the [inspired-by-or-copied-from-list.html](inspired-by-or-copied-from-list.html) list to include the links.
