### PR TITLE
Add touch zoom lock option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 ### Added
 
 - Add documentation for most features and integrate it with the software.
+- Zooming the map via touch input can be disabled by both trainers and participants per device. This helps preventing accidental zooming if multiple participants are working on a single device simultaneously.
 
 ### Fixed
 

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/exercise-map.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/exercise-map.component.html
@@ -14,16 +14,24 @@
         (click)="$event.stopPropagation()"
     >
         <button
-            (click)="olMapManagerService.olMapManager?.changeZoom('zoomIn')"
+            (click)="
+                olMapManagerService.olMapManager?.changeZoom('zoomIn');
+                zoomInTooltip.close()
+            "
             class="btn btn-sm btn-light"
+            #zoomInTooltip="ngbTooltip"
             ngbTooltip="Vergrößern"
             triggers="hover"
         >
             <i class="bi-zoom-in"></i>
         </button>
         <button
-            (click)="olMapManagerService.olMapManager?.changeZoom('zoomOut')"
+            (click)="
+                olMapManagerService.olMapManager?.changeZoom('zoomOut');
+                zoomOutTooltip.close()
+            "
             class="btn btn-sm btn-light"
+            #zoomOutTooltip="ngbTooltip"
             ngbTooltip="Verkleinern"
             triggers="hover"
         >
@@ -32,14 +40,14 @@
         @let lockZoom =
             (olMapManagerService.olMapManager?.lockZoom$ | async) ?? false;
         <button
-            (click)="olMapManagerService.olMapManager?.toggleZoomLock()"
+            (click)="
+                olMapManagerService.olMapManager?.toggleZoomLock();
+                lockZoomTooltip.close()
+            "
             class="btn btn-sm btn-light"
             [class.active]="lockZoom"
-            [ngbTooltip]="
-                lockZoom
-                    ? 'Zoom per Touchscreen gesperrt. Zum Aktivieren klicken.'
-                    : 'Zoom per Touchscreen aktiv. Zum Sperren klicken.'
-            "
+            #lockZoomTooltip="ngbTooltip"
+            ngbTooltip="Zoom per Touchscreen sperren/freigeben."
             triggers="hover"
         >
             <i class="bi" [ngClass]="lockZoom ? 'bi-lock' : 'bi-unlock2'"></i>
@@ -50,9 +58,11 @@
         ) {
             <button
                 (click)="
-                    olMapManagerService.olMapManager?.tryToFitViewForOverview()
+                    olMapManagerService.olMapManager?.tryToFitViewForOverview();
+                    fitViewTooltip.close()
                 "
                 class="btn btn-sm btn-light"
+                #fitViewTooltip="ngbTooltip"
                 ngbTooltip="Alle Ansichten anzeigen"
                 triggers="hover"
             >
@@ -64,8 +74,9 @@
             (restrictedToViewport$ | async) === undefined
         ) {
             <button
-                (click)="goToCoordinates()"
+                (click)="goToCoordinates(); goToCoordinatesTooltip.close()"
                 class="btn btn-sm btn-light"
+                #goToCoordinatesTooltip="ngbTooltip"
                 ngbTooltip="Zu Koordinaten springen"
                 triggers="hover"
             >
@@ -73,8 +84,9 @@
             </button>
         }
         <button
-            (click)="toggleFullscreen()"
+            (click)="toggleFullscreen(); fullscreenTooltip.close()"
             class="btn btn-sm btn-light"
+            #fullscreenTooltip="ngbTooltip"
             ngbTooltip="Vollbildmodus"
             triggers="hover"
         >

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/exercise-map.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/exercise-map.component.html
@@ -16,16 +16,33 @@
         <button
             (click)="olMapManagerService.olMapManager?.changeZoom('zoomIn')"
             class="btn btn-sm btn-light"
-            title="Vergrößern"
+            ngbTooltip="Vergrößern"
+            triggers="hover"
         >
             <i class="bi-zoom-in"></i>
         </button>
         <button
             (click)="olMapManagerService.olMapManager?.changeZoom('zoomOut')"
             class="btn btn-sm btn-light"
-            title="Verkleinern"
+            ngbTooltip="Verkleinern"
+            triggers="hover"
         >
             <i class="bi-zoom-out"></i>
