### PR TITLE
Remove unused component import

### DIFF
--- a/frontend/src/app/pages/landing-page/landing-page/landing-page.component.ts
+++ b/frontend/src/app/pages/landing-page/landing-page/landing-page.component.ts
@@ -19,7 +19,6 @@ import { ApiService } from '../../../core/api.service';
 import { MessageService } from '../../../core/messages/message.service';
 import { HeaderComponent } from '../../../shared/components/header/header.component';
 import { AutofocusDirective } from '../../../shared/directives/autofocus.directive';
-import { DisplayValidationComponent } from '../../../shared/validation/display-validation/display-validation.component';
 import { FileInputDirective } from '../../../shared/directives/file-input.directive';
 import { FooterComponent } from '../../../shared/components/footer/footer.component';
 import { DisplayModelValidationComponent } from '../../../shared/validation/display-model-validation/display-model-validation.component';
@@ -32,7 +31,6 @@ import { DisplayModelValidationComponent } from '../../../shared/validation/disp
         HeaderComponent,
         FormsModule,
         AutofocusDirective,
-        DisplayValidationComponent,
         RouterLink,
         FileInputDirective,
         FooterComponent,


### PR DESCRIPTION
### Summary

`DisplayValidationComponent` is not used by `LandingPageComponent`, as indicated by a warning emitted by the Angular compiler.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
