### PR TITLE
Show Toast When Measure Is Executed / Scoutable Is Viewed During Replay Playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+### Added
+
+- There are now notifications when viewing an exercise replay whenever a measure is taken or a scoutable element is viewed.
+
 ### Changed
 
 - Trainers now have access to the 'Einsatzübersicht' in Exercises and Exercise Templates.

--- a/frontend/src/app/core/time-jump-helper.ts
+++ b/frontend/src/app/core/time-jump-helper.ts
@@ -14,7 +14,7 @@ export class TimeJumpHelper {
 
     constructor(private readonly exerciseTimeLine: ExerciseTimeline) {
         this.exerciseStateCache.add(exerciseTimeLine.initialState.currentTime, {
-            state: exerciseTimeLine.initialState,
+            state: { ...exerciseTimeLine.initialState, logEntries: [] },
             nextActionIndex: 0,
         });
     }

--- a/frontend/src/app/pages/exercises/exercise/shared/time-travel/time-travel.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/time-travel/time-travel.component.ts
@@ -6,6 +6,7 @@ import { cloneDeepMutable, StateExport } from 'fuesim-digital-shared';
 import { throttle } from 'lodash-es';
 import { FormsModule } from '@angular/forms';
 import { AsyncPipe } from '@angular/common';
+import type { LogEntry } from 'fuesim-digital-shared';
 import { openClientsModal } from '../clients-modal/open-clients-modal';
 import { openExerciseStatisticsModal } from '../exercise-statistics/open-exercise-statistics-modal';
 import { openTransferOverviewModal } from '../transfer-overview/open-transfer-overview-modal';
@@ -85,9 +86,36 @@ export class TimeTravelComponent implements OnDestroy {
                 this.stopReplay();
                 return;
             }
+            const prevLogEntries =
+                selectStateSnapshot(selectExerciseState, this.store).logEntries
+                    ?.length ?? 0;
             this.timeTravelService.jumpToTime(
                 timeConstraints.current + 1000 * this.replaySpeed
             );
+            const nextLogEntries =
+                selectStateSnapshot(selectExerciseState, this.store)
+                    .logEntries ?? [];
+            const newLogEntries = nextLogEntries.slice(prevLogEntries);
+
+            const onlyMeasures = (e: LogEntry): boolean =>
+                e.tags.some((t) => t.category === 'Maßnahme');
+            for (const entry of newLogEntries.filter(onlyMeasures)) {
+                this.messageService.postMessage({
+                    color: 'info',
+                    title: 'Maßnahme getroffen',
+                    body: entry.description,
+                });
+            }
+
+            const onlyScoutings = (e: LogEntry): boolean =>
+                e.tags.some((t) => t.category === 'Erkundungselement');
+            for (const entry of newLogEntries.filter(onlyScoutings)) {
+                this.messageService.postMessage({
+                    color: 'info',
+                    title: 'Element erkundet',
+                    body: entry.description,
+                });
+            }
         }, 1000);
     }
 


### PR DESCRIPTION
### Summary

Closes #1400 by showing toasts when measures are taken and scoutables and viewed by participants.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
