### PR TITLE
Make migrations 49 and 50 standalone

### DIFF
--- a/shared/src/state-migrations/49-add-operations-tablet-view.ts
+++ b/shared/src/state-migrations/49-add-operations-tablet-view.ts
@@ -1,5 +1,4 @@
 import type { UUID } from '../utils/uuid.js';
-import { defaultOperationsMapProperties } from '../data/default-state/map-properties.js';
 import type { Migration } from './migration-functions.js';
 
 interface VehicleParameters {
@@ -53,7 +52,11 @@ export const addOperationsTabletView49: Migration = {
         Object.values(typedState.vehicles).forEach((vehicle) => {
             vehicle.operationalAssignment = null;
         });
-        typedState.configuration.operationsMapProperties =
-            defaultOperationsMapProperties;
+        typedState.configuration.operationsMapProperties = {
+            tileUrl:
+                'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+            dataUrl: 'https://tiles.openfreemap.org/planet',
+            enable3dBuildings: true,
+        };
     },
 };

--- a/shared/src/state-migrations/50-add-scoutables.ts
+++ b/shared/src/state-migrations/50-add-scoutables.ts
@@ -1,7 +1,9 @@
-import type { MapImage } from '../models/map-image.js';
-import type { Patient } from '../models/patient.js';
 import type { UUID } from '../utils/uuid.js';
 import type { Migration } from './migration-functions.js';
+
+interface WithScoutableId {
+    scoutableId: null;
+}
 
 export const addScoutables50: Migration = {
     action: (intermediateState, action) => {
@@ -9,14 +11,14 @@ export const addScoutables50: Migration = {
         switch (typedAction.type) {
             case '[Patient] Add patient': {
                 const typedPatientAction = action as {
-                    patient: Patient;
+                    patient: WithScoutableId;
                 };
                 typedPatientAction.patient.scoutableId = null;
                 break;
             }
             case '[MapImage] Add MapImage': {
                 const typedMapImageAction = action as {
-                    mapImage: MapImage;
+                    mapImage: WithScoutableId;
                 };
                 typedMapImageAction.mapImage.scoutableId = null;
                 break;


### PR DESCRIPTION
### Summary

Migrations 49 and 50 used data or type definitions from outside. This could break if the data model advances.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
