### PR TITLE
fix: guard non-array vehicle priorities in preview

### DIFF
--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/provide-personnel/simulated-region-overview-behavior-provide-personnel.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/provide-personnel/simulated-region-overview-behavior-provide-personnel.component.ts
@@ -68,7 +68,11 @@ export class SimulatedRegionOverviewBehaviorProvidePersonnelComponent
         );
 
         const ownVehicleTemplateIds$ = behaviorState$.pipe(
-            map((behaviorState) => behaviorState.vehicleTemplatePriorities)
+            map((behaviorState) =>
+                normalizeVehicleTemplatePriorities(
+                    behaviorState.vehicleTemplatePriorities
+                )
+            )
         );
         const availableVehicleTemplates$ = this.store.select(
             selectVehicleTemplates
@@ -126,4 +130,15 @@ export class SimulatedRegionOverviewBehaviorProvidePersonnelComponent
             true
         );
     }
+}
+
+
+function normalizeVehicleTemplatePriorities(
+    vehicleTemplatePriorities: unknown
+): readonly UUID[] {
+    if (Array.isArray(vehicleTemplatePriorities)) {
+        return vehicleTemplatePriorities;
+    }
+
+    return [];
 }


### PR DESCRIPTION
Fixes #1300

`vehicleTemplatePriorities` can come through in an unexpected shape while loading/unloading data in the simulated region view. The component was calling `.includes()` directly and crashed when that value was not an array.

This normalizes the priorities before using them so non-array payloads fall back to an empty list instead of throwing.

Greetings, saschabuehrle
