### PR TITLE
fix vehicles from simulated regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 - The vehicle status display now uses the correct visible status of a patient. Thus, after a patient that has been triaged by personnel on the map, the color determined in this triage is used.
 - Permissions for multiple actions around simulated regions that were mistakenly allowed for participants have been changed to trainers only.
 - Vehicles inside a simulated region can now be properly selected again
+- Vehicles inside simulated regions are now shown inside the "operations detail view"
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 - `DFM_UPLOAD_LIMIT` values are now correctly applied again, after a bug in version 0.11.0
 - The vehicle status display now uses the correct visible status of a patient. Thus, after a patient that has been triaged by personnel on the map, the color determined in this triage is used.
 - Permissions for multiple actions around simulated regions that were mistakenly allowed for participants have been changed to trainers only.
+- Vehicles inside a simulated region can now be properly selected again
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 - `DFM_UPLOAD_LIMIT` values are now correctly applied again, after a bug in version 0.11.0
 - The vehicle status display now uses the correct visible status of a patient. Thus, after a patient that has been triaged by personnel on the map, the color determined in this triage is used.
 - Permissions for multiple actions around simulated regions that were mistakenly allowed for participants have been changed to trainers only.
+- The exercise map now fits on mobile device screens
 - Vehicles inside a simulated region can now be properly selected again
 - Vehicles inside simulated regions are now shown inside the "operations detail view"
