### PR TITLE
Fix navigation to authenticated routes on load

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
+import { inject, NgModule, provideAppInitializer } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
@@ -20,6 +20,7 @@ import {
     errorHandlingInterceptor,
     withCredentialsInterceptor,
 } from './shared/functions/http';
+import { AuthService } from './core/auth.service';
 
 @NgModule({
     declarations: [AppComponent, HealthPageComponent],
@@ -43,6 +44,10 @@ import {
                 withCredentialsInterceptor,
                 errorHandlingInterceptor,
             ])
+        ),
+        // Returns promise to block application loading until AuthService is initialized
+        provideAppInitializer(
+            async (): Promise<void> => inject(AuthService).initialize()
         ),
     ],
 })

--- a/frontend/src/app/core/auth.service.ts
+++ b/frontend/src/app/core/auth.service.ts
@@ -1,12 +1,13 @@
 import { Injectable, signal, inject } from '@angular/core';
 import { lastValueFrom } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, UrlTree } from '@angular/router';
 import {
     AuthQueryParams,
     UserDataResponse,
     userDataResponseSchema,
 } from 'fuesim-digital-shared';
+import { Location as NgLocation } from '@angular/common';
 import { httpOrigin } from './api-origins';
 import { MessageService } from './messages/message.service';
 
@@ -17,6 +18,7 @@ export class AuthService {
     private readonly httpClient = inject(HttpClient);
     private readonly route = inject(ActivatedRoute);
     private readonly router = inject(Router);
+    private readonly location = inject(NgLocation);
     private readonly messageService = inject(MessageService);
 
     public readonly SESSION_REFRESH_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
@@ -25,9 +27,9 @@ export class AuthService {
         user: undefined,
     });
 
-    constructor() {
-        this.fetchUserData();
-        this.handleAuthMessageToast();
+    public async initialize() {
+        this.setupQueryParamsHandler();
+        return this.fetchUserData();
     }
 
     private async refreshSessionHandler() {
@@ -74,59 +76,70 @@ export class AuthService {
         this.refreshSessionHandler();
     }
 
-    private handleAuthMessageToast() {
+    private setupQueryParamsHandler() {
         this.route.queryParams.subscribe((params: AuthQueryParams) => {
-            switch (params.logoutStatus) {
-                case 'loggedOut':
-                    this.messageService.postMessage({
-                        title: 'Erfolgreich abgemeldet',
-                        color: 'info',
-                        body: 'Sie wurden erfolgreich abgemeldet.',
-                    });
-                    break;
-                case 'noSessionFound':
-                    this.messageService.postMessage({
-                        title: 'Abmeldung fehlgeschlagen',
-                        color: 'warning',
-                        body: 'Es wurde keine aktive Sitzung gefunden.',
-                    });
-                    break;
-                case 'sessionExpired':
-                    this.messageService.postMessage({
-                        title: 'Sitzung abgelaufen',
-                        color: 'warning',
-                        body: 'Ihre Sitzung ist abgelaufen.',
-                    });
-                    break;
-                default:
-                    break;
-            }
+            if (
+                !params.logoutStatus &&
+                !params.loginFailure &&
+                !params.loginSuccess
+            )
+                return;
 
-            if (params.loginFailure !== undefined) {
-                this.messageService.postMessage({
-                    color: 'danger',
-                    title: 'Login fehlgeschlagen',
-                    body: params.loginFailure,
-                });
-            }
-
-            if (params.loginSuccess !== undefined) {
-                this.messageService.postMessage({
-                    color: 'success',
-                    title: 'Login erfolgreich',
-                    body: 'Willkommen zurück!',
-                });
-            }
-
-            this.router.navigate([], {
-                queryParams: {
-                    loginFailure: null,
-                    logoutStatus: null,
-                    loginSuccess: null,
-                },
-                queryParamsHandling: 'merge',
-            });
+            const tree = this.router.parseUrl(this.router.url);
+            this.showAuthMessageToast(params);
+            this.clearQueryParams(tree);
         });
+    }
+
+    private clearQueryParams(tree: UrlTree) {
+        delete tree.queryParams['logoutStatus'];
+        delete tree.queryParams['loginFailure'];
+        delete tree.queryParams['loginSuccess'];
+        this.location.replaceState(this.router.serializeUrl(tree));
+    }
+
+    private showAuthMessageToast(params: AuthQueryParams) {
+        switch (params.logoutStatus) {
+            case 'loggedOut':
+                this.messageService.postMessage({
+                    title: 'Erfolgreich abgemeldet',
+                    color: 'info',
+                    body: 'Sie wurden erfolgreich abgemeldet.',
+                });
+                break;
+            case 'noSessionFound':
+                this.messageService.postMessage({
+                    title: 'Abmeldung fehlgeschlagen',
+                    color: 'warning',
+                    body: 'Es wurde keine aktive Sitzung gefunden.',
+                });
+                break;
+            case 'sessionExpired':
+                this.messageService.postMessage({
+                    title: 'Sitzung abgelaufen',
+                    color: 'warning',
+                    body: 'Ihre Sitzung ist abgelaufen.',
+                });
+                break;
+            default:
+                break;
+        }
+
+        if (params.loginFailure !== undefined) {
+            this.messageService.postMessage({
+                color: 'danger',
+                title: 'Login fehlgeschlagen',
+                body: params.loginFailure,
+            });
+        }
+
+        if (params.loginSuccess !== undefined) {
+            this.messageService.postMessage({
+                color: 'success',
+                title: 'Login erfolgreich',
+                body: 'Willkommen zurück!',
+            });
+        }
     }
 
     public get loginUrl() {


### PR DESCRIPTION
### Summary

Closes #1278 by
1. Using `Location.replaceState()` instead of `Router.navigate()` to remove the Query Parameters.
2. Moving the initialization of the `AuthService` to a `provideAppInitializer` provider, which leads to the application blocking on load until the user data has been fetched.

This assumes that navigating to `/` when removing URL-Parameters was unintentional.

Furthermore, it assumes that the `AuthService` should always be injected, and not only when a protected route is visited. I am not sure if this is the case.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [ ] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
