### PR TITLE
Fix: Keep non-requestable interactions in DOM

### DIFF
--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/signaller-modal/signaller-modal-interactions/signaller-modal-interactions.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/signaller-modal/signaller-modal-interactions/signaller-modal-interactions.component.html
@@ -33,87 +33,83 @@
         let index = $index
     ) {
         <li class="list-group-item" [class.active]="index === selectedIndex">
-            @if (interaction.requestable$ | async; as requestable) {
-                <div class="d-flex flex-row mb-2">
-                    <div class="flex-grow-1">
-                        <span [class.text-muted]="!requestable">
-                            <strong>{{ interaction.name }}</strong>
-                            @if (interaction.details; as details) {
-                                <span>
-                                    {{ details }}
-                                </span>
-                            }
-                        </span>
-                        @if (!requestable && interaction.errorMessage) {
-                            <br />
-                            <span class="text-warning">{{
-                                interaction.errorMessage
-                            }}</span>
+            @let requestable = interaction.requestable$ | async;
+            <div class="d-flex flex-row mb-2">
+                <div class="flex-grow-1">
+                    <span [class.text-muted]="!requestable">
+                        <strong>{{ interaction.name }}</strong>
+                        @if (interaction.details; as details) {
+                            <span>
+                                {{ details }}
+                            </span>
                         }
-                    </div>
-                    <div class="flex-shrink-1 text-nowrap">
-                        @let loading =
-                            interaction.loading$ === undefined
-                                ? false
-                                : (interaction.loading$ | async);
+                    </span>
+                    @if (!requestable && interaction.errorMessage) {
+                        <br />
+                        <span class="text-warning">{{
+                            interaction.errorMessage
+                        }}</span>
+                    }
+                </div>
+                <div class="flex-shrink-1 text-nowrap">
+                    @let loading =
+                        interaction.loading$ === undefined
+                            ? false
+                            : (interaction.loading$ | async);
+                    <button
+                        [disabled]="!requestable || loading"
+                        class="btn btn-primary"
+                        [class.btn-primary]="index !== selectedIndex"
+                        [class.btn-outline-light]="index === selectedIndex"
+                        (click)="interaction.callback()"
+                    >
+                        {{ primaryActionLabel() }}
+                        @if (loading) {
+                            <span
+                                class="spinner-border spinner-border-sm"
+                                role="status"
+                                aria-hidden="true"
+                            ></span>
+                        } @else {
+                            @if (index !== selectedIndex) {
+                                <app-hotkey-indicator
+                                    [hotkey]="interaction.hotkeys.primary"
+                                />
+                            }
+                            @if (index === selectedIndex) {
+                                <app-hotkey-indicator
+                                    [hotkey]="confirmHotkey"
+                                />
+                            }
+                        }
+                    </button>
+                    @if (showSecondaryButton()) {
                         <button
-                            [disabled]="!requestable || loading"
-                            class="btn btn-primary"
-                            [class.btn-primary]="index !== selectedIndex"
-                            [class.btn-outline-light]="index === selectedIndex"
-                            (click)="interaction.callback()"
+                            [disabled]="
+                                !requestable || !interaction.hasSecondaryAction
+                            "
+                            class="btn btn-secondary ms-1"
+                            (click)="tryCallSecondaryAction(interaction)"
                         >
-                            {{ primaryActionLabel() }}
-                            @if (loading) {
-                                <span
-                                    class="spinner-border spinner-border-sm"
-                                    role="status"
-                                    aria-hidden="true"
-                                ></span>
-                            } @else {
+                            <i class="bi bi-clock-history"></i>
+                            @if (interaction.hotkeys.secondary) {
                                 @if (index !== selectedIndex) {
                                     <app-hotkey-indicator
-                                        [hotkey]="interaction.hotkeys.primary"
+                                        [hotkey]="interaction.hotkeys.secondary"
+                                        class="ms-1"
                                     />
                                 }
                                 @if (index === selectedIndex) {
                                     <app-hotkey-indicator
-                                        [hotkey]="confirmHotkey"
+                                        [hotkey]="confirmSecondaryHotkey"
+                                        class="ms-1"
                                     />
                                 }
                             }
                         </button>
-                        @if (showSecondaryButton()) {
-                            <button
-                                [disabled]="
-                                    !requestable ||
-                                    !interaction.hasSecondaryAction
-                                "
-                                class="btn btn-secondary ms-1"
-                                (click)="tryCallSecondaryAction(interaction)"
-                            >
-                                <i class="bi bi-clock-history"></i>
-                                @if (interaction.hotkeys.secondary) {
-                                    @if (index !== selectedIndex) {
-                                        <app-hotkey-indicator
-                                            [hotkey]="
-                                                interaction.hotkeys.secondary
-                                            "
-                                            class="ms-1"
-                                        />
-                                    }
-                                    @if (index === selectedIndex) {
-                                        <app-hotkey-indicator
-                                            [hotkey]="confirmSecondaryHotkey"
-                                            class="ms-1"
-                                        />
-                                    }
-                                }
-                            </button>
-                        }
-                    </div>
+                    }
                 </div>
-            }
+            </div>
 
             @for (
                 radiogram of (requestedRadiograms$ | async)?.[


### PR DESCRIPTION
### Summary

#1290 converted the `*appLet` into an `@if`. This completely removes the interaction from the DOM. However, it should only be grayed out.

Bug introduced after last release, so no changelog written.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
