### PR TITLE
chore: update prettier to 3.8.3

### DIFF
--- a/backend/src/test/utils.ts
+++ b/backend/src/test/utils.ts
@@ -65,14 +65,14 @@ export class WebsocketClient {
 
     public async emit<
         EventKey extends keyof ClientToServerEvents,
-        Event extends
-            ClientToServerEvents[EventKey] = ClientToServerEvents[EventKey],
+        Event extends ClientToServerEvents[EventKey] =
+            ClientToServerEvents[EventKey],
         EventParameters extends Parameters<Event> = Parameters<Event>,
         // We expect the callback to be the last parameter
-        EventCallback extends
-            LastElement<EventParameters> = LastElement<EventParameters>,
-        Response extends
-            Parameters<EventCallback>[0] = Parameters<EventCallback>[0],
+        EventCallback extends LastElement<EventParameters> =
+            LastElement<EventParameters>,
+        Response extends Parameters<EventCallback>[0] =
+            Parameters<EventCallback>[0],
     >(
         event: EventKey,
         ...args: HeadElements<Parameters<Event>>
@@ -93,16 +93,16 @@ export class WebsocketClient {
 
     public on<
         EventKey extends keyof AllServerToClientEvents,
-        Callback extends
-            AllServerToClientEvents[EventKey] = AllServerToClientEvents[EventKey],
+        Callback extends AllServerToClientEvents[EventKey] =
+            AllServerToClientEvents[EventKey],
     >(event: EventKey, callback: Callback): void {
         this.socket.on(event, callback as any);
     }
 
     public async waitOn<
         EventKey extends keyof AllServerToClientEvents,
-        Callback extends
-            AllServerToClientEvents[EventKey] = AllServerToClientEvents[EventKey],
+        Callback extends AllServerToClientEvents[EventKey] =
+            AllServerToClientEvents[EventKey],
         Response extends Parameters<Callback>[0] = Parameters<Callback>[0],
     >(event: EventKey): Promise<Response> {
         return new Promise<Response>((resolve) => {

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/moveable-feature-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/feature-managers/moveable-feature-manager.ts
@@ -28,9 +28,9 @@ import { ElementManager } from './element-manager';
  * Automatically redraws a feature (= reevaluates its style function) when an element property has changed.
  */
 export abstract class MoveableFeatureManager<
-        ManagedElement extends PositionableElement,
-        FeatureType extends GeometryWithCoordinates = Point,
-    >
+    ManagedElement extends PositionableElement,
+    FeatureType extends GeometryWithCoordinates = Point,
+>
     extends ElementManager<ManagedElement, FeatureType>
     implements FeatureManager<FeatureType>
 {

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/polygon-geometry-helper.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/polygon-geometry-helper.ts
@@ -13,9 +13,10 @@ import type {
 } from './geometry-helper';
 import { interpolate } from './geometry-helper';
 
-export class PolygonGeometryHelper
-    implements GeometryHelper<Polygon, ResizableElement>
-{
+export class PolygonGeometryHelper implements GeometryHelper<
+    Polygon,
+    ResizableElement
+> {
     create = (element: ResizableElement): Feature<Polygon> =>
         new Feature(new Polygon(this.getElementCoordinates(element)));
 

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/radiogram-list/radiogram-card/radiogram-card-content-missing-transfer-connection/radiogram-card-content-missing-transfer-connection.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/radiogram-list/radiogram-card/radiogram-card-content-missing-transfer-connection/radiogram-card-content-missing-transfer-connection.component.ts
@@ -23,9 +23,7 @@ import {
     ],
     imports: [AsyncPipe],
 })
-export class RadigoramCardContentMissingTransferConnectionComponent
-    implements OnInit
-{
+export class RadigoramCardContentMissingTransferConnectionComponent implements OnInit {
     private readonly store = inject<Store<AppState>>(Store);
 
     readonly radiogramId = input.required<UUID>();

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/radiogram-list/radiogram-card/radiogram-card-content-transfer-category-completed/radiogram-card-content-transfer-category-completed.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/radiogram-list/radiogram-card/radiogram-card-content-transfer-category-completed/radiogram-card-content-transfer-category-completed.component.ts
@@ -20,9 +20,7 @@ import { PatientStatusBadgeComponent } from '../../../../../../../../../shared/c
     ],
     imports: [PatientStatusBadgeComponent, AsyncPipe],
 })
-export class RadiogramCardContentTransferCategoryCompletedComponent
-    implements OnInit
-{
+export class RadiogramCardContentTransferCategoryCompletedComponent implements OnInit {
     private readonly store = inject<Store<AppState>>(Store);
 
     readonly radiogramId = input.required<UUID>();

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/radiogram-list/radiogram-card/radiogram-card-content-transfer-connections/radiogram-card-content-transfer-connections.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/radiogram-list/radiogram-card/radiogram-card-content-transfer-connections/radiogram-card-content-transfer-connections.component.ts
@@ -17,9 +17,7 @@ import { FormatDurationPipe } from '../../../../../../../../../shared/pipes/form
     styleUrls: ['./radiogram-card-content-transfer-connections.component.scss'],
     imports: [FormatDurationPipe, AsyncPipe],
 })
-export class RadiogramCardContentTransferConnectionsComponent
-    implements OnInit
-{
+export class RadiogramCardContentTransferConnectionsComponent implements OnInit {
     private readonly store = inject<Store<AppState>>(Store);
 
     readonly radiogramId = input.required<UUID>();

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/assign-leader/simulated-region-overview-behavior-assign-leader.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/assign-leader/simulated-region-overview-behavior-assign-leader.component.ts
@@ -17,9 +17,7 @@ import { createSelectPersonnel } from '../../../../../../../../../../state/appli
     ],
     imports: [AsyncPipe],
 })
-export class SimulatedRegionOverviewBehaviorAssignLeaderComponent
-    implements OnChanges
-{
+export class SimulatedRegionOverviewBehaviorAssignLeaderComponent implements OnChanges {
     private readonly store = inject<Store<AppState>>(Store);
 
     readonly assignLeaderBehaviorState =

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/automatically-distribute-vehicles/simulated-region-overview-behavior-automatically-distribute-vehicles.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/automatically-distribute-vehicles/simulated-region-overview-behavior-automatically-distribute-vehicles.component.ts
@@ -54,9 +54,7 @@ import { OrderByPipe } from '../../../../../../../../../../shared/pipes/order-by
         AsyncPipe,
     ],
 })
-export class SimulatedRegionOverviewBehaviorAutomaticallyDistributeVehiclesComponent
-    implements OnInit
-{
+export class SimulatedRegionOverviewBehaviorAutomaticallyDistributeVehiclesComponent implements OnInit {
     private readonly exerciseService = inject(ExerciseService);
     private readonly store = inject<Store<AppState>>(Store);
 

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/manage-patient-transport-to-hospital/shared/manage-patient-transport-to-hospital-managed-regions-table/manage-patient-transport-to-hospital-managed-regions-table.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/manage-patient-transport-to-hospital/shared/manage-patient-transport-to-hospital-managed-regions-table/manage-patient-transport-to-hospital-managed-regions-table.component.ts
@@ -47,9 +47,7 @@ import { AppSaveOnTypingDirective } from '../../../../../../../../../../../../sh
         AsyncPipe,
     ],
 })
-export class ManagePatientTransportToHospitalManagedRegionsTableComponent
-    implements OnChanges
-{
+export class ManagePatientTransportToHospitalManagedRegionsTableComponent implements OnChanges {
     private readonly store = inject<Store<AppState>>(Store);
     private readonly exerciseService = inject(ExerciseService);
 

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/manage-patient-transport-to-hospital/shared/manage-patient-transport-to-hospital-maximum-category-editor/manage-patient-transport-to-hospital-maximum-category-editor.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/manage-patient-transport-to-hospital/shared/manage-patient-transport-to-hospital-maximum-category-editor/manage-patient-transport-to-hospital-maximum-category-editor.component.ts
@@ -37,9 +37,7 @@ import { PatientStatusBadgeComponent } from '../../../../../../../../../../../..
         AsyncPipe,
     ],
 })
-export class ManagePatientTransportToHospitalMaximumCategoryEditorComponent
-    implements OnChanges
-{
+export class ManagePatientTransportToHospitalMaximumCategoryEditorComponent implements OnChanges {
     private readonly store = inject<Store<AppState>>(Store);
     private readonly exerciseService = inject(ExerciseService);
 

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/manage-patient-transport-to-hospital/shared/manage-patient-transport-to-hospital-request-target-editor/manage-patient-transport-to-hospital-request-target-editor.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/manage-patient-transport-to-hospital/shared/manage-patient-transport-to-hospital-request-target-editor/manage-patient-transport-to-hospital-request-target-editor.component.ts
@@ -26,9 +26,7 @@ import {
     ],
     imports: [FormsModule, AsyncPipe],
 })
-export class ManagePatientTransportToHospitalRequestTargetEditorComponent
-    implements OnChanges
-{
+export class ManagePatientTransportToHospitalRequestTargetEditorComponent implements OnChanges {
     private readonly store = inject<Store<AppState>>(Store);
     private readonly exerciseService = inject(ExerciseService);
 

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/manage-patient-transport-to-hospital/shared/manage-patient-transport-to-hospital-settings-editor/manage-patient-transport-to-hospital-settings-editor.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/manage-patient-transport-to-hospital/shared/manage-patient-transport-to-hospital-settings-editor/manage-patient-transport-to-hospital-settings-editor.component.ts
@@ -22,9 +22,7 @@ import { AppSaveOnTypingDirective } from '../../../../../../../../../../../../sh
     ],
     imports: [FormsModule, AppSaveOnTypingDirective, AsyncPipe],
 })
-export class ManagePatientTransportToHospitalSettingsEditorComponent
-    implements OnChanges
-{
+export class ManagePatientTransportToHospitalSettingsEditorComponent implements OnChanges {
     private readonly store = inject<Store<AppState>>(Store);
     private readonly exerciseService = inject(ExerciseService);
 

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/manage-patient-transport-to-hospital/shared/manage-patient-transport-to-hospital-status-editor/manage-patient-transport-to-hospital-status-editor.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/manage-patient-transport-to-hospital/shared/manage-patient-transport-to-hospital-status-editor/manage-patient-transport-to-hospital-status-editor.component.ts
@@ -20,9 +20,7 @@ import { ExerciseService } from '../../../../../../../../../../../../core/exerci
     ],
     imports: [AsyncPipe],
 })