-- The exercise map now fits on mobile device screens
 
 ### Added
 

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operation-details/operations-vehicles/operations-vehicles.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operation-details/operations-vehicles/operations-vehicles.component.ts
@@ -2,10 +2,9 @@ import { Component, computed, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { AppState } from '../../../../../../../state/app.state';
 import {
-    selectVehiclesInSimulatedRegions,
     selectVehiclesInTransfer,
+    selectVehiclesOnOperationsLocation,
 } from '../../../../../../../state/application/selectors/exercise.selectors';
-import { selectVisibleVehicles } from '../../../../../../../state/application/selectors/shared.selectors';
 import { OperationsVehicleItemComponent } from './operations-vehicle-item/operations-vehicle-item.component';
 
 @Component({
@@ -17,38 +16,17 @@ import { OperationsVehicleItemComponent } from './operations-vehicle-item/operat
 export class OperationsVehiclesComponent {
     private readonly store = inject(Store<AppState>);
 
-    private readonly visibleVehiclesMap = this.store.selectSignal(
-        selectVisibleVehicles
-    );
-    private readonly visibleVehicles = computed(() =>
-        Object.values(this.visibleVehiclesMap())
-    );
-
     private readonly vehiclesInTransfer = this.store.selectSignal(
         selectVehiclesInTransfer
     );
-    private readonly vehiclesInBetweenTransferpoints = computed(() =>
-        Object.values(this.vehiclesInTransfer()).filter(
-            (vehicle) =>
-                vehicle.position.type === 'transfer' &&
-                vehicle.position.transfer.startPoint.type ===
-                    'transferStartPoint'
-        )
-    );
 
-    private readonly vehiclesInSimulatedRegionMap = this.store.selectSignal(
-        selectVehiclesInSimulatedRegions
+    private readonly vehiclesOnLocationMap = this.store.selectSignal(
+        selectVehiclesOnOperationsLocation
     );
-    private readonly vehiclesInSimulatedRegions = computed(() =>
-        Object.values(this.vehiclesInSimulatedRegionMap())
-    );
-
     public readonly vehiclesOnLocation = computed(() =>
-        [
-            ...this.visibleVehicles(),
-            ...this.vehiclesInBetweenTransferpoints(),
-            ...this.vehiclesInSimulatedRegions(),
-        ].sort((a, b) => a.name.localeCompare(b.name))
+        Object.values(this.vehiclesOnLocationMap()).sort((a, b) =>
+            a.name.localeCompare(b.name)
+        )
     );
 
     public readonly alarmGroupVehiclesInTransfer = computed(() =>

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operation-details/operations-vehicles/operations-vehicles.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operation-details/operations-vehicles/operations-vehicles.component.ts
@@ -1,7 +1,10 @@
 import { Component, computed, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { AppState } from '../../../../../../../state/app.state';
-import { selectVehiclesInTransfer } from '../../../../../../../state/application/selectors/exercise.selectors';
+import {
+    selectVehiclesInSimulatedRegions,
+    selectVehiclesInTransfer,
+} from '../../../../../../../state/application/selectors/exercise.selectors';
 import { selectVisibleVehicles } from '../../../../../../../state/application/selectors/shared.selectors';
 import { OperationsVehicleItemComponent } from './operations-vehicle-item/operations-vehicle-item.component';
 
@@ -33,10 +36,18 @@ export class OperationsVehiclesComponent {
         )
     );
 
+    private readonly vehiclesInSimulatedRegionMap = this.store.selectSignal(
+        selectVehiclesInSimulatedRegions
+    );
+    private readonly vehiclesInSimulatedRegions = computed(() =>
+        Object.values(this.vehiclesInSimulatedRegionMap())
+    );
+
     public readonly vehiclesOnLocation = computed(() =>
         [
             ...this.visibleVehicles(),
             ...this.vehiclesInBetweenTransferpoints(),
+            ...this.vehiclesInSimulatedRegions(),
         ].sort((a, b) => a.name.localeCompare(b.name))
     );
 

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operation-details/operations-vehicles/operations-vehicles.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operation-details/operations-vehicles/operations-vehicles.component.ts
@@ -20,8 +20,8 @@ export class OperationsVehiclesComponent {
         selectVehiclesInTransfer
     );
 
-    public readonly vehiclesOnLocation = computed(() =>
-        Object.values(this.store.selectSignal(selectVehiclesOnLocation))
+    public readonly vehiclesOnLocation = this.store.selectSignal(
+        selectVehiclesOnLocation
     );
 
     public readonly alarmGroupVehiclesInTransfer = computed(() =>

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operation-details/operations-vehicles/operations-vehicles.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operation-details/operations-vehicles/operations-vehicles.component.ts
@@ -3,7 +3,7 @@ import { Store } from '@ngrx/store';
 import { AppState } from '../../../../../../../state/app.state';
 import {
     selectVehiclesInTransfer,
-    selectVehiclesOnOperationsLocation,
+    selectVehiclesOnLocation,
 } from '../../../../../../../state/application/selectors/exercise.selectors';
 import { OperationsVehicleItemComponent } from './operations-vehicle-item/operations-vehicle-item.component';
 
@@ -21,16 +21,15 @@ export class OperationsVehiclesComponent {
     );
 
     public readonly vehiclesOnLocation = computed(() =>
-        Object.values(this.store.selectSignal(
-            selectVehiclesOnOperationsLocation
-        )));
+        Object.values(this.store.selectSignal(selectVehiclesOnLocation))
+    );
 
     public readonly alarmGroupVehiclesInTransfer = computed(() =>
         Object.values(this.vehiclesInTransfer()).filter(
             (vehicle) =>
                 vehicle.position.type === 'transfer' &&
                 vehicle.position.transfer.startPoint.type ===
-                'alarmGroupStartPoint'
+                    'alarmGroupStartPoint'
         )
     );
 }

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operation-details/operations-vehicles/operations-vehicles.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operation-details/operations-vehicles/operations-vehicles.component.ts
@@ -20,21 +20,17 @@ export class OperationsVehiclesComponent {
         selectVehiclesInTransfer
     );
 
-    private readonly vehiclesOnLocationMap = this.store.selectSignal(
-        selectVehiclesOnOperationsLocation
-    );
     public readonly vehiclesOnLocation = computed(() =>
-        Object.values(this.vehiclesOnLocationMap()).sort((a, b) =>
-            a.name.localeCompare(b.name)
-        )
-    );
+        Object.values(this.store.selectSignal(
+            selectVehiclesOnOperationsLocation
+        )));
 
     public readonly alarmGroupVehiclesInTransfer = computed(() =>
         Object.values(this.vehiclesInTransfer()).filter(
             (vehicle) =>
                 vehicle.position.type === 'transfer' &&
                 vehicle.position.transfer.startPoint.type ===
-                    'alarmGroupStartPoint'
+                'alarmGroupStartPoint'
         )
     );
 }

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operational-sections/vehicles-on-location/vehicles-on-location.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operational-sections/vehicles-on-location/vehicles-on-location.component.html
@@ -3,7 +3,7 @@
     <div class="flex-grow-1">
         <app-vehicles-zone
             class="w-100"
-            [vehicles]="vehicles()"
+            [vehicles]="vehiclesOnLocation()"
             mode="x-scroll"
             (vehicleDropped)="onVehicleDropped($event.vehicleId)"
         />

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operational-sections/vehicles-on-location/vehicles-on-location.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operational-sections/vehicles-on-location/vehicles-on-location.component.ts
@@ -1,6 +1,6 @@
 import { Component, computed, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { selectVehiclesOnOperationsLocation } from '../../../../../../../state/application/selectors/exercise.selectors';
+import { selectVehiclesOnLocation } from '../../../../../../../state/application/selectors/exercise.selectors';
 import { ExerciseService } from '../../../../../../../core/exercise.service';
 import { AppState } from '../../../../../../../state/app.state';
 import { VehiclesZoneComponent } from '../vehicles-zone/vehicles-zone.component';
@@ -16,9 +16,9 @@ export class VehiclesOnLocationComponent {
     private readonly store = inject(Store<AppState>);
 
     public readonly vehiclesOnLocation = computed(() => {
-        const data = Object.values(this.store.selectSignal(
-            selectVehiclesOnOperationsLocation
-        ));
+        const data = Object.values(
+            this.store.selectSignal(selectVehiclesOnLocation)
+        );
         return data.filter((vehicle) => vehicle.operationalAssignment === null);
     });
 

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operational-sections/vehicles-on-location/vehicles-on-location.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operational-sections/vehicles-on-location/vehicles-on-location.component.ts
@@ -15,13 +15,10 @@ export class VehiclesOnLocationComponent {
     private readonly exerciseService = inject(ExerciseService);
     private readonly store = inject(Store<AppState>);
 
-    private readonly vehiclesOnLocationMap = this.store.selectSignal(
-        selectVehiclesOnOperationsLocation
-    );
     public readonly vehiclesOnLocation = computed(() => {
-        const data = Object.values(this.vehiclesOnLocationMap()).sort((a, b) =>
-            a.name.localeCompare(b.name)
-        );
+        const data = Object.values(this.store.selectSignal(
+            selectVehiclesOnOperationsLocation
+        ));
         return data.filter((vehicle) => vehicle.operationalAssignment === null);
     });
 

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operational-sections/vehicles-on-location/vehicles-on-location.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operational-sections/vehicles-on-location/vehicles-on-location.component.ts
@@ -1,12 +1,8 @@
 import { Component, computed, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
-import {
-    selectVehiclesInSimulatedRegions,
-    selectVehiclesInTransfer,
-} from '../../../../../../../state/application/selectors/exercise.selectors';
+import { selectVehiclesOnOperationsLocation } from '../../../../../../../state/application/selectors/exercise.selectors';
 import { ExerciseService } from '../../../../../../../core/exercise.service';
 import { AppState } from '../../../../../../../state/app.state';
-import { selectVisibleVehicles } from '../../../../../../../state/application/selectors/shared.selectors';
 import { VehiclesZoneComponent } from '../vehicles-zone/vehicles-zone.component';
 
 @Component({
@@ -19,39 +15,13 @@ export class VehiclesOnLocationComponent {
     private readonly exerciseService = inject(ExerciseService);
     private readonly store = inject(Store<AppState>);
 
-    private readonly visibleVehiclesMap = this.store.selectSignal(
-        selectVisibleVehicles
+    private readonly vehiclesOnLocationMap = this.store.selectSignal(
+        selectVehiclesOnOperationsLocation
     );
-    private readonly visibleVehicles = computed(() =>
-        Object.values(this.visibleVehiclesMap())
-    );
-    private readonly vehiclesInBetweenTransferpointsMap =
-        this.store.selectSignal(selectVehiclesInTransfer);
-    private readonly vehiclesInBetweenTransferpoints = computed(() =>
-        Object.values(this.vehiclesInBetweenTransferpointsMap()).filter(
-            (vehicle) =>
-                vehicle.position.type === 'transfer' &&
-                vehicle.position.transfer.startPoint.type ===
-                    'transferStartPoint'
-        )
-    );
-
-    private readonly vehiclesInSimulatedRegionMap = this.store.selectSignal(
-        selectVehiclesInSimulatedRegions
-    );
-    private readonly vehiclesInSimulatedRegions = computed(() =>
-        Object.values(this.vehiclesInSimulatedRegionMap())
-    );
-
-    public readonly vehicles = computed(() => {
-        const data = [
-            ...this.visibleVehicles(),
-            ...this.vehiclesInBetweenTransferpoints(),
-            ...this.vehiclesInSimulatedRegions(),
-        ];
-
-        data.sort((a, b) => a.name.localeCompare(b.name));
-
+    public readonly vehiclesOnLocation = computed(() => {
+        const data = Object.values(this.vehiclesOnLocationMap()).sort((a, b) =>
+            a.name.localeCompare(b.name)
+        );
         return data.filter((vehicle) => vehicle.operationalAssignment === null);
     });
 

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operational-sections/vehicles-on-location/vehicles-on-location.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operational-sections/vehicles-on-location/vehicles-on-location.component.ts
@@ -16,9 +16,7 @@ export class VehiclesOnLocationComponent {
     private readonly store = inject(Store<AppState>);
 
     public readonly vehiclesOnLocation = computed(() => {
-        const data = Object.values(
-            this.store.selectSignal(selectVehiclesOnLocation)
-        );
+        const data = this.store.selectSignal(selectVehiclesOnLocation)();
         return data.filter((vehicle) => vehicle.operationalAssignment === null);
     });
 

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operational-sections/vehicles-on-location/vehicles-on-location.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/operational-sections/vehicles-on-location/vehicles-on-location.component.ts
@@ -1,6 +1,9 @@
 import { Component, computed, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { selectVehiclesInTransfer } from '../../../../../../../state/application/selectors/exercise.selectors';
+import {
+    selectVehiclesInSimulatedRegions,
+    selectVehiclesInTransfer,
+} from '../../../../../../../state/application/selectors/exercise.selectors';
 import { ExerciseService } from '../../../../../../../core/exercise.service';
 import { AppState } from '../../../../../../../state/app.state';
 import { selectVisibleVehicles } from '../../../../../../../state/application/selectors/shared.selectors';
@@ -33,10 +36,18 @@ export class VehiclesOnLocationComponent {
         )
     );
 
+    private readonly vehiclesInSimulatedRegionMap = this.store.selectSignal(
+        selectVehiclesInSimulatedRegions
+    );
+    private readonly vehiclesInSimulatedRegions = computed(() =>
+        Object.values(this.vehiclesInSimulatedRegionMap())
+    );
+
     public readonly vehicles = computed(() => {
         const data = [
             ...this.visibleVehicles(),
             ...this.vehiclesInBetweenTransferpoints(),
+            ...this.vehiclesInSimulatedRegions(),
         ];
 
         data.sort((a, b) => a.name.localeCompare(b.name));

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/vehicles-tab/details/simulated-region-overview-vehicle-details.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/vehicles-tab/details/simulated-region-overview-vehicle-details.component.html
@@ -1,4 +1,4 @@
-@if (selection$ | async; as selection) {
+@if (selection(); as selection) {
     <div class="container d-flex flex-column h-100" style="min-height: 0">
         <div
             class="flex-shrink-1 flex-grow-1 overflow-auto"

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/vehicles-tab/details/simulated-region-overview-vehicle-details.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/vehicles-tab/details/simulated-region-overview-vehicle-details.component.ts
@@ -47,25 +47,25 @@ export class SimulatedRegionOverviewVehicleDetailsComponent {
         const vehicle = this.vehicle();
         if (!vehicle) return null;
 
-        const personnel = this.store.selectSignal(selectPersonnel);
-        const patients = this.store.selectSignal(selectPatients);
-        const configuration = this.store.selectSignal(selectConfiguration);
+        const personnel = this.store.selectSignal(selectPersonnel)();
+        const patients = this.store.selectSignal(selectPatients)();
+        const configuration = this.store.selectSignal(selectConfiguration)();
 
         const vehiclePersonnel = Object.keys(vehicle.personnelIds)
-            .map((id) => personnel()[id]!)
+            .map((id) => personnel[id]!)
             .map((pers) => ({
                 ...pers,
                 isInVehicle: isInSpecificVehicle(pers, vehicle.id),
             }));
 
         const vehiclePatients = Object.keys(vehicle.patientIds)
-            .map((id) => patients()[id]!)
+            .map((id) => patients[id]!)
             .map((patient) => ({
                 ...patient,
                 visibleStatus: getPatientVisibleStatus(
                     patient,
-                    configuration().pretriageEnabled,
-                    configuration().bluePatientsEnabled
+                    configuration.pretriageEnabled,
+                    configuration.bluePatientsEnabled
                 ),
             }));
 

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/vehicles-tab/details/simulated-region-overview-vehicle-details.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/vehicles-tab/details/simulated-region-overview-vehicle-details.component.ts
@@ -1,17 +1,12 @@
-import type { OnInit } from '@angular/core';
-import { Component, inject, input } from '@angular/core';
+import { Component, computed, inject, input } from '@angular/core';
 import { Store } from '@ngrx/store';
-import type { Personnel, Vehicle } from 'fuesim-digital-shared';
+import type { Vehicle } from 'fuesim-digital-shared';
 import {
     getPatientVisibleStatus,
     isInSpecificVehicle,
     SimulatedRegion,
 } from 'fuesim-digital-shared';
-import type { Observable } from 'rxjs';
-import { combineLatest, map } from 'rxjs';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
-import { AsyncPipe } from '@angular/common';
-import type { PatientWithVisibleStatus } from '../../../patients-table/simulated-region-overview-patients-table.component';
 import { StartTransferService } from '../../../start-transfer.service';
 import { ExerciseService } from '../../../../../../../../../core/exercise.service';
 import type { AppState } from '../../../../../../../../../state/app.state';
@@ -37,10 +32,9 @@ import { SimulatedRegionOverviewPatientsTableComponent } from '../../../patients
         VehicleAvailableSlotsDisplayComponent,
         SimulatedRegionOverviewPatientsTableComponent,
         NgbTooltip,
-        AsyncPipe,
     ],
 })
-export class SimulatedRegionOverviewVehicleDetailsComponent implements OnInit {
+export class SimulatedRegionOverviewVehicleDetailsComponent {
     private readonly store = inject<Store<AppState>>(Store);
     private readonly exerciseService = inject(ExerciseService);
     readonly startTransferService = inject(StartTransferService);
@@ -49,51 +43,38 @@ export class SimulatedRegionOverviewVehicleDetailsComponent implements OnInit {
 
     readonly vehicle = input<Vehicle>();
 
-    selection$!: Observable<{
-        vehicle: Vehicle;
-        personnel: (Personnel & { isInVehicle: boolean })[];
-        patients: PatientWithVisibleStatus[];
-    } | null>;
+    public readonly selection = computed(() => {
+        const vehicle = this.vehicle();
+        if (!vehicle) return null;
 
-    ngOnInit() {
-        const personnel$ = this.store.select(selectPersonnel);
-        const patients$ = this.store.select(selectPatients);
-        const configuration$ = this.store.select(selectConfiguration);
+        const personnel = this.store.selectSignal(selectPersonnel);
+        const patients = this.store.selectSignal(selectPatients);
+        const configuration = this.store.selectSignal(selectConfiguration);
 
-        this.selection$ = combineLatest([
-            personnel$,
-            patients$,
-            configuration$,
-        ]).pipe(
-            map(([personnel, patients, configuration]) => {
-                const vehicle = this.vehicle();
-                if (!vehicle) return null;
-                const vehiclePersonnel = Object.keys(vehicle.personnelIds)
-                    .map((id) => personnel[id]!)
-                    .map((pers) => ({
-                        ...pers,
-                        isInVehicle: isInSpecificVehicle(pers, vehicle.id),
-                    }));
+        const vehiclePersonnel = Object.keys(vehicle.personnelIds)
+            .map((id) => personnel()[id]!)
+            .map((pers) => ({
+                ...pers,
+                isInVehicle: isInSpecificVehicle(pers, vehicle.id),
+            }));
 
-                const vehiclePatients = Object.keys(vehicle.patientIds)
-                    .map((id) => patients[id]!)
-                    .map((patient) => ({
-                        ...patient,
-                        visibleStatus: getPatientVisibleStatus(
-                            patient,
-                            configuration.pretriageEnabled,
-                            configuration.bluePatientsEnabled
-                        ),
-                    }));
+        const vehiclePatients = Object.keys(vehicle.patientIds)
+            .map((id) => patients()[id]!)
+            .map((patient) => ({
+                ...patient,
+                visibleStatus: getPatientVisibleStatus(
+                    patient,
+                    configuration().pretriageEnabled,
+                    configuration().bluePatientsEnabled
+                ),
+            }));
 
-                return {
-                    vehicle,
-                    personnel: vehiclePersonnel,
-                    patients: vehiclePatients,
-                };
-            })
-        );
-    }
+        return {
+            vehicle,
+            personnel: vehiclePersonnel,
+            patients: vehiclePatients,
+        };
+    });
 
     removeVehicle() {
         this.exerciseService.proposeAction({

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/vehicles-tab/tab/simulated-region-overview-vehicles-tab.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/vehicles-tab/tab/simulated-region-overview-vehicles-tab.component.html
@@ -20,8 +20,7 @@
                                 style="cursor: pointer"
                                 (click)="selectVehicle(vehicle)"
                                 [class.table-primary]="
-                                    (selectedVehicle$ | async)?.id ===
-                                    vehicle.id
+                                    selectedVehicle()?.id === vehicle.id
                                 "
                             >
                                 <td>
@@ -40,7 +39,7 @@
     </div>
     <div class="vr"></div>
     <div class="col h-100" style="max-width: 70%">
-        @if (selectedVehicle$ | async; as selectedVehicle) {
+        @if (selectedVehicle(); as selectedVehicle) {
             <app-simulated-region-overview-vehicle-details
                 [simulatedRegion]="simulatedRegion()"
                 [vehicle]="selectedVehicle"

--- a/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/vehicles-tab/tab/simulated-region-overview-vehicles-tab.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/simulation/trainer-modal/tabs/vehicles-tab/tab/simulated-region-overview-vehicles-tab.component.ts
@@ -1,11 +1,11 @@
 import type { OnInit } from '@angular/core';
-import { Component, inject, input } from '@angular/core';
+import { Component, inject, input, signal } from '@angular/core';
 import { Store } from '@ngrx/store';
 import type { Vehicle, VehicleTemplate } from 'fuesim-digital-shared';
 import { SimulatedRegion } from 'fuesim-digital-shared';
 import { groupBy } from 'lodash-es';
 import type { Observable } from 'rxjs';
-import { combineLatest, map, Subject } from 'rxjs';
+import { combineLatest, map } from 'rxjs';
 import { AsyncPipe } from '@angular/common';
 import { StartTransferService } from '../../../start-transfer.service';
 import { ExerciseService } from '../../../../../../../../../core/exercise.service';
@@ -30,15 +30,13 @@ export class SimulatedRegionOverviewVehiclesTabComponent implements OnInit {
 
     readonly simulatedRegion = input.required<SimulatedRegion>();
 
-    selectedVehicle$ = new Subject<Vehicle | null>();
+    public readonly selectedVehicle = signal<Vehicle | null>(null);
 
     groupedVehicles$!: Observable<
         { vehicleType: string; vehicles: Vehicle[] }[]
     >;
 
     ngOnInit() {
-        this.selectedVehicle$.next(null);
-
         const vehicles$ = this.store.select(
             createSelectElementsInSimulatedRegion(
                 selectVehicles,
@@ -81,7 +79,7 @@ export class SimulatedRegionOverviewVehiclesTabComponent implements OnInit {
     }
 
     selectVehicle(vehicle: Vehicle) {
-        this.selectedVehicle$.next(vehicle);
+        this.selectedVehicle.set(vehicle);
     }
 
     private indexOfTemplate(

--- a/frontend/src/app/state/application/selectors/exercise.selectors.ts
+++ b/frontend/src/app/state/application/selectors/exercise.selectors.ts
@@ -232,7 +232,7 @@ export const selectVehiclesOnOperationsLocation = createSelector(
                 isOnMap(vehicle) ||
                 isPositionInSimulatedRegion(vehicle.position) ||
                 isInTransfer(vehicle)
-        )
+        ).sort((a, b) => a.name.localeCompare(b.name))
 );
 
 export const selectVehiclesInTransfer = createSelector(

--- a/frontend/src/app/state/application/selectors/exercise.selectors.ts
+++ b/frontend/src/app/state/application/selectors/exercise.selectors.ts
@@ -15,6 +15,7 @@ import type {
 import {
     isInSpecificSimulatedRegion,
     isInTransfer,
+    isPositionInSimulatedRegion,
     nestedCoordinatesOf,
     scoutableElementTypes,
 } from 'fuesim-digital-shared';
@@ -221,6 +222,14 @@ export function createSelectVehiclesInOperationalSection(
         )
     );
 }
+
+export const selectVehiclesInSimulatedRegions = createSelector(
+    selectVehicles,
+    (vehicles) =>
+        Object.values(vehicles).filter((vehicle) =>
+            isPositionInSimulatedRegion(vehicle.position)
+        )
+);
 
 export const selectVehiclesInTransfer = createSelector(
     selectVehicles,

--- a/frontend/src/app/state/application/selectors/exercise.selectors.ts
+++ b/frontend/src/app/state/application/selectors/exercise.selectors.ts
@@ -15,8 +15,7 @@ import type {
 import {
     isInSpecificSimulatedRegion,
     isInTransfer,
-    isOnMap,
-    isPositionInSimulatedRegion,
+    isInTransferFromAlarmgroup,
     nestedCoordinatesOf,
     scoutableElementTypes,
 } from 'fuesim-digital-shared';
@@ -224,15 +223,12 @@ export function createSelectVehiclesInOperationalSection(
     );
 }
 
-export const selectVehiclesOnOperationsLocation = createSelector(
+export const selectVehiclesOnLocation = createSelector(
     selectVehicles,
     (vehicles) =>
-        Object.values(vehicles).filter(
-            (vehicle) =>
-                isOnMap(vehicle) ||
-                isPositionInSimulatedRegion(vehicle.position) ||
-                isInTransfer(vehicle)
-        ).sort((a, b) => a.name.localeCompare(b.name))
+        Object.values(vehicles)
+            .filter((vehicle) => !isInTransferFromAlarmgroup(vehicle))
+            .sort((a, b) => a.name.localeCompare(b.name))
 );
 
 export const selectVehiclesInTransfer = createSelector(

--- a/frontend/src/app/state/application/selectors/exercise.selectors.ts
+++ b/frontend/src/app/state/application/selectors/exercise.selectors.ts
@@ -15,6 +15,7 @@ import type {
 import {
     isInSpecificSimulatedRegion,
     isInTransfer,
+    isOnMap,
     isPositionInSimulatedRegion,
     nestedCoordinatesOf,
     scoutableElementTypes,
@@ -223,11 +224,14 @@ export function createSelectVehiclesInOperationalSection(
     );
 }
 
-export const selectVehiclesInSimulatedRegions = createSelector(
+export const selectVehiclesOnOperationsLocation = createSelector(
     selectVehicles,
     (vehicles) =>
-        Object.values(vehicles).filter((vehicle) =>
-            isPositionInSimulatedRegion(vehicle.position)
+        Object.values(vehicles).filter(
+            (vehicle) =>
+                isOnMap(vehicle) ||
+                isPositionInSimulatedRegion(vehicle.position) ||
+                isInTransfer(vehicle)
         )
 );
 

--- a/shared/src/models/utils/position/position-helpers.ts
+++ b/shared/src/models/utils/position/position-helpers.ts
@@ -4,6 +4,7 @@ import type { SimulatedRegion } from '../../simulated-region.js';
 import type { Transfer } from '../transfer.js';
 import type { UUID } from '../../../utils/uuid.js';
 import { getElement } from '../../../store/action-reducers/utils/get-element.js';
+import type { StartPoint } from '../start-points.js';
 import type { MapCoordinates } from './map-coordinates.js';
 import type { MapPosition } from './map-position.js';
 import type { Position } from './position.js';
@@ -22,8 +23,22 @@ export function isInVehicle(withPosition: WithPosition): boolean {
 export function isInTransfer(withPosition: WithPosition): boolean {
     return isPositionInTransfer(withPosition.position);
 }
+export function isInTransferFromAlarmgroup(
+    withPosition: WithPosition
+): boolean {
+    return (
+        isPositionInTransfer(withPosition.position) &&
+        isAlarmgroupStartPoint(
+            transferOfPosition(withPosition.position).startPoint
+        )
+    );
+}
 export function isInSimulatedRegion(withPosition: WithPosition): boolean {
     return isPositionInSimulatedRegion(withPosition.position);
+}
+
+export function isAlarmgroupStartPoint(startPoint: StartPoint) {
+    return startPoint.type === 'alarmGroupStartPoint';
 }
 
 export function isInSpecificVehicle(


### PR DESCRIPTION
### Summary

This PR:
- fixes the vehicles tab in simulated regions now changeing the UI again when selecting a different vehicle
- shows the vehicles inside simulated regions in the Operations Tablet View ( closes #1443 )

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [X] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [X] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [X] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [X] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