+        </button>
+        @let lockZoom =
+            (olMapManagerService.olMapManager?.lockZoom$ | async) ?? false;
+        <button
+            (click)="olMapManagerService.olMapManager?.toggleZoomLock()"
+            class="btn btn-sm btn-light"
+            [class.active]="lockZoom"
+            [ngbTooltip]="
+                lockZoom
+                    ? 'Zoom per Touchscreen gesperrt. Zum Aktivieren klicken.'
+                    : 'Zoom per Touchscreen aktiv. Zum Sperren klicken.'
+            "
+            triggers="hover"
+        >
+            <i class="bi" [ngClass]="lockZoom ? 'bi-lock' : 'bi-unlock2'"></i>
         </button>
         @if (
             (currentRole$ | async) !== 'participant' &&
@@ -36,7 +53,8 @@
                     olMapManagerService.olMapManager?.tryToFitViewForOverview()
                 "
                 class="btn btn-sm btn-light"
-                title="Alle Ansichten anzeigen"
+                ngbTooltip="Alle Ansichten anzeigen"
+                triggers="hover"
             >
                 <i class="bi-aspect-ratio"></i>
             </button>
@@ -48,7 +66,8 @@
             <button
                 (click)="goToCoordinates()"
                 class="btn btn-sm btn-light"
-                title="Zu Koordinaten springen"
+                ngbTooltip="Zu Koordinaten springen"
+                triggers="hover"
             >
                 <i class="bi bi-pin-map"></i>
             </button>
@@ -56,7 +75,8 @@
         <button
             (click)="toggleFullscreen()"
             class="btn btn-sm btn-light"
-            title="Vollbildmodus"
+            ngbTooltip="Vollbildmodus"
+            triggers="hover"
         >
             <i
                 [class.bi-fullscreen]="!fullscreenEnabled()"

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/exercise-map.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/exercise-map.component.ts
@@ -22,6 +22,7 @@ import {
     selectCurrentMainRole,
 } from '../../../../../state/application/selectors/shared.selectors';
 import { DisplayMessagesComponent } from '../../../../../feature/messages/display-messages/display-messages.component';
+import { MessageService } from '../../../../../core/messages/message.service';
 import { OlMapManager, olMapCoordinatesSchema } from './utility/ol-map-manager';
 import { PopupManager } from './utility/popup-manager';
 import { PopupService } from './utility/popup.service';
@@ -42,6 +43,7 @@ export class ExerciseMapComponent implements AfterViewInit, OnDestroy {
     private readonly modalService = inject(NgbModal);
     private readonly route = inject(ActivatedRoute);
     readonly olMapManagerService = inject(OlMapManagerService);
+    private readonly messageService = inject(MessageService);
 
     readonly openLayersContainer = viewChild.required<
         ElementRef<HTMLDivElement>
@@ -71,7 +73,8 @@ export class ExerciseMapComponent implements AfterViewInit, OnDestroy {
             this.openLayersContainer().nativeElement,
             this.transferLinesService,
             this.popupManager,
-            this.popupService
+            this.popupService,
+            this.messageService
         );
         this.dragElementService.registerMap(
             this.olMapManagerService.olMapManager.olMap

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/exercise-map.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/exercise-map.component.ts
@@ -9,8 +9,8 @@ import {
 } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Subject } from 'rxjs';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { AsyncPipe } from '@angular/common';
+import { NgbModal, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import { AsyncPipe, NgClass } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { DragElementService } from '../core/drag-element.service';
 import { TransferLinesService } from '../core/transfer-lines.service';
@@ -31,7 +31,7 @@ import { OlMapManagerService } from './utility/ol-map-manager.service';
     selector: 'app-exercise-map',
     templateUrl: './exercise-map.component.html',
     styleUrls: ['./exercise-map.component.scss'],
-    imports: [DisplayMessagesComponent, AsyncPipe],
+    imports: [DisplayMessagesComponent, AsyncPipe, NgClass, NgbTooltip],
 })
 export class ExerciseMapComponent implements AfterViewInit, OnDestroy {
     private readonly store = inject<Store<AppState>>(Store);

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-interactions-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-interactions-manager.ts
@@ -31,6 +31,7 @@ export class OlMapInteractionsManager {
     private lastStatus: ExerciseStatus | undefined;
     private lastRole: Role | undefined;
     private lastExerciseStateMode: 'exercise' | 'timeTravel' | undefined;
+    private _lockZoom = false;
 
     constructor(
         private readonly mapInteractions: Collection<Interaction>,
@@ -54,6 +55,15 @@ export class OlMapInteractionsManager {
 
     public addTrainerInteraction(interaction: Interaction) {
         this.trainerInteractions.push(interaction);
+        this.syncInteractionsAndHandler();
+    }
+
+    public get lockZoom() {
+        return this._lockZoom;
+    }
+
+    public set lockZoom(value) {
+        this._lockZoom = value;
         this.syncInteractionsAndHandler();
     }
 
@@ -92,6 +102,7 @@ export class OlMapInteractionsManager {
         this.updateParticipantInteractions();
         this.interactions = defaultInteractions({
             pinchRotate: false,
+            pinchZoom: !this._lockZoom,
             altShiftDragRotate: false,
             keyboard: true,
         }).extend(

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
@@ -11,7 +11,7 @@ import { Collection, View } from 'ol';
 import type { Interaction } from 'ol/interaction';
 import type VectorLayer from 'ol/layer/Vector';
 import OlMap from 'ol/Map';
-import { Subject, takeUntil } from 'rxjs';
+import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { fromLonLat, toLonLat } from 'ol/proj';
 import { z } from 'zod';
 import type { Coordinate } from 'ol/coordinate';
@@ -60,6 +60,7 @@ export class OlMapManager {
     private featureManagers: FeatureManager<any>[];
     private readonly mapInteractionsManager: OlMapInteractionsManager;
     private static readonly defaultZoom = 20;
+    public readonly lockZoom$ = new BehaviorSubject(false);
     private readonly destroy$ = new Subject<void>();
 
     /**
@@ -138,10 +139,20 @@ export class OlMapManager {
             this.layerFeatureManagerDictionary,
             this.featureNameFeatureManagerDictionary
         );
+
+        this.lockZoom$
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(
+                (lockZoom) => (this.mapInteractionsManager.lockZoom = lockZoom)
+            );
     }
 
     public get olMap(): OlMap {
         return this._olMap;
+    }
+
+    public toggleZoomLock() {
+        this.lockZoom$.next(!this.lockZoom$.value);
     }
 
     private isInViewport(coordinate: Coordinate, viewport: Viewport): boolean {

--- a/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/exercise-map/utility/ol-map-manager.ts
@@ -41,6 +41,7 @@ import {
 import { selectStateSnapshot } from '../../../../../../state/get-state-snapshot';
 import type { ExerciseService } from '../../../../../../core/exercise.service';
 import { ScoutableIndicatorsFeatureManager } from '../feature-managers/scoutable-indicators-feature-manager';
+import type { MessageService } from '../../../../../../core/messages/message.service';
 import type { FeatureManager } from './feature-manager';
 import type { PopupManager } from './popup-manager';
 import { OlMapInteractionsManager } from './ol-map-interactions-manager';
@@ -87,7 +88,8 @@ export class OlMapManager {
         private readonly openLayersContainer: HTMLDivElement,
         private readonly transferLinesService: TransferLinesService,
         private readonly popupManager: PopupManager,
-        private readonly popupService: PopupService
+        private readonly popupService: PopupService,
+        private readonly messageService: MessageService
     ) {
         this._olMap = new OlMap({
             interactions: new Collection<Interaction>(),
@@ -153,6 +155,10 @@ export class OlMapManager {
 
     public toggleZoomLock() {
         this.lockZoom$.next(!this.lockZoom$.value);
+        this.messageService.postMessage({
+            title: `Zoom per Touchscreen ${this.lockZoom$.value ? 'gesperrt' : 'freigegeben'}`,
+            color: 'info',
+        });
     }
 
     private isInViewport(coordinate: Coordinate, viewport: Viewport): boolean {


### PR DESCRIPTION
### Summary

Adds a button to both trainer and participant map that disables zoom via touch input. This helps preventing accidental zooming if multiple participants are working on a single device simultaneously.

### PR Checklist

Please make sure to fulfill the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
