### PR TITLE
Fix layout of parallel exercise components

### DIFF
--- a/frontend/src/app/pages/exercises/parallel-exercise/instance-row/parallel-exercise-instance-row.component.html
+++ b/frontend/src/app/pages/exercises/parallel-exercise/instance-row/parallel-exercise-instance-row.component.html
@@ -5,7 +5,11 @@
 </td>
 <td>
     <code class="me-2">{{ exerciseInstance().participantKey }}</code>
-    <button app-copy-button [value]="participantUrl()"></button>
+    <button
+        app-copy-button
+        class="btn btn-light btn-sm"
+        [value]="participantUrl()"
+    ></button>
 </td>
 <td>{{ exerciseInstance().clientNames.join(', ') }}</td>
 <td>

--- a/frontend/src/app/pages/exercises/parallel-exercise/list/parallel-exercise-list.component.html
+++ b/frontend/src/app/pages/exercises/parallel-exercise/list/parallel-exercise-list.component.html
@@ -1,5 +1,5 @@
 <app-header />
-<div class="container">
+<main class="container">
     <h1>Meine Parallelübungen</h1>
     @if (parallelExercises.hasValue()) {
         <div class="row row-cols-3">
@@ -52,5 +52,5 @@
             }
         </div>
     }
-</div>
+</main>
 <app-footer />

--- a/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
+++ b/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
@@ -1,5 +1,5 @@
 <app-header />
-<div class="container">
+<main class="container">
     @if (parallelExercise.hasValue()) {
         @let exercise = parallelExercise.value();
         <h1 class="mb-4 d-flex align-items-center">
@@ -163,5 +163,5 @@
             }
         </div>
     }
-</div>
+</main>
 <app-footer />

--- a/frontend/src/app/shared/components/parallel-exercise-card/parallel-exercise-card.component.html
+++ b/frontend/src/app/shared/components/parallel-exercise-card/parallel-exercise-card.component.html
@@ -15,7 +15,11 @@
         </h2>
         <p class="card-text">
             Teilnehmenden-PIN: {{ parallelExercise().participantKey }}
-            <button app-copy-button [value]="participantUrl()"></button>
+            <button
+                app-copy-button
+                class="btn btn-light btn-sm"
+                [value]="participantUrl()"
+            ></button>
         </p>
     </div>
     <ul class="list-group list-group-flush">


### PR DESCRIPTION
### Summary

This fixes the page height of the parallel exercise components as well as the missing styling of some copy buttons.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
