### PR TITLE
Handle saving of exercise states without crashing the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+### Fixed
+
+- Deleting exercise templates which have exercise instances doesn't crash the server anymore.
+
 ## [0.12.0] - 2026-05-17
 
 ### Added

--- a/backend/src/database/repositories/exercise-repository.ts
+++ b/backend/src/database/repositories/exercise-repository.ts
@@ -136,20 +136,29 @@ export class ExerciseRepository extends BaseRepository {
             );
     }
 
-    public async saveExerciseState(exercise: ExerciseInsert) {
+    public async saveExerciseState(
+        exercise: ExerciseInsert & { id: ExerciseId }
+    ) {
+        const {
+            currentStateString,
+            initialStateString,
+            stateVersion,
+            id,
+            tickCounter,
+        } = exercise;
         const exercisePatch = {
-            ...exercise,
+            currentStateString,
+            initialStateString,
+            stateVersion,
+            tickCounter,
             lastUsedAt: new Date(),
         };
 
         return this.onlySingle(
             await this.databaseConnection
-                .insert(exerciseTable)
-                .values(exercisePatch)
-                .onConflictDoUpdate({
-                    target: exerciseTable.id,
-                    set: exercisePatch,
-                })
+                .update(exerciseTable)
+                .set(exercisePatch)
+                .where(eq(exerciseTable.id, id))
                 .returning()
         );
     }

--- a/backend/src/routers/exercise-manager-router.spec.ts
+++ b/backend/src/routers/exercise-manager-router.spec.ts
@@ -79,6 +79,35 @@ describe('exercise manager router', () => {
             );
             expect(parsed.lastUsedAt.getTime()).toBeLessThan(Date.now());
         });
+        it('works with deleted base templates', async () => {
+            const exerciseTemplate = await createExerciseTemplate(
+                environment,
+                session
+            );
+            await environment
+                .httpRequest(
+                    'post',
+                    `/api/exercise_templates/${exerciseTemplate.id}/new`,
+                    session
+                )
+                .expect(201);
+            await environment
+                .httpRequest(
+                    'delete',
+                    `/api/exercise_templates/${exerciseTemplate.id}`,
+                    session
+                )
+                .expect(204);
+
+            const response = await environment
+                .httpRequest('get', '/api/exercises', session)
+                .expect(200);
+            const parsed = getExercisesResponseDataSchema.parse(
+                response.body
+            )[0]!;
+
+            expect(parsed.baseTemplate).toBe(null);
+        });
     });
     describe('POST /api/exercise_templates', () => {
         it('fails with 403 if not authenticated', async () => {


### PR DESCRIPTION
### Summary

Closes #1478 

The issue was that the save handler in the backend tried to save the exercise with `baseTemplateId` still set to the cached template id and not to null (on deleting an exercise template, the database sets this to null in all related exercises).

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
