### PR TITLE
Improve InlineTextEditorComponent

### DIFF
--- a/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
+++ b/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
@@ -8,6 +8,7 @@
                 class="flex-grow-1"
                 [required]="true"
                 [value]="exercise.name"
+                name="Name der Paralellübung"
                 (update)="
                     patchParallelExercise({
                         name: $event,

--- a/frontend/src/app/shared/components/exercise-template-card/exercise-template-card.component.html
+++ b/frontend/src/app/shared/components/exercise-template-card/exercise-template-card.component.html
@@ -6,6 +6,7 @@
                     class="flex-grow-1"
                     [required]="true"
                     [value]="exerciseTemplate.name"
+                    name="Name der Übungsvorlage"
                     (update)="
                         patchExerciseTemplate({
                             name: $event,
@@ -35,6 +36,7 @@
                 <app-inline-text-editor
                     class="flex-grow-1"
                     [value]="exerciseTemplate.description"
+                    name="Beschreibung der Übungsvorlage"
                     (update)="
                         patchExerciseTemplate({
                             description: $event,

--- a/frontend/src/app/shared/components/inline-text-editor/inline-text-editor.component.html
+++ b/frontend/src/app/shared/components/inline-text-editor/inline-text-editor.component.html
@@ -35,7 +35,7 @@
             type="submit"
             [disabled]="!f.form.valid"
         >
-            <i class="bi bi-save"></i>
+            <i class="bi bi-floppy"></i>
         </button>
     </form>
 } @else {

--- a/frontend/src/app/shared/components/inline-text-editor/inline-text-editor.component.html
+++ b/frontend/src/app/shared/components/inline-text-editor/inline-text-editor.component.html
@@ -8,6 +8,7 @@
                     class="form-control"
                     [(ngModel)]="newValue"
                     [required]="required()"
+                    [title]="name()"
                     name="inline"
                     [appAutofocus]="true"
                 />
@@ -21,6 +22,7 @@
                     rows="3"
                     [(ngModel)]="newValue"
                     [required]="required()"
+                    [title]="name()"
                     name="inline"
                     [appAutofocus]="true"
                 ></textarea>
@@ -34,20 +36,21 @@
             class="btn btn-primary ms-2"
             type="submit"
             [disabled]="!f.form.valid"
+            title="Speichern"
         >
-            <i class="bi bi-floppy"></i>
+            <i class="bi bi-floppy" aria-hidden="true"></i>
         </button>
     </form>
 } @else {
     <div class="d-flex">
-        <div class="flex-grow-1">
+        <div class="flex-grow-1" [title]="name()">
             @if (value()) {
                 {{ value() }}
             } @else {
                 –
             }
         </div>
-        <button class="btn btn-sm" (click)="startEdit()">
+        <button class="btn btn-sm" (click)="startEdit()" title="Bearbeiten">
             <i class="bi bi-pencil"></i>
         </button>
     </div>

--- a/frontend/src/app/shared/components/inline-text-editor/inline-text-editor.component.ts
+++ b/frontend/src/app/shared/components/inline-text-editor/inline-text-editor.component.ts
@@ -12,6 +12,7 @@ import { AutofocusDirective } from '../../directives/autofocus.directive';
 export class InlineTextEditorComponent {
     readonly required = input<boolean>(false);
     readonly singleLine = input<boolean>(false);
+    readonly name = input.required<string>();
     readonly value = model<string>('');
     newValue = '';
     readonly update = output<string>();

--- a/frontend/src/app/shared/components/parallel-exercise-card/parallel-exercise-card.component.html
+++ b/frontend/src/app/shared/components/parallel-exercise-card/parallel-exercise-card.component.html
@@ -5,6 +5,7 @@
                 class="flex-grow-1"
                 [required]="true"
                 [value]="parallelExercise().name"
+                name="Name der Parallelübung"
                 (update)="
                     patchParallelExercise({
                         name: $event,


### PR DESCRIPTION
### Summary

Changes the icon of the save button in the inline text editor to `bi-floppy`. This makes the intent more clear.

Also adds a `name` that is used to set fitting titles.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
