### PR TITLE
fix: update template in memory

### DIFF
--- a/backend/src/database/services/exercise-manager-service.ts
+++ b/backend/src/database/services/exercise-manager-service.ts
@@ -98,6 +98,11 @@ export class ExerciseManagerService {
         if (!updatedTemplate) {
             throw new ApiError();
         }
+        const exercise = this.exerciseService.getExerciseByKey(
+            exerciseTemplate.trainerKey,
+            session
+        );
+        exercise.template = updatedTemplate;
         return {
             ...updatedTemplate,
             trainerKey: exerciseTemplate.trainerKey,


### PR DESCRIPTION
### Summary

Closes #1348 by, in addition to modifying the database entry, updating the template attached to the in-memory exercise connected to a template. This should keep the two in sync.

I assume this change to the behavior does not merit a changelog entry?

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
