### PR TITLE
Fix parallel exercise pausing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 - The exercise map now fits on mobile device screens
 - Vehicles inside a simulated region can now be properly selected again
 - Vehicles inside simulated regions are now shown inside the "operations detail view"
+- Exercise instances that are part of a parallel exercise no longer get paused when all participants have left, i.e. due to connection issues. This ensures that all instances stay synchronized.
 
 ### Added
 

--- a/backend/src/exercise/active-exercise.ts
+++ b/backend/src/exercise/active-exercise.ts
@@ -207,7 +207,8 @@ export class ActiveExercise {
         });
         if (
             this.clients.size === 0 &&
-            this.exercise.currentStateString.currentStatus === 'running'
+            this.exercise.currentStateString.currentStatus === 'running' &&
+            this.exercise.parallelExerciseId === null
         ) {
             // Pause the exercise
             this.applyAction(


### PR DESCRIPTION
### Summary

While the issue (#1391) describes keeping the exercise status in sync with all other exercises in the same parallel context, I propose keeping this more simple and never pausing a task unless it is done manually by the trainer. This ensures the tasks always stay in sync.

Closes #1391.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
