### PR TITLE
Generate UUIDs for EOC log entries in frontend

### DIFF
--- a/frontend/src/app/pages/exercises/exercise/shared/emergency-operations-center/eoc-log-interface/eoc-log-interface.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/emergency-operations-center/eoc-log-interface/eoc-log-interface.component.ts
@@ -3,6 +3,7 @@ import { Store } from '@ngrx/store';
 import { map } from 'rxjs';
 import { FormsModule } from '@angular/forms';
 import { AsyncPipe } from '@angular/common';
+import { uuid } from 'fuesim-digital-shared';
 import { ExerciseService } from '../../../../../../core/exercise.service';
 import type { AppState } from '../../../../../../state/app.state';
 import {
@@ -56,6 +57,7 @@ export class EocLogInterfaceComponent {
                 this.currentRole() === 'trainer'
                     ? this.sendingPrivateLog
                     : false,
+            id: uuid(),
         });
         if (response.success) {
             this.newLogEntry = '';

--- a/frontend/src/app/shared/components/send-alarm-group-interface/send-alarm-group-interface.component.ts
+++ b/frontend/src/app/shared/components/send-alarm-group-interface/send-alarm-group-interface.component.ts
@@ -290,6 +290,7 @@ export class SendAlarmGroupInterfaceComponent implements OnInit, OnDestroy {
             firstVehiclesCount: firstVehiclesCountForAction,
             firstVehiclesTargetTransferPointId:
                 this.selectedFirstVehiclesTarget?.key,
+            eocLogId: uuid(),
         });
 
         this.loading = false;

--- a/frontend/src/app/shared/components/start-pause-button/start-pause-button.component.ts
+++ b/frontend/src/app/shared/components/start-pause-button/start-pause-button.component.ts
@@ -1,6 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { AsyncPipe } from '@angular/common';
+import { uuid } from 'fuesim-digital-shared';
 import { ConfirmationModalService } from '../../../core/confirmation-modal/confirmation-modal.service';
 import { ExerciseService } from '../../../core/exercise.service';
 import type { AppState } from '../../../state/app.state';
@@ -80,6 +81,7 @@ export class StartPauseButtonComponent {
             name: selectStateSnapshot(selectOwnClient, this.store)!.name,
             message,
             isPrivate: true,
+            id: uuid(),
         });
     }
 

