### PR TITLE
Fix Upload Limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+### Fixed
+
+- `DFM_UPLOAD_LIMIT` values are now correctly applied again, after a bug in version 0.11.0
+
 ## [0.11.1] - 2026-04-30
 
 ### Fixed

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,6 +1,6 @@
 import './utils/dotenv-config.js';
 import dotenv from 'dotenv';
-import { bool, cleanEnv, makeValidator, num, str, url } from 'envalid';
+import { bool, cleanEnv, makeValidator, str, url } from 'envalid';
 
 export class Config {
     private static _websocketPort?: number;
@@ -11,7 +11,7 @@ export class Config {
 
     private static _httpFrontendUrl?: string;
 
-    private static _uploadLimit?: number;
+    private static _uploadLimit?: string;
 
     private static _useDb?: boolean;
 
@@ -61,7 +61,7 @@ export class Config {
         return this._httpFrontendUrl!;
     }
 
-    public static get uploadLimit(): number {
+    public static get uploadLimit(): string {
         this.throwIfNotInitialized();
         return this._uploadLimit!;
     }
@@ -167,7 +167,7 @@ export class Config {
             DFM_HTTP_FRONTEND_URL_TESTING: url({
                 default: 'http://localhost:14200',
             }),
-            DFM_UPLOAD_LIMIT: num({ default: 200 }),
+            DFM_UPLOAD_LIMIT: str({ default: '200m' }),
             DFM_USE_DB: bool(),
             DFM_USE_DB_TESTING: bool({ default: undefined }),
             DFM_DB_USER: str(

--- a/backend/src/http-server.ts
+++ b/backend/src/http-server.ts
@@ -39,7 +39,9 @@ export class ApiHttpServer {
         app.use(cookieParser());
         app.use(createSessionMiddleware(services.authService));
 
-        app.use(express.json({ limit: `${Config.uploadLimit}mb` }));
+        // The upload limit is specified as a Nginx compatible size (https://nginx.org/en/docs/syntax.html#size) (i.e., can have a "k", "m", or "g" suffix)
+        // Express parses the limit using https://github.com/visionmedia/bytes.js#bytesparsestringnumber-value-numbernull, so we have to append "b"
+        app.use(express.json({ limit: `${Config.uploadLimit}b` }));
 
         app.use('/api', healthRouter);
 


### PR DESCRIPTION
### Summary

Fixes a bug introduced in #1275. Upload limits with units are now correctly applied in both nginx and express.

### PR Checklist

Please make sure to fulfill the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