-export class ManagePatientTransportToHospitalStatusEditorComponent
-    implements OnChanges
-{
+export class ManagePatientTransportToHospitalStatusEditorComponent implements OnChanges {
     private readonly store = inject<Store<AppState>>(Store);
     private readonly exerciseService = inject(ExerciseService);
 

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/manage-patient-transport-to-hospital/shared/manage-patient-transport-to-hospital-vehicles-for-categories-editor/manage-patient-transport-to-hospital-vehicles-for-categories-editor.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/manage-patient-transport-to-hospital/shared/manage-patient-transport-to-hospital-vehicles-for-categories-editor/manage-patient-transport-to-hospital-vehicles-for-categories-editor.component.ts
@@ -43,9 +43,7 @@ import { PatientStatusBadgeComponent } from '../../../../../../../../../../../..
         AsyncPipe,
     ],
 })
-export class ManagePatientTransportToHospitalVehiclesForCategoriesEditorComponent
-    implements OnChanges
-{
+export class ManagePatientTransportToHospitalVehiclesForCategoriesEditorComponent implements OnChanges {
     private readonly store = inject<Store<AppState>>(Store);
     private readonly exerciseService = inject(ExerciseService);
 

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/treat-patients/simulated-region-overview-behavior-treat-patients.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/treat-patients/simulated-region-overview-behavior-treat-patients.component.ts
@@ -48,9 +48,7 @@ let globalLastInformationCollapsed = true;
         AsyncPipe,
     ],
 })
