### PR TITLE
Add Operations Tablet To Trainer View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+### Added
+
+- Trainers now have access to the 'Einsatzübersicht' in Exercises and Exercise Templates.
+
 ## [0.13.1] - 2026-06-01
 
 ### Fixed

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/trainer-operations-tablet-modal/open-trainer-operations-tablet-modal.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/trainer-operations-tablet-modal/open-trainer-operations-tablet-modal.ts
@@ -1,0 +1,8 @@
+import type { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { TrainerOperationsTabletModalComponent } from './trainer-operations-tablet-modal.component';
+
+export function openTrainerOperationsTabletModal(ngbModalService: NgbModal) {
+    ngbModalService.open(TrainerOperationsTabletModalComponent, {
+        size: 'xl',
+    });
+}

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/trainer-operations-tablet-modal/trainer-operations-tablet-modal.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/trainer-operations-tablet-modal/trainer-operations-tablet-modal.component.html
@@ -1,0 +1,12 @@
+<div class="modal-header">
+    <h4 class="modal-title">Einsatztablet</h4>
+    <button
+        type="button"
+        class="btn-close"
+        data-cy="closeTrainerOperationsTabletButton"
+        (click)="close()"
+    ></button>
+</div>
+<div class="modal-body p-2 operations-tablet-modal">
+    <app-operations-tablet-view />
+</div>

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/trainer-operations-tablet-modal/trainer-operations-tablet-modal.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/trainer-operations-tablet-modal/trainer-operations-tablet-modal.component.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-    <h4 class="modal-title">Einsatztablet</h4>
+    <h4 class="modal-title">Einsatzübersicht</h4>
     <button
         type="button"
         class="btn-close"

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/trainer-operations-tablet-modal/trainer-operations-tablet-modal.component.scss
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/trainer-operations-tablet-modal/trainer-operations-tablet-modal.component.scss
@@ -1,0 +1,3 @@
+.operations-tablet-modal {
+    height: 85vh;
+}

--- a/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/trainer-operations-tablet-modal/trainer-operations-tablet-modal.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/operations-tablet-view/trainer-operations-tablet-modal/trainer-operations-tablet-modal.component.ts
@@ -1,0 +1,17 @@
+import { Component, inject } from '@angular/core';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { OperationsTabletViewComponent } from '../operations-tablet-view.component';
+
+@Component({
+    selector: 'app-trainer-operations-tablet-modal',
+    imports: [OperationsTabletViewComponent],
+    templateUrl: './trainer-operations-tablet-modal.component.html',
+    styleUrl: './trainer-operations-tablet-modal.component.scss',
+})
+export class TrainerOperationsTabletModalComponent {
+    private readonly activeModal = inject(NgbActiveModal);
+
+    public close() {
+        this.activeModal.close();
+    }
+}

--- a/frontend/src/app/pages/exercises/exercise/shared/trainer-toolbar/trainer-toolbar.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/trainer-toolbar/trainer-toolbar.component.html
@@ -56,7 +56,7 @@
             class="btn btn-outline-primary"
             data-cy="trainerToolbarOperationsTabletButton"
         >
-            Einsatztablet
+            Einsatzübersicht
         </button>
     } @else {
         <div ngbDropdown placement="top-start" class="d-inline-block">
@@ -128,7 +128,7 @@
                     class="btn btn-primary"
                     data-cy="trainerToolbarOperationsTabletButton"
                 >
-                    Einsatztablet
+                    Einsatzübersicht
                 </button>
                 <button
                     ngbDropdownItem

--- a/frontend/src/app/pages/exercises/exercise/shared/trainer-toolbar/trainer-toolbar.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/trainer-toolbar/trainer-toolbar.component.html
@@ -51,6 +51,13 @@
         >
             Krankenhäuser
         </button>
+        <button
+            (click)="openOperationsTabletModal()"
+            class="btn btn-outline-primary"
+            data-cy="trainerToolbarOperationsTabletButton"
+        >
+            Einsatztablet
+        </button>
     } @else {
         <div ngbDropdown placement="top-start" class="d-inline-block">
             <button
@@ -114,6 +121,14 @@
                     data-cy="trainerToolbarControlCenterButton"
                 >
                     Leitstelle
+                </button>
+                <button
+                    ngbDropdownItem
+                    (click)="openOperationsTabletModal()"
+                    class="btn btn-primary"
+                    data-cy="trainerToolbarOperationsTabletButton"
+                >
+                    Einsatztablet
                 </button>
                 <button
                     ngbDropdownItem

--- a/frontend/src/app/pages/exercises/exercise/shared/trainer-toolbar/trainer-toolbar.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/trainer-toolbar/trainer-toolbar.component.ts
@@ -17,9 +17,10 @@ import { openEmergencyOperationsCenterModal } from '../emergency-operations-cent
 import { openExerciseSettingsModal } from '../exercise-settings/open-exercise-settings-modal';
 import { openExerciseStatisticsModal } from '../exercise-statistics/open-exercise-statistics-modal';
 import { openHospitalEditorModal } from '../hospital-editor/hospital-editor-modal';
+import { openTrainerOperationsTabletModal } from '../operations-tablet-view/trainer-operations-tablet-modal/open-trainer-operations-tablet-modal';
 import { openSimulationTrainerModal } from '../simulation/trainer-modal/open-simulation-trainer-modal';
-import { openTransferOverviewModal } from '../transfer-overview/open-transfer-overview-modal';
 import { openSimulationSignallerModal } from '../simulation/signaller-modal/open-simulation-signaller-modal';
+import { openTransferOverviewModal } from '../transfer-overview/open-transfer-overview-modal';
 import { ApiService } from '../../../../../core/api.service';
 import { ApplicationService } from '../../../../../core/application.service';
 import { ConfirmationModalService } from '../../../../../core/confirmation-modal/confirmation-modal.service';
@@ -105,6 +106,10 @@ export class TrainerToolbarComponent {
 
     public openSimulationSignallerModal() {
         openSimulationSignallerModal(this.modalService);
+    }
+
+    public openOperationsTabletModal() {
+        openTrainerOperationsTabletModal(this.modalService);
     }
 
     public async deleteExercise() {


### PR DESCRIPTION
### Summary

Closes #1489 by adding a modal to the trainer exercise and exercise template views where they have full access to the operations tablet view.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
