### PR TITLE
always pass an event onFeatureDrop()

### DIFF
--- a/frontend/src/app/pages/exercises/exercise/shared/core/drag-element.service.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/core/drag-element.service.ts
@@ -319,12 +319,13 @@ export class DragElementService {
                 break;
         }
 
-        this.executeDropSideEffects(pixel, createdElement);
+        this.executeDropSideEffects(pixel, createdElement, event);
     };
 
     private executeDropSideEffects(
         pixel: Pixel,
-        createdElement: Element | null
+        createdElement: Element | null,
+        event: MouseEvent
     ) {
         if (
             createdElement === null ||
@@ -343,7 +344,11 @@ export class DragElementService {
             // We stop propagating the event as soon as the onFeatureDropped function returns true
             return this.layerFeatureManagerDictionary
                 .get(layer as VectorLayer)!
-                .onFeatureDrop(createdElement, droppedOnFeature as Feature);
+                .onFeatureDrop(
+                    createdElement,
+                    droppedOnFeature as Feature,
+                    event
+                );
         });
     }
 

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/catering-lines-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/catering-lines-feature-manager.ts
@@ -106,7 +106,7 @@ export class CateringLinesFeatureManager
     onFeatureDrop(
         droppedElement: Element,
         droppedOnFeature: Feature<LineString>,
-        dropEvent?: TranslateEvent
+        dropEvent: MouseEvent | TranslateEvent
     ) {
         return false;
     }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/delete-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/delete-feature-manager.ts
@@ -87,7 +87,7 @@ export class DeleteFeatureManager implements FeatureManager<Point> {
     public onFeatureDrop(
         droppedElement: Element,
         droppedOnFeature: Feature<Point>,
-        dropEvent?: TranslateEvent
+        dropEvent: MouseEvent | TranslateEvent
     ) {
         const id = droppedElement.id;
         switch (droppedElement.type) {

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/moveable-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/moveable-feature-manager.ts
@@ -158,7 +158,7 @@ export abstract class MoveableFeatureManager<
     public onFeatureDrop(
         droppedElement: Element,
         droppedOnFeature: Feature<FeatureType>,
-        dropEvent?: TranslateEvent
+        dropEvent: MouseEvent | TranslateEvent
     ): boolean {
         return false;
     }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/simulated-region-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/simulated-region-feature-manager.ts
@@ -151,7 +151,7 @@ export class SimulatedRegionFeatureManager
     public override onFeatureDrop(
         droppedElement: Element | undefined,
         droppedOnFeature: Feature<any>,
-        dropEvent?: TranslateEvent
+        dropEvent: MouseEvent | TranslateEvent
     ) {
         const droppedOnSimulatedRegion = this.getElementFromFeature(
             droppedOnFeature

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-lines-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-lines-feature-manager.ts
@@ -113,7 +113,7 @@ export class TransferLinesFeatureManager
     onFeatureDrop(
         droppedElement: Element,
         droppedOnFeature: Feature<LineString>,
-        dropEvent?: TranslateEvent
+        dropEvent: MouseEvent | TranslateEvent
     ) {
         return false;
     }

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-point-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/transfer-point-feature-manager.ts
@@ -89,7 +89,7 @@ export class TransferPointFeatureManager extends MoveableFeatureManager<Transfer
     public override onFeatureDrop(
         droppedElement: Element | undefined,
         droppedOnFeature: Feature<Point>,
-        dropEvent?: TranslateEvent
+        dropEvent: MouseEvent | TranslateEvent
     ) {
         // TODO: droppedElement isn't necessarily a transfer point -> fix getElementFromFeature typings
         const droppedOnTransferPoint = this.getElementFromFeature(

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/vehicle-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/vehicle-feature-manager.ts
@@ -215,7 +215,7 @@ export class VehicleFeatureManager extends MoveableFeatureManager<Vehicle> {
     public override onFeatureDrop(
         droppedElement: Element | undefined,
         droppedOnFeature: Feature<Point>,
-        dropEvent?: TranslateEvent
+        dropEvent: MouseEvent | TranslateEvent
     ) {
         const droppedOnVehicle = this.getElementFromFeature(
             droppedOnFeature

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/feature-manager.ts
@@ -37,7 +37,7 @@ export interface FeatureManager<T extends Geometry> {
     onFeatureDrop: (
         droppedElement: Element,
         droppedOnFeature: Feature<T>,
-        dropEvent?: TranslateEvent
+        dropEvent: MouseEvent | TranslateEvent
     ) => boolean;
 
     register: (


### PR DESCRIPTION
### Summary

`FeatureManager.onFeatureDrop()` expected, that `dropEvent` could be undefined. As there are only two cases when it gets called, after a translate (`TranslateEvent`) and after drag-drop from the editor into the map (`MouseEvent`), this PR makes sure it is always given.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