-export class SimulatedRegionOverviewBehaviorTreatPatientsComponent
-    implements OnInit
-{
+export class SimulatedRegionOverviewBehaviorTreatPatientsComponent implements OnInit {
     private readonly exerciseService = inject(ExerciseService);
     private readonly store = inject<Store<AppState>>(Store);
     readonly selectPatientService = inject(SelectPatientService);

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/unload-arriving-vehicles/simulated-region-overview-behavior-unload-arriving-vehicles.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/behavior-tab/behaviors/unload-arriving-vehicles/simulated-region-overview-behavior-unload-arriving-vehicles.component.ts
@@ -38,9 +38,7 @@ import { FormatDurationPipe } from '../../../../../../../../../../shared/pipes/f
         AsyncPipe,
     ],
 })
-export class SimulatedRegionOverviewBehaviorUnloadArrivingVehiclesComponent
-    implements OnInit
-{
+export class SimulatedRegionOverviewBehaviorUnloadArrivingVehiclesComponent implements OnInit {
     private readonly exerciseService = inject(ExerciseService);
     readonly store = inject<Store<AppState>>(Store);
 

--- a/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.html
@@ -209,9 +209,7 @@
                                             <input
                                                 type="checkbox"
                                                 class="btn-check"
-                                                [id]="
-                                                    `patient-status-filter-${category}`
-                                                "
+                                                [id]="`patient-status-filter-${category}`"
                                                 autocomplete="off"
                                                 [ngModel]="
                                                     selectedCategories[
@@ -229,9 +227,7 @@
                                             />
                                             <label
                                                 class="btn btn-outline-primary"
-                                                [for]="
-                                                    `patient-status-filter-${category}`
-                                                "
+                                                [for]="`patient-status-filter-${category}`"
                                             >
                                                 <app-patient-status-badge
                                                     [status]="category"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "node-json2html": "^3.3.3",
                 "npm-run-all": "^4.1.5",
                 "nyc": "^17.1.0",
-                "prettier": "^3.5.3"
+                "prettier": "^3.8.3"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -4053,9 +4053,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-            "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
             "dev": true,
             "license": "MIT",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "node-json2html": "^3.3.3",
         "npm-run-all": "^4.1.5",
         "nyc": "^17.1.0",
-        "prettier": "^3.5.3",
+        "prettier": "^3.8.3",
         "eslint-plugin-antfu": "^3.2.2"
     },
     "overrides": {

--- a/shared/src/store/action-reducers/simulation.ts
+++ b/shared/src/store/action-reducers/simulation.ts
@@ -119,9 +119,7 @@ export class UpdateTreatPatientsIntervalsAction implements Action {
     public readonly countingTimePerPatient?: number;
 }
 
-export class ProvidePersonnelBehaviorUpdateVehiclePrioritiesAction
-    implements Action
-{
+export class ProvidePersonnelBehaviorUpdateVehiclePrioritiesAction implements Action {
     @IsValue('[ProvidePersonnelBehavior] Update VehiclePriorities' as const)
     public readonly type =
         '[ProvidePersonnelBehavior] Update VehiclePriorities';
@@ -136,9 +134,7 @@ export class ProvidePersonnelBehaviorUpdateVehiclePrioritiesAction
     public readonly priorities!: readonly UUID[];
 }
 
-export class UnloadArrivingVehiclesBehaviorUpdateUnloadDelayAction
-    implements Action
-{
+export class UnloadArrivingVehiclesBehaviorUpdateUnloadDelayAction implements Action {
     @IsValue('[UnloadArrivingVehiclesBehavior] Update UnloadDelay' as const)
     public readonly type =
         '[UnloadArrivingVehiclesBehavior] Update UnloadDelay';
@@ -184,9 +180,7 @@ export class UpdateReportTreatmentStatusChangesAction implements Action {
     public readonly reportChanges!: boolean;
 }
 
-export class UpdateReportTransferOfCategoryInSingleRegionCompletedAction
-    implements Action
-{
+export class UpdateReportTransferOfCategoryInSingleRegionCompletedAction implements Action {
     @IsValue(
         '[ReportBehavior] Update report transfer of category in single region completed'
     )
@@ -203,9 +197,7 @@ export class UpdateReportTransferOfCategoryInSingleRegionCompletedAction
     public readonly reportChanges!: boolean;
 }
 
-export class UpdateReportTransferOfCategoryInMultipleRegionsCompletedAction
-    implements Action
-{
+export class UpdateReportTransferOfCategoryInMultipleRegionsCompletedAction implements Action {
     @IsValue(
         '[ReportBehavior] Update report transfer of category in multiple regions completed'
     )
@@ -485,9 +477,7 @@ export class AddSimulatedRegionToManageForTransportAction implements Action {
     public readonly managedSimulatedRegionId!: UUID;
 }
 
-export class RemoveSimulatedRegionToManageFromTransportAction
-    implements Action
-{
+export class RemoveSimulatedRegionToManageFromTransportAction implements Action {
     @IsValue(
         '[ManagePatientsTransportToHospitalBehavior] Remove Simulated Region To Manage From Transport'
     )
@@ -504,9 +494,7 @@ export class RemoveSimulatedRegionToManageFromTransportAction
     public readonly managedSimulatedRegionId!: UUID;
 }
 
-export class UpdatePatientsExpectedInRegionForTransportAction
-    implements Action
-{
+export class UpdatePatientsExpectedInRegionForTransportAction implements Action {
     @IsValue(
         '[ManagePatientsTransportToHospitalBehavior] Update Patients Expected In Region For Transport'
     )
@@ -570,9 +558,7 @@ export class RemoveVehicleTypeForPatientTransportAction implements Action {
     public readonly patientStatus!: PatientStatusForTransport;
 }
 
-export class UpdateRequestVehicleDelayForPatientTransportAction
-    implements Action
-{
+export class UpdateRequestVehicleDelayForPatientTransportAction implements Action {
     @IsValue(
         '[ManagePatientsTransportToHospitalBehavior] Update Request Vehicle Delay For Patient Transport'
     )
@@ -590,9 +576,7 @@ export class UpdateRequestVehicleDelayForPatientTransportAction
     public readonly requestVehicleDelay!: number;
 }
 
-export class UpdateRequestPatientCountDelayForPatientTransportAction
-    implements Action
-{
+export class UpdateRequestPatientCountDelayForPatientTransportAction implements Action {
     @IsValue(
         '[ManagePatientsTransportToHospitalBehavior] Update Request Patient Count Delay For Patient Transport'
     )
@@ -610,9 +594,7 @@ export class UpdateRequestPatientCountDelayForPatientTransportAction
     public readonly requestPatientCountDelay!: number;
 }
 
-export class UpdatePromiseInvalidationIntervalForPatientTransportAction
-    implements Action
-{
+export class UpdatePromiseInvalidationIntervalForPatientTransportAction implements Action {
     @IsValue(
         '[ManagePatientsTransportToHospitalBehavior] Update Promise Invalidation Interval For Patient Transport'
     )


### PR DESCRIPTION
### Summary

Updates the dependency prettier to version 3.8.3. This (among other things) adds support for some previously not supported angular template syntax.

Apart from the changes to `package-lock.json`, all changes were done by prettier as a result of the update.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
