### PR TITLE
Show expected reducer errors and without auto dismiss

### DIFF
--- a/frontend/src/app/core/exercise.service.ts
+++ b/frontend/src/app/core/exercise.service.ts
@@ -184,17 +184,23 @@ export class ExerciseService {
                     }
                 );
                 if (!response.success) {
+                    const errorMessage = `Action failed: ${response.message}`;
                     if (!response.expected) {
                         this.messageService.postError({
                             title: 'Fehler beim Senden der Aktion',
-                            error: response.message,
+                            error: errorMessage,
                         });
                     } else {
-                        this.messageService.postError({
-                            title: 'Diese Aktion ist nicht gestattet!',
-                            error: response.message,
-                        });
+                        this.messageService.postError(
+                            {
+                                title: 'Diese Aktion ist nicht gestattet!',
+                                body: response.message,
+                                error: errorMessage,
+                            },
+                            null
+                        );
                     }
+                    console.error(action);
                 }
                 return response;
             }

--- a/shared/src/store/action-reducers/utils/restricted-vehicle-movement.ts
+++ b/shared/src/store/action-reducers/utils/restricted-vehicle-movement.ts
@@ -12,7 +12,7 @@ import {
 import type { NoPosition } from '../../../models/utils/position/no-position.js';
 import type { Vehicle } from '../../../models/vehicle.js';
 import type { ExerciseState } from '../../../state.js';
-import { ReducerError } from '../../reducer-error.js';
+import { ExpectedReducerError } from '../../reducer-error.js';
 
 /**
  * Checks whether moving the vehicle from the old to the new position is allowed under the constraints of all restricted zones.
@@ -95,7 +95,7 @@ export function checkRestrictedVehicleMovementOrThrow(
             newPosition
         )
     )
-        throw new ReducerError(
+        throw new ExpectedReducerError(
             'Eine eingeschränkte Zone verbietet es, das Fahrzeug an diese Stelle zu bewegen.'
         );
 }


### PR DESCRIPTION
### Summary

Close #1323 and #1330

Additionally, this change requires participants to actively dismiss expected errors.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
