### PR TITLE
Implement Exercise Lazy-Loading

### DIFF
--- a/backend/src/database/repositories/exercise-repository.ts
+++ b/backend/src/database/repositories/exercise-repository.ts
@@ -1,5 +1,11 @@
-import type { ExerciseId, ExerciseTemplateId } from 'fuesim-digital-shared';
-import { ExerciseState } from 'fuesim-digital-shared';
+import type {
+    ExerciseId,
+    ExerciseKey,
+    ExerciseTemplateId,
+    ParticipantKey,
+    TrainerKey,
+} from 'fuesim-digital-shared';
+import { ExerciseState, isTrainerKey } from 'fuesim-digital-shared';
 import { getTableColumns, sql, eq, lt, and, isNull, desc } from 'drizzle-orm';
 import type { ExerciseInsert, ExerciseTemplateInsert } from '../schema.js';
 import { exerciseTable, exerciseTemplateTable } from '../schema.js';
@@ -38,6 +44,25 @@ export class ExerciseRepository extends BaseRepository {
     public async getExerciseById(id: ExerciseId) {
         return this.onlySingle(
             await this.exerciseQuery.where(eq(exerciseTable.id, id))
+        );
+    }
+
+    public async getExerciseByKey(key: ExerciseKey) {
+        if (isTrainerKey(key)) return this.getExerciseByTrainerKey(key);
+        return this.getExerciseByParticipantKey(key);
+    }
+
+    public async getExerciseByTrainerKey(key: TrainerKey) {
+        return this.onlySingle(
+            await this.exerciseQuery.where(eq(exerciseTable.trainerKey, key))
+        );
+    }
+
+    public async getExerciseByParticipantKey(key: ParticipantKey) {
+        return this.onlySingle(
+            await this.exerciseQuery.where(
+                eq(exerciseTable.participantKey, key)
+            )
         );
     }
 

--- a/backend/src/database/services/exercise-manager-service.spec.ts
+++ b/backend/src/database/services/exercise-manager-service.spec.ts
@@ -46,6 +46,10 @@ describe('exercise manager service', () => {
                 'standalone',
                 sessionInformation
             );
+        await environment.services.exerciseService.getExerciseByKey(
+            newActiveExercise.trainerKey,
+            sessionInformation
+        );
         expect(
             environment.services.exerciseService.TESTING_getExerciseMap().size
         ).toBe(6);

--- a/backend/src/database/services/exercise-manager-service.spec.ts
+++ b/backend/src/database/services/exercise-manager-service.spec.ts
@@ -21,10 +21,11 @@ describe('exercise manager service', () => {
             environment,
             session
         );
-        const exercise = environment.services.exerciseService.getExerciseByKey(
-            exerciseTemplate.trainerKey,
-            sessionInformation
-        );
+        const exercise =
+            await environment.services.exerciseService.getExerciseByKey(
+                exerciseTemplate.trainerKey,
+                sessionInformation
+            );
         const action: ExerciseAction = {
             type: '[AlarmGroup] Add AlarmGroup',
             alarmGroup: {

--- a/backend/src/database/services/exercise-manager-service.ts
+++ b/backend/src/database/services/exercise-manager-service.ts
@@ -159,7 +159,7 @@ export class ExerciseManagerService {
         if (exerciseTemplate.user !== session.user.id) {
             throw new PermissionDeniedError();
         }
-        const activeExercise = this.exerciseService.getExerciseByKey(
+        const activeExercise = await this.exerciseService.getExerciseByKey(
             exerciseTemplate.trainerKey,
             session
         );

--- a/backend/src/database/services/exercise-manager-service.ts
+++ b/backend/src/database/services/exercise-manager-service.ts
@@ -139,7 +139,6 @@ export class ExerciseManagerService {
         const newExercise =
             await this.exerciseService.createExercise(newExerciseEntry);
         const activeExercise = new ActiveExercise(newExercise, []);
-        await this.exerciseService.loadExercise(activeExercise);
         await this.exerciseRepository.updateExerciseTemplate(
             exerciseTemplate.id,
             { lastExerciseCreatedAt: new Date() }

--- a/backend/src/database/services/exercise-manager-service.ts
+++ b/backend/src/database/services/exercise-manager-service.ts
@@ -184,7 +184,8 @@ export class ExerciseManagerService {
             throw new PermissionDeniedError();
         }
         return this.exerciseService.getExercisesViewportsById(
-            exerciseTemplate.exercise.id
+            exerciseTemplate.exercise.id,
+            session
         );
     }
 }

--- a/backend/src/database/services/exercise-service.spec.ts
+++ b/backend/src/database/services/exercise-service.spec.ts
@@ -20,9 +20,10 @@ describe('Exercise-Service', () => {
     // In a naive implementation it can happen that such actions get removed from memory without being saved to the database.
     it('does not throw away actions while saving', async () => {
         const exerciseKeys = await createExercise(environment);
-        const exercise = environment.services.exerciseService.getExerciseByKey(
-            exerciseKeys.trainerKey
-        );
+        const exercise =
+            await environment.services.exerciseService.getExerciseByKey(
+                exerciseKeys.trainerKey
+            );
         const markAsAboutToBeSaved =
             exercise.markAsAboutToBeSaved.bind(exercise);
 
@@ -66,9 +67,10 @@ describe('Exercise-Service', () => {
     });
     it('does correctly update lastUsedAt', async () => {
         const exerciseKeys = await createExercise(environment);
-        const exercise = environment.services.exerciseService.getExerciseByKey(
-            exerciseKeys.trainerKey
-        );
+        const exercise =
+            await environment.services.exerciseService.getExerciseByKey(
+                exerciseKeys.trainerKey
+            );
         const beforeAction = Date.now();
         exercise.applyAction(
             {

--- a/backend/src/database/services/exercise-service.spec.ts
+++ b/backend/src/database/services/exercise-service.spec.ts
@@ -51,17 +51,16 @@ describe('Exercise-Service', () => {
             null
         );
 
-        const saveTick: () => Promise<void> = (
-            environment.server as any
-        ).saveTick.bind(environment.server);
-        await saveTick();
+        const saveUnsavedExercises = async () =>
+            environment.services.exerciseService.saveUnsavedExercises();
+        await saveUnsavedExercises();
 
         expect(markAsAboutToBeSavedMock).toHaveBeenCalledTimes(1);
         // one action still unsaved
         expect(exercise.temporaryActionHistory.length).toBe(1);
 
         markAsAboutToBeSaved();
-        await saveTick();
+        await saveUnsavedExercises();
         expect(markAsAboutToBeSavedMock).toHaveBeenCalledTimes(2);
         expect(exercise.temporaryActionHistory.length).toBe(0);
     });
@@ -87,7 +86,7 @@ describe('Exercise-Service', () => {
             null
         );
 
-        await environment.server.saveTick();
+        await environment.services.exerciseService.saveUnsavedExercises();
 
         const exerciseEntry =
             await environment.repositories.exerciseRepository.getExerciseById(
@@ -124,7 +123,7 @@ describe('Exercise-Service', () => {
             null
         );
 
-        await environment.server.saveTick();
+        await environment.services.exerciseService.saveUnsavedExercises();
 
         const exerciseTemplateEntry =
             await environment.repositories.exerciseRepository.getExerciseTemplateById(
@@ -137,5 +136,84 @@ describe('Exercise-Service', () => {
         expect(exerciseTemplateEntry!.lastUpdatedAt.getTime()).toBeLessThan(
             Date.now()
         );
+    });
+
+    describe('upkeep tick', () => {
+        it('unloads exercises with no clients', async () => {
+            const exerciseKeys = await createExercise(environment);
+            const exerciseMap =
+                environment.services.exerciseService.TESTING_getExerciseMap();
+            expect(exerciseMap.has(exerciseKeys.trainerKey)).toBe(true);
+
+            await environment.server.exerciseUpkeepTick();
+
+            expect(exerciseMap.has(exerciseKeys.trainerKey)).toBe(false);
+            expect(exerciseMap.has(exerciseKeys.participantKey)).toBe(false);
+        });
+
+        it('keeps exercises with active clients', async () => {
+            const exerciseKeys = await createExercise(environment);
+            const exerciseMap =
+                environment.services.exerciseService.TESTING_getExerciseMap();
+
+            await environment.withWebsocket(async (socket) => {
+                const join = await socket.emit(
+                    'joinExercise',
+                    exerciseKeys.trainerKey,
+                    'Test'
+                );
+                expect(join.success).toBe(true);
+
+                await environment.server.exerciseUpkeepTick();
+
+                expect(exerciseMap.has(exerciseKeys.trainerKey)).toBe(true);
+            });
+        });
+    });
+
+    describe('restoring from database', () => {
+        it('getExerciseByKey restores an unloaded exercise', async () => {
+            const exerciseKeys = await createExercise(environment);
+            const originalId = (
+                await environment.services.exerciseService.getExerciseByKey(
+                    exerciseKeys.trainerKey
+                )
+            ).exercise.id;
+            const exerciseMap =
+                environment.services.exerciseService.TESTING_getExerciseMap();
+
+            await environment.server.exerciseUpkeepTick();
+            expect(exerciseMap.has(exerciseKeys.trainerKey)).toBe(false);
+
+            const restored =
+                await environment.services.exerciseService.getExerciseByKey(
+                    exerciseKeys.trainerKey
+                );
+
+            expect(restored.exercise.id).toBe(originalId);
+            expect(exerciseMap.has(exerciseKeys.trainerKey)).toBe(true);
+        });
+
+        it('getExerciseById restores an unloaded exercise', async () => {
+            const exerciseKeys = await createExercise(environment);
+            const originalId = (
+                await environment.services.exerciseService.getExerciseByKey(
+                    exerciseKeys.trainerKey
+                )
+            ).exercise.id;
+            const exerciseMap =
+                environment.services.exerciseService.TESTING_getExerciseMap();
+
+            await environment.server.exerciseUpkeepTick();
+            expect(exerciseMap.has(originalId)).toBe(false);
+
+            const restored =
+                await environment.services.exerciseService.getExerciseById(
+                    originalId
+                );
+
+            expect(restored.exercise.id).toBe(originalId);
+            expect(exerciseMap.has(originalId)).toBe(true);
+        });
     });
 });

--- a/backend/src/database/services/exercise-service.spec.ts
+++ b/backend/src/database/services/exercise-service.spec.ts
@@ -100,13 +100,20 @@ describe('Exercise-Service', () => {
     });
     it('does correctly update lastUpdatedAt for exercise templates', async () => {
         const session = await createTestUserSession(environment);
+        const sessionInformation =
+            (await environment.services.authService.getDataFromSessionToken(
+                session
+            ))!;
+
         const exerciseTemplate = await createExerciseTemplate(
             environment,
             session
         );
-        const exercise = environment.services.exerciseService
-            .TESTING_getExerciseMap()
-            .get(exerciseTemplate.trainerKey)!;
+        const exercise =
+            await environment.services.exerciseService.getExerciseByKey(
+                exerciseTemplate.trainerKey,
+                sessionInformation
+            );
         const beforeAction = Date.now();
         exercise.applyAction(
             {
@@ -143,6 +150,10 @@ describe('Exercise-Service', () => {
             const exerciseKeys = await createExercise(environment);
             const exerciseMap =
                 environment.services.exerciseService.TESTING_getExerciseMap();
+            // Ensure exercise is loaded into in-memory map
+            await environment.services.exerciseService.getExerciseByKey(
+                exerciseKeys.trainerKey
+            );
             expect(exerciseMap.has(exerciseKeys.trainerKey)).toBe(true);
 
             await environment.server.exerciseUpkeepTick();
@@ -168,52 +179,6 @@ describe('Exercise-Service', () => {
 
                 expect(exerciseMap.has(exerciseKeys.trainerKey)).toBe(true);
             });
-        });
-    });
-
-    describe('restoring from database', () => {
-        it('getExerciseByKey restores an unloaded exercise', async () => {
-            const exerciseKeys = await createExercise(environment);
-            const originalId = (
-                await environment.services.exerciseService.getExerciseByKey(
-                    exerciseKeys.trainerKey
-                )
-            ).exercise.id;
-            const exerciseMap =
-                environment.services.exerciseService.TESTING_getExerciseMap();
-
-            await environment.server.exerciseUpkeepTick();
-            expect(exerciseMap.has(exerciseKeys.trainerKey)).toBe(false);
-
-            const restored =
-                await environment.services.exerciseService.getExerciseByKey(
-                    exerciseKeys.trainerKey
-                );
-
-            expect(restored.exercise.id).toBe(originalId);
-            expect(exerciseMap.has(exerciseKeys.trainerKey)).toBe(true);
-        });
-
-        it('getExerciseById restores an unloaded exercise', async () => {
-            const exerciseKeys = await createExercise(environment);
-            const originalId = (
-                await environment.services.exerciseService.getExerciseByKey(
-                    exerciseKeys.trainerKey
-                )
-            ).exercise.id;
-            const exerciseMap =
-                environment.services.exerciseService.TESTING_getExerciseMap();
-
-            await environment.server.exerciseUpkeepTick();
-            expect(exerciseMap.has(originalId)).toBe(false);
-
-            const restored =
-                await environment.services.exerciseService.getExerciseById(
-                    originalId
-                );
-
-            expect(restored.exercise.id).toBe(originalId);
-            expect(exerciseMap.has(originalId)).toBe(true);
         });
     });
 });

--- a/backend/src/database/services/exercise-service.ts
+++ b/backend/src/database/services/exercise-service.ts
@@ -45,6 +45,12 @@ export class ExerciseService {
         ActiveExercise
     >();
 
+    /*
+     * NOTE: This does NOT load the exercise into the in-memory
+     * map if it is fetched from the database. If you make changes
+     * to the exercise and are unsure if it's currently loaded,
+     * call exerciseService.loadExercise() after modification.
+     */
     public async getExerciseByKey(
         exerciseKey: ExerciseKey,
         session?: SessionInformation
@@ -63,9 +69,16 @@ export class ExerciseService {
         ) {
             throw new PermissionDeniedError();
         }
+        this.loadExercise(exercise);
         return exercise;
     }
 
+    /*
+     * NOTE: This does NOT load the exercise into the in-memory
+     * map if it is fetched from the database. If you make changes
+     * to the exercise and are unsure if it's currently loaded,
+     * call exerciseService.loadExercise() after modification.
+     */
     public async getExerciseById(
         exerciseId: ExerciseId,
         session?: SessionInformation
@@ -80,6 +93,7 @@ export class ExerciseService {
         if (exercise.template && exercise.template.user !== session?.user.id) {
             throw new PermissionDeniedError();
         }
+        this.loadExercise(exercise);
         return exercise;
     }
 

--- a/backend/src/database/services/exercise-service.ts
+++ b/backend/src/database/services/exercise-service.ts
@@ -45,11 +45,13 @@ export class ExerciseService {
         ActiveExercise
     >();
 
-    public getExerciseByKey(
+    public async getExerciseByKey(
         exerciseKey: ExerciseKey,
         session?: SessionInformation
     ) {
-        const exercise = this.exerciseMap.get(exerciseKey);
+        const exercise =
+            this.exerciseMap.get(exerciseKey) ??
+            (await this.restoreExercise(exerciseKey));
         if (!exercise) {
             throw new NotFoundError();
         }
@@ -223,9 +225,9 @@ export class ExerciseService {
     }
 
     /**
-     * Restore all Exercises from Database; called on startup
+     * Migrate all outdated Exercises in Database; called on startup
      */
-    public async restoreAllExercises(): Promise<ActiveExercise[]> {
+    public async migrateAllExercises(): Promise<number> {
         return this.exerciseRepository.transaction(
             async (exerciseRepoTransaction) => {
                 const outdatedExercises =
@@ -243,47 +245,52 @@ export class ExerciseService {
                     })
                 );
 
-                const exercises = await Promise.all(
-                    (await exerciseRepoTransaction.getAllExercises()).map(
-                        async (exerciseEntity) => {
-                            const exercise = new ActiveExercise(exerciseEntity);
-                            exercise.template = exerciseEntity.template ?? null;
+                return outdatedExercises.length;
+            }
+        );
+    }
 
-                            // Load all actions
-                            pushAll(
-                                exercise.temporaryActionHistory,
-                                (
-                                    await this.actionRepository
-                                        .withConnection(exerciseRepoTransaction)
-                                        .getActionsForExerciseId(
-                                            exerciseEntity.id
-                                        )
-                                ).map(
-                                    (actionEntity) =>
-                                        new ActionWrapper(
-                                            actionEntity.actionString,
-                                            actionEntity.emitterId,
-                                            exercise,
-                                            actionEntity.index,
-                                            actionEntity.id
-                                        )
-                                )
-                            );
-                            return exercise;
-                        }
+    /**
+     * Attempt to restore an Exercise from Database
+     */
+    public async restoreExercise(
+        key: ExerciseKey
+    ): Promise<ActiveExercise | null> {
+        return this.exerciseRepository.transaction(
+            async (exerciseRepoTransaction) => {
+                const exerciseEntity =
+                    await exerciseRepoTransaction.getExerciseByKey(key);
+
+                if (!exerciseEntity) return null;
+
+                const exercise = new ActiveExercise(exerciseEntity);
+                exercise.template = exerciseEntity.template ?? null;
+
+                // Load all actions
+                pushAll(
+                    exercise.temporaryActionHistory,
+                    (
+                        await this.actionRepository
+                            .withConnection(exerciseRepoTransaction)
+                            .getActionsForExerciseId(exerciseEntity.id)
+                    ).map(
+                        (actionEntity) =>
+                            new ActionWrapper(
+                                actionEntity.actionString,
+                                actionEntity.emitterId,
+                                exercise,
+                                actionEntity.index,
+                                actionEntity.id
+                            )
                     )
                 );
-                await Promise.all(
-                    // The actions have already been saved in the database -> do not keep them
-                    exercises.map(async (exercise) => exercise.restore(false))
-                );
-                exercises.forEach((exercise) => {
-                    this.exerciseMap.set(exercise.participantKey, exercise);
-                    this.exerciseMap.set(exercise.trainerKey, exercise);
-                    this.exerciseMap.set(exercise.exercise.id, exercise);
-                    this.loadExercise(exercise);
-                });
-                return exercises;
+
+                // The actions have already been saved in the database -> do not keep them
+                exercise.restore(false);
+
+                this.loadExercise(exercise);
+
+                return exercise;
             }
         );
     }
@@ -303,7 +310,10 @@ export class ExerciseService {
             throw new PermissionDeniedError();
         }
 
-        const activeExercise = this.getExerciseByKey(exerciseKey, session);
+        const activeExercise = await this.getExerciseByKey(
+            exerciseKey,
+            session
+        );
 
         const exerciseEntry = await this.exerciseRepository.getExerciseById(
             activeExercise.exercise.id
@@ -354,11 +364,20 @@ export class ExerciseService {
         });
     }
 
+    public async unloadEmptyExercises() {
+        new Set(this.exerciseMap.values()).forEach((exercise) => {
+            if (exercise.clients.size === 0) this.unloadExercise(exercise);
+        });
+    }
+
     public async getTimeline(
         exerciseKey: ExerciseKey,
         session?: SessionInformation
     ): Promise<ExerciseTimeline> {
-        const activeExercise = this.getExerciseByKey(exerciseKey, session);
+        const activeExercise = await this.getExerciseByKey(
+            exerciseKey,
+            session
+        );
         const completeHistory: ExerciseTimeline['actionsWrappers'] = [
             ...(
                 await this.actionRepository.getActionsForExerciseId(

--- a/backend/src/database/services/exercise-service.ts
+++ b/backend/src/database/services/exercise-service.ts
@@ -51,7 +51,7 @@ export class ExerciseService {
     ) {
         const exercise =
             this.exerciseMap.get(exerciseKey) ??
-            (await this.restoreExercise(exerciseKey));
+            (await this.restoreExerciseByKey(exerciseKey));
         if (!exercise) {
             throw new NotFoundError();
         }
@@ -61,6 +61,23 @@ export class ExerciseService {
             (exercise.template.user !== session?.user.id ||
                 !isTrainerKey(exerciseKey))
         ) {
+            throw new PermissionDeniedError();
+        }
+        return exercise;
+    }
+
+    public async getExerciseById(
+        exerciseId: ExerciseId,
+        session?: SessionInformation
+    ) {
+        const exercise =
+            this.exerciseMap.get(exerciseId) ??
+            (await this.restoreExerciseById(exerciseId));
+        if (!exercise) {
+            throw new NotFoundError();
+        }
+
+        if (exercise.template && exercise.template.user !== session?.user.id) {
             throw new PermissionDeniedError();
         }
         return exercise;
@@ -251,48 +268,57 @@ export class ExerciseService {
     }
 
     /**
-     * Attempt to restore an Exercise from Database
+     * Attempt to restore an Exercise from Database by its key
      */
-    public async restoreExercise(
-        key: ExerciseKey
+    public async restoreExerciseByKey(key: ExerciseKey) {
+        return this.restoreExerciseFrom(async (tx) => tx.getExerciseByKey(key));
+    }
+
+    /**
+     * Attempt to restore an Exercise from Database by its id
+     */
+    public async restoreExerciseById(id: ExerciseId) {
+        return this.restoreExerciseFrom(async (tx) => tx.getExerciseById(id));
+    }
+
+    private async restoreExerciseFrom(
+        lookup: (
+            tx: ExerciseRepository
+        ) => ReturnType<ExerciseRepository['getExerciseByKey']> // TODO: Find better way to type this
     ): Promise<ActiveExercise | null> {
-        return this.exerciseRepository.transaction(
-            async (exerciseRepoTransaction) => {
-                const exerciseEntity =
-                    await exerciseRepoTransaction.getExerciseByKey(key);
+        return this.exerciseRepository.transaction(async (tx) => {
+            const exerciseEntity = await lookup(tx);
+            if (!exerciseEntity) return null;
 
-                if (!exerciseEntity) return null;
+            const exercise = new ActiveExercise(exerciseEntity);
+            exercise.template = exerciseEntity.template ?? null;
 
-                const exercise = new ActiveExercise(exerciseEntity);
-                exercise.template = exerciseEntity.template ?? null;
+            // Load all actions
+            pushAll(
+                exercise.temporaryActionHistory,
+                (
+                    await this.actionRepository
+                        .withConnection(tx)
+                        .getActionsForExerciseId(exerciseEntity.id)
+                ).map(
+                    (actionEntity) =>
+                        new ActionWrapper(
+                            actionEntity.actionString,
+                            actionEntity.emitterId,
+                            exercise,
+                            actionEntity.index,
+                            actionEntity.id
+                        )
+                )
+            );
 
-                // Load all actions
-                pushAll(
-                    exercise.temporaryActionHistory,
-                    (
-                        await this.actionRepository
-                            .withConnection(exerciseRepoTransaction)
-                            .getActionsForExerciseId(exerciseEntity.id)
-                    ).map(
-                        (actionEntity) =>
-                            new ActionWrapper(
-                                actionEntity.actionString,
-                                actionEntity.emitterId,
-                                exercise,
-                                actionEntity.index,
-                                actionEntity.id
-                            )
-                    )
-                );
+            // The actions have already been saved in the database -> do not keep them
+            exercise.restore(false);
 
-                // The actions have already been saved in the database -> do not keep them
-                exercise.restore(false);
+            this.loadExercise(exercise);
 
-                this.loadExercise(exercise);
-
-                return exercise;
-            }
-        );
+            return exercise;
+        });
     }
 
     /**
@@ -403,11 +429,11 @@ export class ExerciseService {
         };
     }
 
-    public getExercisesViewportsById(id: ExerciseId) {
-        const activeExercise = this.exerciseMap.get(id);
-        if (!activeExercise) {
-            throw new NotFoundError();
-        }
+    public async getExercisesViewportsById(
+        id: ExerciseId,
+        session?: SessionInformation
+    ) {
+        const activeExercise = await this.getExerciseById(id, session);
         return Object.values(
             activeExercise.exercise.currentStateString.viewports
         );

--- a/backend/src/database/services/exercise-service.ts
+++ b/backend/src/database/services/exercise-service.ts
@@ -144,7 +144,6 @@ export class ExerciseService {
         } satisfies ExerciseInsert;
         const exerciseEntry = await this.createExercise(exerciseInsert);
         const activeExercise = new ActiveExercise(exerciseEntry);
-        await this.loadExercise(activeExercise);
         return activeExercise;
     }
 
@@ -200,8 +199,6 @@ export class ExerciseService {
 
             // The actions haven't been saved in the database yet -> keep them
             activeExercise.restore(true);
-
-            await this.loadExercise(activeExercise);
 
             return activeExercise;
         } catch (err) {
@@ -314,8 +311,6 @@ export class ExerciseService {
 
             // The actions have already been saved in the database -> do not keep them
             exercise.restore(false);
-
-            this.loadExercise(exercise);
 
             return exercise;
         });

--- a/backend/src/database/services/parallel-exercise-service.ts
+++ b/backend/src/database/services/parallel-exercise-service.ts
@@ -186,8 +186,12 @@ export class ParallelExerciseService {
             await this.parallelExerciseRepository.getParallelExerciseInstancesById(
                 parallelExercise.id
             );
-        const activeExercises = exerciseInstances.map((exerciseEntry) =>
-            this.exerciseService.getExerciseByKey(exerciseEntry.participantKey)
+        const activeExercises = await Promise.all(
+            exerciseInstances.map(async (exerciseEntry) =>
+                this.exerciseService.getExerciseByKey(
+                    exerciseEntry.participantKey
+                )
+            )
         );
         return activeExercises;
     }

--- a/backend/src/database/services/parallel-exercise-service.ts
+++ b/backend/src/database/services/parallel-exercise-service.ts
@@ -89,6 +89,9 @@ export class ParallelExerciseService {
         };
         exercise.applyAction(setAutojoinViewportAction, null);
 
+        // Ensure exercise is in-memory to persist changes
+        this.exerciseService.loadExercise(exercise);
+
         this.newJoin.next({
             parallelExerciseId: parallelExercise.id,
             activeExercise: exercise,

--- a/backend/src/exercise/client-wrapper.ts
+++ b/backend/src/exercise/client-wrapper.ts
@@ -91,7 +91,7 @@ export class ExerciseClientWrapper extends ClientWrapper {
                 : role !== 'trainer'
         );
         this.chosenExercise.addClient(this);
-        // Load exercise only after client has been added to
+        // Load exercise again after client has been added to
         // prevent immediate removal by automatic unloading
         this.services.exerciseService.loadExercise(this.chosenExercise);
         return this.relatedExerciseClient.id;

--- a/backend/src/exercise/client-wrapper.ts
+++ b/backend/src/exercise/client-wrapper.ts
@@ -70,11 +70,15 @@ export class ExerciseClientWrapper extends ClientWrapper {
      * @param clientName The public name of the client.
      * @returns The joined client's id, or undefined when the exercise doesn't exist.
      */
-    public joinExercise(exerciseKey: ExerciseKey, clientName: string): UUID {
-        this.chosenExercise = this.services.exerciseService.getExerciseByKey(
-            exerciseKey,
-            this.session
-        );
+    public async joinExercise(
+        exerciseKey: ExerciseKey,
+        clientName: string
+    ): Promise<UUID> {
+        this.chosenExercise =
+            await this.services.exerciseService.getExerciseByKey(
+                exerciseKey,
+                this.session
+            );
         // Although getRoleFromUsedId may throw an error, this should never happen here
         // as the provided id is guaranteed to be one of the ids of the exercise as the exercise
         // was fetched with this exact id from the exercise map.

--- a/backend/src/exercise/client-wrapper.ts
+++ b/backend/src/exercise/client-wrapper.ts
@@ -91,6 +91,9 @@ export class ExerciseClientWrapper extends ClientWrapper {
                 : role !== 'trainer'
         );
         this.chosenExercise.addClient(this);
+        // Load exercise only after client has been added to
+        // prevent immediate removal by automatic unloading
+        this.services.exerciseService.loadExercise(this.chosenExercise);
         return this.relatedExerciseClient.id;
     }
 

--- a/backend/src/exercise/websocket-handler/join-exercise-handler.spec.ts
+++ b/backend/src/exercise/websocket-handler/join-exercise-handler.spec.ts
@@ -13,6 +13,7 @@ import {
     createTestEnvironment,
     createTestUserSession,
 } from '../../test/utils.js';
+import type { SessionInformation } from '../../auth/auth-service.js';
 
 describe('join exercise', () => {
     const environment = createTestEnvironment();
@@ -60,12 +61,17 @@ describe('join exercise', () => {
     describe('exercise template', () => {
         let exerciseTemplate: GetExerciseTemplateResponseData;
         let session: string;
+        let sessionInformation: SessionInformation;
         beforeEach(async () => {
             session = await createTestUserSession(environment);
             exerciseTemplate = await createExerciseTemplate(
                 environment,
                 session
             );
+            sessionInformation =
+                (await environment.services.authService.getDataFromSessionToken(
+                    session
+                ))!;
         });
         it('fails joining with trainer key if not logged in', async () => {
             await environment.withWebsocket(async (socket) => {
@@ -107,9 +113,11 @@ describe('join exercise', () => {
         });
 
         it('fails joining with participant key if not logged in', async () => {
-            const exercise = environment.services.exerciseService
-                .TESTING_getExerciseMap()
-                .get(exerciseTemplate.trainerKey)!;
+            const exercise =
+                await environment.services.exerciseService.getExerciseByKey(
+                    exerciseTemplate.trainerKey,
+                    sessionInformation
+                );
             await environment.withWebsocket(async (socket) => {
                 const join = await socket.emit(
                     'joinExercise',
@@ -121,9 +129,11 @@ describe('join exercise', () => {
             });
         });
         it('fails joining with participant key if logged in', async () => {
-            const exercise = environment.services.exerciseService
-                .TESTING_getExerciseMap()
-                .get(exerciseTemplate.trainerKey)!;
+            const exercise =
+                await environment.services.exerciseService.getExerciseByKey(
+                    exerciseTemplate.trainerKey,
+                    sessionInformation
+                );
             await environment.withWebsocket(async (socket) => {
                 const join = await socket.emit(
                     'joinExercise',

--- a/backend/src/exercise/websocket-handler/join-exercise-handler.ts
+++ b/backend/src/exercise/websocket-handler/join-exercise-handler.ts
@@ -44,10 +44,10 @@ export function registerJoinExerciseHandler(
                 return;
             }
 
-            clientWrapper.getSessionInformation().then(() => {
+            clientWrapper.getSessionInformation().then(async () => {
                 let clientId: UUID | undefined;
                 try {
-                    clientId = clientWrapper.joinExercise(
+                    clientId = await clientWrapper.joinExercise(
                         exerciseKey,
                         clientName
                     );

--- a/backend/src/fuesim-server.ts
+++ b/backend/src/fuesim-server.ts
@@ -8,12 +8,13 @@ export class FuesimServer {
     private readonly _httpServer: ApiHttpServer;
     private readonly _websocketServer: ExerciseWebsocketServer;
 
-    private readonly saveTickInterval = 10_000;
+    private readonly exerciseUpkeepTickInterval = 10_000;
 
-    private readonly saveHandler: PeriodicEventHandler;
+    private readonly exerciseUpkeepHandler: PeriodicEventHandler;
 
-    public async saveTick() {
+    public async exerciseUpkeepTick() {
         await this.services.exerciseService.saveUnsavedExercises();
+        await this.services.exerciseService.unloadEmptyExercises();
     }
 
     public constructor(private readonly services: Services) {
@@ -21,11 +22,11 @@ export class FuesimServer {
         this._websocketServer = new ExerciseWebsocketServer(app, this.services);
         this._httpServer = new ApiHttpServer(app, services);
 
-        this.saveHandler = new PeriodicEventHandler(
-            this.saveTick.bind(this),
-            this.saveTickInterval
+        this.exerciseUpkeepHandler = new PeriodicEventHandler(
+            this.exerciseUpkeepTick.bind(this),
+            this.exerciseUpkeepTickInterval
         );
-        this.saveHandler.start();
+        this.exerciseUpkeepHandler.start();
     }
 
     public get websocketServer(): ExerciseWebsocketServer {
@@ -39,10 +40,10 @@ export class FuesimServer {
     public async destroy() {
         this.httpServer.close();
         this.websocketServer.close();
-        this.saveHandler.pause();
+        this.exerciseUpkeepHandler.pause();
         // Save all remaining instances, if it's still possible
         if (this.services.databaseService.isInitialized) {
-            await this.saveTick();
+            await this.exerciseUpkeepTick();
         }
     }
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -97,17 +97,17 @@ async function main() {
 
     if (Config.useDb) {
         try {
-            console.log('Loading exercises from database…');
+            console.log('Migrate exercises in database…');
             const startTime = performance.now();
-            const exercises = await exerciseService.restoreAllExercises();
+            const amount = await exerciseService.migrateAllExercises();
             const endTime = performance.now();
             console.log(
-                `✅ Successfully loaded ${exercises.length} exercise(s) in ${(
+                `✅ Successfully migrated ${amount} exercise(s) in ${(
                     endTime - startTime
                 ).toFixed(3)} ms.`
             );
         } catch (e: unknown) {
-            console.error('❌ An error occurred while loading exercises.');
+            console.error('❌ An error occurred while migrating exercises.');
             if (e instanceof ValidationErrorWrapper) {
                 console.error(
                     'The validation of the exercises and actions in the database failed:',

--- a/backend/src/routers/exercise-manager-router.spec.ts
+++ b/backend/src/routers/exercise-manager-router.spec.ts
@@ -14,14 +14,20 @@ import {
     createTestEnvironment,
     createExerciseTemplate,
 } from '../test/utils.js';
+import type { SessionInformation } from '../auth/auth-service.js';
 
 describe('exercise manager router', () => {
     const environment = createTestEnvironment();
     let session: string;
+    let sessionInformation: SessionInformation;
     beforeEach(async () => {
         await environment.repositories.accessKeyRepository.freeAll();
         environment.services.exerciseService.TESTING_getExerciseMap().clear();
         session = await createTestUserSession(environment);
+        sessionInformation =
+            (await environment.services.authService.getDataFromSessionToken(
+                session
+            ))!;
     });
     describe('GET /api/exercises', () => {
         it('fails with 403 if not authenticated', async () => {
@@ -172,9 +178,11 @@ describe('exercise manager router', () => {
             expect(parsed.lastUpdatedAt.getTime()).toBeLessThan(Date.now());
             expect(parsed.lastExerciseCreatedAt).toBe(null);
 
-            const importedExercise = environment.services.exerciseService
-                .TESTING_getExerciseMap()
-                .get(parsed.trainerKey)!;
+            const importedExercise =
+                await environment.services.exerciseService.getExerciseByKey(
+                    parsed.trainerKey,
+                    sessionInformation
+                );
             expect(importedExercise.exercise.currentStateString).toMatchObject({
                 ...exercise.exercise.currentStateString,
                 participantKey: importedExercise.participantKey,

--- a/backend/src/routers/exercise-router.spec.ts
+++ b/backend/src/routers/exercise-router.spec.ts
@@ -13,6 +13,7 @@ import {
     createExercise,
     createTestEnvironment,
 } from '../test/utils.js';
+import type { SessionInformation } from '../auth/auth-service.js';
 
 describe('exercise router', () => {
     const environment = createTestEnvironment();
@@ -135,6 +136,7 @@ describe('exercise router', () => {
 
         describe('exercise template', () => {
             let session: string;
+            let sessionInformation: SessionInformation;
             let exerciseTemplate: GetExerciseTemplateResponseData;
             beforeEach(async () => {
                 session = await createTestUserSession(environment);
@@ -142,6 +144,10 @@ describe('exercise router', () => {
                     environment,
                     session
                 );
+                sessionInformation =
+                    (await environment.services.authService.getDataFromSessionToken(
+                        session
+                    ))!;
             });
 
             it('fails with trainer key if not logged in', async () => {
@@ -183,9 +189,11 @@ describe('exercise router', () => {
             });
 
             it('fails with participant key if not logged in', async () => {
-                const exercise = environment.services.exerciseService
-                    .TESTING_getExerciseMap()
-                    .get(exerciseTemplate.trainerKey)!;
+                const exercise =
+                    await environment.services.exerciseService.getExerciseByKey(
+                        exerciseTemplate.trainerKey,
+                        sessionInformation
+                    );
                 await environment
                     .httpRequest(
                         'get',
@@ -195,9 +203,11 @@ describe('exercise router', () => {
             });
 
             it('fails with participant key if logged in', async () => {
-                const exercise = environment.services.exerciseService
-                    .TESTING_getExerciseMap()
-                    .get(exerciseTemplate.trainerKey)!;
+                const exercise =
+                    await environment.services.exerciseService.getExerciseByKey(
+                        exerciseTemplate.trainerKey,
+                        sessionInformation
+                    );
                 await environment
                     .httpRequest(
                         'get',

--- a/backend/src/routers/exercise-router.ts
+++ b/backend/src/routers/exercise-router.ts
@@ -36,7 +36,7 @@ export function createExerciseRouter(exerciseService: ExerciseService): Router {
             }
             let exercise = null;
             try {
-                exercise = exerciseService.getExerciseByKey(
+                exercise = await exerciseService.getExerciseByKey(
                     req.params.exerciseKey,
                     req.session
                 );

--- a/backend/src/routers/parallel-exercise-router.spec.ts
+++ b/backend/src/routers/parallel-exercise-router.spec.ts
@@ -22,13 +22,19 @@ import {
     createViewport,
     joinParallelExercise,
 } from '../test/parallel-exercise-utils.js';
+import type { SessionInformation } from '../auth/auth-service.js';
 
 describe('parallel exercise router', () => {
     const environment = createTestEnvironment();
     let session: string;
+    let sessionInformation: SessionInformation;
     beforeEach(async () => {
         environment.services.exerciseService.TESTING_getExerciseMap().clear();
         session = await createTestUserSession(environment);
+        sessionInformation =
+            (await environment.services.authService.getDataFromSessionToken(
+                session
+            ))!;
     });
     describe('GET /api/parallel_exercises', () => {
         it('fails with 403 if not authenticated', async () => {
@@ -153,9 +159,10 @@ describe('parallel exercise router', () => {
             const template = await createExerciseTemplate(environment, session);
 
             const viewport = createViewport(
-                environment.services.exerciseService
-                    .TESTING_getExerciseMap()
-                    .get(template.trainerKey)!
+                await environment.services.exerciseService.getExerciseByKey(
+                    template.trainerKey,
+                    sessionInformation
+                )
             );
             const testData = {
                 name: 'Test Parallel Exercise',

--- a/backend/src/test/parallel-exercise-utils.ts
+++ b/backend/src/test/parallel-exercise-utils.ts
@@ -37,10 +37,16 @@ export async function createParallelExercise(
     const exerciseTemplate =
         template ?? (await createExerciseTemplate(environment, session));
 
+    const sessionInformation =
+        (await environment.services.authService.getDataFromSessionToken(
+            session
+        ))!;
+
     const viewport = createViewport(
-        environment.services.exerciseService
-            .TESTING_getExerciseMap()
-            .get(exerciseTemplate.trainerKey)!
+        await environment.services.exerciseService.getExerciseByKey(
+            exerciseTemplate.trainerKey,
+            sessionInformation
+        )
     );
     const response = await environment
         .httpRequest('post', '/api/parallel_exercises/', session)


### PR DESCRIPTION
### Summary

Closes #1234 by not loading all exercises from the database on startup. Instead, they are only migrated on startup and then lazily loaded when needed. They are purged from memory when no users are left in the exercise, directly after the save operation (which happens every 10 seconds).

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