--- a/shared/src/models/eoc-log-entry.ts
+++ b/shared/src/models/eoc-log-entry.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { uuid, uuidSchema } from '../utils/uuid.js';
+import { UUID, uuid, uuidSchema } from '../utils/uuid.js';
 
 export const eocLogEntrySchema = z.strictObject({
     id: uuidSchema,
@@ -17,10 +17,11 @@ export function newEocLogEntry(
     exerciseTimestamp: number,
     message: string,
     clientName: string,
-    isPrivate: boolean
+    isPrivate: boolean,
+    id ?: UUID
 ): EocLogEntry {
     return {
-        id: uuid(),
+        id: id ?? uuid(),
         type: 'eocLogEntry',
         exerciseTimestamp,
         message,

--- a/shared/src/models/eoc-log-entry.ts
+++ b/shared/src/models/eoc-log-entry.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { UUID, uuid, uuidSchema } from '../utils/uuid.js';
+import type { UUID } from '../utils/uuid.js';
+import { uuid, uuidSchema } from '../utils/uuid.js';
 
 export const eocLogEntrySchema = z.strictObject({
     id: uuidSchema,
@@ -18,7 +19,7 @@ export function newEocLogEntry(
     message: string,
     clientName: string,
     isPrivate: boolean,
-    id ?: UUID
+    id?: UUID
 ): EocLogEntry {
     return {
         id: id ?? uuid(),

--- a/shared/src/models/eoc-log-entry.ts
+++ b/shared/src/models/eoc-log-entry.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { UUID } from '../utils/uuid.js';
-import { uuid, uuidSchema } from '../utils/uuid.js';
+import { uuidSchema } from '../utils/uuid.js';
 
 export const eocLogEntrySchema = z.strictObject({
     id: uuidSchema,
@@ -15,14 +15,14 @@ export const eocLogEntrySchema = z.strictObject({
 export type EocLogEntry = z.infer<typeof eocLogEntrySchema>;
 
 export function newEocLogEntry(
+    id: UUID,
     exerciseTimestamp: number,
     message: string,
     clientName: string,
-    isPrivate: boolean,
-    id?: UUID
+    isPrivate: boolean
 ): EocLogEntry {
     return {
-        id: id ?? uuid(),
+        id,
         type: 'eocLogEntry',
         exerciseTimestamp,
         message,

--- a/shared/src/state-migrations/51-add-uuid-to-add-eoc-log-action.ts
+++ b/shared/src/state-migrations/51-add-uuid-to-add-eoc-log-action.ts
@@ -1,0 +1,25 @@
+import type { UUID } from '../utils/uuid.js';
+import { uuid } from '../utils/uuid.js';
+import type { Migration } from './migration-functions.js';
+
+export const addUUIDtoAddEocLogEntryAction: Migration = {
+    action: (intermediateState, action) => {
+        const typedAction = action as { type: string };
+        switch (typedAction.type) {
+            case '[Emergency Operation Center] Add Log Entry': {
+                const typedLogAction = action as { id: UUID };
+                typedLogAction.id = uuid();
+                break;
+            }
+            case '[Emergency Operation Center] Send Alarm Group': {
+                const typedAlarmAction = action as { eocLogId: UUID };
+                typedAlarmAction.eocLogId = uuid();
+                break;
+            }
+            default:
+                break;
+        }
+        return true;
+    },
+    state: null,
+};

--- a/shared/src/state-migrations/51-add-uuid-to-add-eoc-log-action.ts
+++ b/shared/src/state-migrations/51-add-uuid-to-add-eoc-log-action.ts
@@ -2,7 +2,7 @@ import type { UUID } from '../utils/uuid.js';
 import { uuid } from '../utils/uuid.js';
 import type { Migration } from './migration-functions.js';
 
-export const addUUIDtoAddEocLogEntryAction: Migration = {
+export const addUUIDtoAddEocLogEntryAction51: Migration = {
     action: (intermediateState, action) => {
         const typedAction = action as { type: string };
         switch (typedAction.type) {

--- a/shared/src/state-migrations/migration-functions.ts
+++ b/shared/src/state-migrations/migration-functions.ts
@@ -48,7 +48,7 @@ import { participantIdToKey47 } from './47-participant-id-to-key.js';
 import { addOperationsTabletView49 } from './49-add-operations-tablet-view.js';
 import { addAutojoinViewport48 } from './48-autojoin-viewport.js';
 import { addScoutables50 } from './50-add-scoutables.js';
-import { addUUIDtoAddEocLogEntryAction } from './51-add-uuid-to-add-eoc-log-action.js';
+import { addUUIDtoAddEocLogEntryAction51 } from './51-add-uuid-to-add-eoc-log-action.js';
 
 /**
  * Migrate a single action
@@ -125,5 +125,5 @@ export const migrations: {
     48: addAutojoinViewport48,
     49: addOperationsTabletView49,
     50: addScoutables50,
-    51: addUUIDtoAddEocLogEntryAction,
+    51: addUUIDtoAddEocLogEntryAction51,
 };

--- a/shared/src/state-migrations/migration-functions.ts
+++ b/shared/src/state-migrations/migration-functions.ts
@@ -48,6 +48,7 @@ import { participantIdToKey47 } from './47-participant-id-to-key.js';
 import { addOperationsTabletView49 } from './49-add-operations-tablet-view.js';
 import { addAutojoinViewport48 } from './48-autojoin-viewport.js';
 import { addScoutables50 } from './50-add-scoutables.js';
+import { addUUIDtoAddEocLogEntryAction } from './51-add-uuid-to-add-eoc-log-action.js';
 
 /**
  * Migrate a single action
@@ -124,4 +125,5 @@ export const migrations: {
     48: addAutojoinViewport48,
     49: addOperationsTabletView49,
     50: addScoutables50,
+    51: addUUIDtoAddEocLogEntryAction,
 };

--- a/shared/src/state.ts
+++ b/shared/src/state.ts
@@ -243,5 +243,5 @@ export class ExerciseState {
      *
      * This number MUST be increased every time a change to any object (that is part of the state or the state itself) is made in a way that there may be states valid before that are no longer valid.
      */
-    static readonly currentStateVersion = 50;
+    static readonly currentStateVersion = 51;
 }

--- a/shared/src/store/action-reducers/emergency-operation-center.ts
+++ b/shared/src/store/action-reducers/emergency-operation-center.ts
@@ -20,7 +20,6 @@ import {
     vehicleParametersSchema,
 } from '../../models/utils/vehicle-parameters.js';
 import { newAlarmGroupStartPoint } from '../../models/utils/start-points.js';
-import { nextUUID } from '../../simulation/utils/randomness.js';
 import { getElement } from './utils/get-element.js';
 import { logAlarmGroupSent } from './utils/log.js';
 import { TransferActionReducers } from './transfer.js';
@@ -37,6 +36,8 @@ export class AddLogEntryAction implements Action {
     public readonly message!: string;
     @IsBoolean()
     public readonly isPrivate: boolean = false;
+    @IsUUID(4, uuidValidationOptions)
+    public readonly id!: UUID;
 }
 
 export class SendAlarmGroupAction implements Action {
@@ -63,18 +64,21 @@ export class SendAlarmGroupAction implements Action {
     @IsOptional()
     @IsUUID(4, uuidValidationOptions)
     public readonly firstVehiclesTargetTransferPointId: UUID | undefined;
+
+    @IsUUID(4, uuidValidationOptions)
+    public readonly eocLogId!: UUID;
 }
 
 export namespace EmergencyOperationCenterActionReducers {
     export const addLogEntry: ActionReducer<AddLogEntryAction> = {
         action: AddLogEntryAction,
-        reducer: (draftState, { name, message, isPrivate }) => {
+        reducer: (draftState, { name, message, isPrivate, id }) => {
             const logEntry = newEocLogEntry(
+                id,
                 draftState.currentTime,
                 message,
                 name,
-                isPrivate,
-                nextUUID(draftState)
+                isPrivate
             );
             draftState.eocLog.push(logEntry);
             return draftState;
@@ -97,6 +101,7 @@ export namespace EmergencyOperationCenterActionReducers {
                 targetTransferPointId,
                 firstVehiclesCount,
                 firstVehiclesTargetTransferPointId,
+                eocLogId,
             }
         ) => {
             const alarmGroup = getElement(
@@ -163,6 +168,7 @@ export namespace EmergencyOperationCenterActionReducers {
                 message: logEntry,
                 name: clientName,
                 isPrivate: false,
+                id: eocLogId,
             });
 
             logAlarmGroupSent(draftState, alarmGroupId);

--- a/shared/src/store/action-reducers/emergency-operation-center.ts
+++ b/shared/src/store/action-reducers/emergency-operation-center.ts
@@ -20,11 +20,11 @@ import {
     vehicleParametersSchema,
 } from '../../models/utils/vehicle-parameters.js';
 import { newAlarmGroupStartPoint } from '../../models/utils/start-points.js';
+import { nextUUID } from '../../simulation/utils/randomness.js';
 import { getElement } from './utils/get-element.js';
 import { logAlarmGroupSent } from './utils/log.js';
 import { TransferActionReducers } from './transfer.js';
 import { VehicleActionReducers } from './vehicle.js';
-import { nextUUID } from '../../simulation/utils/randomness.js';
 
 export class AddLogEntryAction implements Action {
     @IsValue('[Emergency Operation Center] Add Log Entry' as const)

--- a/shared/src/store/action-reducers/emergency-operation-center.ts
+++ b/shared/src/store/action-reducers/emergency-operation-center.ts
@@ -24,6 +24,7 @@ import { getElement } from './utils/get-element.js';
 import { logAlarmGroupSent } from './utils/log.js';
 import { TransferActionReducers } from './transfer.js';
 import { VehicleActionReducers } from './vehicle.js';
+import { nextUUID } from '../../simulation/utils/randomness.js';
 
 export class AddLogEntryAction implements Action {
     @IsValue('[Emergency Operation Center] Add Log Entry' as const)
@@ -72,7 +73,8 @@ export namespace EmergencyOperationCenterActionReducers {
                 draftState.currentTime,
                 message,
                 name,
-                isPrivate
+                isPrivate,
+                nextUUID(draftState)
             );
             draftState.eocLog.push(logEntry);
             return draftState;


### PR DESCRIPTION
### Summary

resolves https://github.com/hpi-sam/fuesim-digital/issues/580
newEocLogEntry now takes an optional id. The AddLogEntryAction now uses nextUUID.
### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [ ] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).

