### PR TITLE
Make Transfer Overview and EOC available for Exercise Templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 ### Added
 
 - Map tile servers can now be selected from a list of suggested servers
+- Alarm groups can now be sent when preparing an exercise template.
+- Vehicles in transfer can now be managed when preparing an exercise template.
 
 ### Changed
 

--- a/frontend/src/app/pages/exercises/exercise/shared/trainer-toolbar/trainer-toolbar.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/trainer-toolbar/trainer-toolbar.component.html
@@ -8,7 +8,7 @@
         Einstellungen
     </button>
 
-    @if (exerciseService.additionalExerciseMeta()?.exerciseTemplate) {
+    @if (isTemplate()) {
         <button
             (click)="openAlarmGroupOverview()"
             class="btn btn-outline-primary ms-3"
@@ -54,7 +54,7 @@
         </div>
     }
 
-    @if (!exerciseService.additionalExerciseMeta()?.exerciseTemplate) {
+    @if (!isTemplate()) {
         <div ngbDropdown placement="top-start" class="d-inline-block">
             <button
                 type="button"

--- a/frontend/src/app/pages/exercises/exercise/shared/trainer-toolbar/trainer-toolbar.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/trainer-toolbar/trainer-toolbar.component.html
@@ -1,4 +1,4 @@
-<div class="d-flex pt-2">
+<div class="d-flex pt-2 gap-3">
     <button
         (click)="openExerciseSettings()"
         class="btn btn-outline-primary"
@@ -9,16 +9,44 @@
     </button>
 
     @if (isTemplate()) {
-        <button
-            (click)="openAlarmGroupOverview()"
-            class="btn btn-outline-primary ms-3"
-            data-cy="trainerToolbarAlarmGroupsButton"
-        >
-            Alarmierungsgruppen
-        </button>
+        <div ngbDropdown placement="top-start" [style.display]="'contents'">
+            <button
+                type="button"
+                class="btn btn-outline-primary"
+                ngbDropdownToggle
+            >
+                Alarmierungsgruppen
+            </button>
+            <div ngbDropdownMenu>
+                <button
+                    ngbDropdownItem
+                    (click)="openAlarmGroupOverview()"
+                    class="btn btn-outline-primary"
+                    data-cy="trainerToolbarAlarmGroupsButton"
+                >
+                    Erstellen
+                </button>
+                <button
+                    ngbDropdownItem
+                    (click)="openEmergencyOperationsCenter()"
+                    class="btn btn-primary"
+                    data-cy="trainerToolbarControlCenterButton"
+                >
+                    Leitstelle
+                </button>
+                <button
+                    ngbDropdownItem
+                    (click)="openTransferOverview()"
+                    class="btn btn-primary"
+                    data-cy="trainerToolbarTransferButton"
+                >
+                    Transferübersicht
+                </button>
+            </div>
+        </div>
         <button
             (click)="openHospitalEditor()"
-            class="btn btn-outline-primary ms-3"
+            class="btn btn-outline-primary"
             data-cy="trainerToolbarHospitalsButton"
         >
             Krankenhäuser
@@ -27,7 +55,7 @@
         <div ngbDropdown placement="top-start" class="d-inline-block">
             <button
                 type="button"
-                class="btn btn-outline-primary ms-3"
+                class="btn btn-outline-primary"
                 ngbDropdownToggle
                 data-cy="trainerToolbarCreationButton"
             >
@@ -58,7 +86,7 @@
         <div ngbDropdown placement="top-start" class="d-inline-block">
             <button
                 type="button"
-                class="btn btn-outline-primary ms-3"
+                class="btn btn-outline-primary"
                 ngbDropdownToggle
                 data-cy="trainerToolbarExecutionButton"
             >
@@ -109,7 +137,7 @@
         <div ngbDropdown placement="top-start" class="d-inline-block">
             <button
                 type="button"
-                class="btn btn-outline-primary ms-3"
+                class="btn btn-outline-primary"
                 ngbDropdownToggle
                 data-cy="trainerToolbarEvaluationButton"
             >
@@ -139,11 +167,11 @@
 
         <div class="flex-grow-1"></div>
 
-        <button (click)="deleteExercise()" class="btn btn-danger ms-3">
+        <button (click)="deleteExercise()" class="btn btn-danger">
             Übung löschen
         </button>
     } @else {
-        <div class="ms-3 d-flex alert alert-warning p-2 mb-0 px-3" role="alert">
+        <div class="d-flex alert alert-warning p-2 mb-0 px-3" role="alert">
             <i class="bi bi-exclamation-triangle me-2"></i>
             Dies ist eine Übungsvorlage. Erstellen Sie eine Übung aus dieser
             Vorlage, um sie zu starten.

--- a/frontend/src/app/pages/exercises/exercise/shared/trainer-toolbar/trainer-toolbar.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/trainer-toolbar/trainer-toolbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import {
     NgbModal,
@@ -56,6 +56,10 @@ export class TrainerToolbarComponent {
     private readonly messageService = inject(MessageService);
 
     public exerciseStatus$ = this.store.select(selectExerciseStatus);
+
+    public readonly isTemplate = computed<boolean>(
+        () => !!this.exerciseService.additionalExerciseMeta()?.exerciseTemplate
+    );
 
     public openClientsModal() {
         openClientsModal(this.modalService);

--- a/frontend/src/app/shared/components/start-pause-button/start-pause-button.component.html
+++ b/frontend/src/app/shared/components/start-pause-button/start-pause-button.component.html
@@ -1,7 +1,7 @@
 @if ((exerciseStatus$ | async) === 'running') {
     <button
         (click)="pauseExercise()"
-        class="btn btn-primary ms-3"
+        class="btn btn-primary"
         data-cy="trainerToolbarPauseButton"
     >
         Pause
@@ -10,7 +10,7 @@
 @if ((exerciseStatus$ | async) !== 'running') {
     <button
         (click)="startExercise()"
-        class="btn btn-primary ms-3"
+        class="btn btn-primary"
         data-cy="trainerToolbarStartButton"
     >
         Start


### PR DESCRIPTION
### Summary

Makes the transfer overview pop-up and the eoc pop-up available when editing a exercise template.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
