### PR TITLE
add tabular-nums attr to state-badge

### DIFF
--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-state-badge/exercise-state-badge.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-state-badge/exercise-state-badge.component.html
@@ -1,6 +1,6 @@
 @if (exerciseStatus$ | async; as exerciseStatus) {
     <span
-        class="badge rounded-pill bg-light text-dark"
+        class="badge rounded-pill bg-light text-dark state-badge"
         title="Übung {{
             exerciseStatus === 'notStarted'
                 ? 'wurde noch nicht gestartet'

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-state-badge/exercise-state-badge.component.scss
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-state-badge/exercise-state-badge.component.scss
@@ -1,0 +1,3 @@
+.state-badge {
+    font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
### Summary

This adds the [font-variant-numeric](https://developer.mozilla.org/de/docs/Web/CSS/Reference/Properties/font-variant-numeric): `tabular-nums` property to the exercise-state-badge, preventing it from moving the content right next to it.

Before:
[Bildschirmaufzeichnung vom 2026-03-17 13-58-26.webm](https://github.com/user-attachments/assets/6ab14f50-f0b6-4f2c-86f2-4b40e56107d2)

After:
[Bildschirmaufzeichnung vom 2026-03-17 13-58-45.webm](https://github.com/user-attachments/assets/ae2566fe-d3e9-4974-9365-0962a405e92b)


### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [X] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [X] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [X] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [X] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
