### PR TITLE
Remove redundant operations to reduce server startup time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 ### Fixed
 
 - Creating a parallel exercise with many (>10) exercise instances no longer slows down the server significantly.
+- Massively reduce the server start up time with many exercises.
 
 ## [0.12.1] - 2026-05-21
 

--- a/backend/src/database/services/exercise-manager-service.ts
+++ b/backend/src/database/services/exercise-manager-service.ts
@@ -160,7 +160,7 @@ export class ExerciseManagerService {
             if (!exerciseEntry) throw new ApiError();
 
             const activeExercise = new ActiveExercise(exerciseEntry, []);
-            await this.exerciseService.loadExercise(activeExercise);
+            this.exerciseService.loadExercise(activeExercise);
 
             await this.exerciseRepository.updateExerciseTemplate(
                 exerciseTemplate.id,

--- a/backend/src/database/services/exercise-service.ts
+++ b/backend/src/database/services/exercise-service.ts
@@ -63,7 +63,7 @@ export class ExerciseService {
         return new Set(this.exerciseMap.values());
     }
 
-    public async loadExercise(activeExercise: ActiveExercise) {
+    public loadExercise(activeExercise: ActiveExercise) {
         this.exerciseMap.set(activeExercise.participantKey, activeExercise);
         this.exerciseMap.set(activeExercise.trainerKey, activeExercise);
         this.exerciseMap.set(activeExercise.exercise.id, activeExercise);
@@ -109,7 +109,7 @@ export class ExerciseService {
                 if (!exerciseEntry) throw new ApiError();
 
                 const activeExercise = new ActiveExercise(exerciseEntry);
-                await this.loadExercise(activeExercise);
+                this.loadExercise(activeExercise);
                 return activeExercise;
             }
         );
@@ -181,10 +181,8 @@ export class ExerciseService {
                             '[Exercise] Tick'
                     ).length;
 
-                    // The actions haven't been saved in the database yet -> keep them
-                    activeExercise.restore(true);
-
-                    await this.loadExercise(activeExercise);
+                    activeExercise.restoreState();
+                    this.loadExercise(activeExercise);
 
                     return activeExercise;
                 } catch (err) {
@@ -241,41 +239,12 @@ export class ExerciseService {
                         async (exerciseEntity) => {
                             const exercise = new ActiveExercise(exerciseEntity);
                             exercise.template = exerciseEntity.template ?? null;
-
-                            // Load all actions
-                            pushAll(
-                                exercise.temporaryActionHistory,
-                                (
-                                    await this.actionRepository
-                                        .withConnection(exerciseRepoTransaction)
-                                        .getActionsForExerciseId(
-                                            exerciseEntity.id
-                                        )
-                                ).map(
-                                    (actionEntity) =>
-                                        new ActionWrapper(
-                                            actionEntity.actionString,
-                                            actionEntity.emitterId,
-                                            exercise,
-                                            actionEntity.index,
-                                            actionEntity.id
-                                        )
-                                )
-                            );
+                            exercise.resetStopped();
+                            this.loadExercise(exercise);
                             return exercise;
                         }
                     )
                 );
-                await Promise.all(
-                    // The actions have already been saved in the database -> do not keep them
-                    exercises.map(async (exercise) => exercise.restore(false))
-                );
-                exercises.forEach((exercise) => {
-                    this.exerciseMap.set(exercise.participantKey, exercise);
-                    this.exerciseMap.set(exercise.trainerKey, exercise);
-                    this.exerciseMap.set(exercise.exercise.id, exercise);
-                    this.loadExercise(exercise);
-                });
                 return exercises;
             }
         );

--- a/backend/src/exercise/active-exercise.ts
+++ b/backend/src/exercise/active-exercise.ts
@@ -5,10 +5,9 @@ import type {
     ExerciseKey,
     ParticipantKey,
     TrainerKey,
+    ExerciseState,
 } from 'fuesim-digital-shared';
 import {
-    ExerciseState,
-    validateExerciseState,
     applyAction,
     cloneDeepMutable,
     reduceExerciseState,
@@ -286,30 +285,11 @@ export class ActiveExercise {
         }
     }
 
-    public restore(keepActions: boolean): void {
-        // Check State Version
-        if (this.exercise.stateVersion !== ExerciseState.currentStateVersion) {
-            throw new RestoreError(
-                `The exercise was created with an incompatible version of the state (got version ${this.exercise.stateVersion}, required version ${ExerciseState.currentStateVersion})`,
-                this.exercise.id
-            );
-        }
-
-        // Validate initial state
-        const errors = validateExerciseState(this.exercise.initialStateString);
-        if (errors.length > 0) {
-            throw new ValidationErrorWrapper(errors);
-        }
-
-        this.restoreState(keepActions);
-    }
-
     /**
-     * @param keepActions This indicates whether to keep the actions that were applied while restoring in the array (when `true`) or to remove them (when `false` and when the database gets used)
      * Recreates the {@link currentState} by applying all actions from {@link temporaryActionHistory} to the {@link initialState}
      * as well as adding actions to the end to gracefully mark the end of the previous exercise session.
      */
-    private restoreState(keepActions: boolean) {
+    public restoreState() {
         let currentState = cloneDeepMutable(this.exercise.initialStateString);
 
         this.temporaryActionHistory.forEach((actionWrapper) => {
@@ -336,13 +316,11 @@ export class ActiveExercise {
         this.incrementIdGenerator.setCurrent(
             this.temporaryActionHistory.length
         );
-        if (!keepActions) {
-            // Remove all actions to not save them again in the database
-            this.temporaryActionHistory.splice(
-                0,
-                this.temporaryActionHistory.length
-            );
-        }
+        this.resetStopped();
+    }
+
+    /** Adds actions to the end to gracefully mark the end of the previous exercise session.**/
+    public resetStopped() {
         // Pause exercise
         if (this.exercise.currentStateString.currentStatus === 'running')
             this.reduce(


### PR DESCRIPTION
### Summary

While reading the whole code around saving and restoring exercises, I found out the following things:

1. When applying an action, the `currentStateString` is updated and the action is added to the `temporaryActionHistory`.
2. On the next run of `saveTick`, both the current state and the newly added actions are stored in the database in one transaction (so either the updated state and the action is saved or none of them is saved).

On the next server restart, the following things happen:

1. All exercises are fetched from the database and, if outdated, are migrated to the current state version.
2. After this, only up-to-date exercise states are in the database or the server doesn't start.
3. Now, in `restore`, all actions are fetched again, are applied to the initial state, the current state gets set again (to the same current state as before, as the current state was either already up-to-date due to the above-mentioned save logic or due to the migration logic), and the actions are trashed as they are in the database already (of course).

So step 3 seems redundant to me and also causes to take the server start up more than 10 minutes on production.

But: I only discussed this with @Jogius and I am not sure if I missed something. Therefore, I would we clad if @ClFeSc and @lukasrad02 could take a look at this.

### PR Checklist

Please make sure to fulfill the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
