### PR TITLE
Add Client Reconnecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 ### Changed
 
-- Clients now automatically rejoin the exercise with the same view and role when disconnecting due to network issues / reloads.
+- Clients now automatically rejoin the exercise with the same view and role when disconnecting due to network issues/reloads.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+### Changed
+
+- Clients now automatically rejoin the exercise with the same view and role when disconnecting due to network issues / reloads.
+
 ### Fixed
 
 - The server no longer crashes on startup when using `DFM_USE_DB=false`

--- a/backend/src/database/services/parallel-exercise-service.ts
+++ b/backend/src/database/services/parallel-exercise-service.ts
@@ -210,7 +210,7 @@ export class ParallelExerciseService {
                 isActive: Object.values(state.clients).some(
                     (client) =>
                         client.role.mainRole === 'participant' &&
-                        !client.isInactive
+                        client.isActive
                 ),
             });
         });

--- a/backend/src/database/services/parallel-exercise-service.ts
+++ b/backend/src/database/services/parallel-exercise-service.ts
@@ -208,7 +208,9 @@ export class ParallelExerciseService {
                 currentStatus: state.currentStatus,
                 lastLogEntry: state.lastLogEntry,
                 isActive: Object.values(state.clients).some(
-                    (client) => client.role.mainRole === 'participant'
+                    (client) =>
+                        client.role.mainRole === 'participant' &&
+                        !client.isInactive
                 ),
             });
         });

--- a/backend/src/exercise/active-exercise.ts
+++ b/backend/src/exercise/active-exercise.ts
@@ -240,15 +240,15 @@ export class ActiveExercise {
         }
     }
 
-    public reactivateClient(clientWrapper: ExerciseClientWrapper) {
+    public setClientActive(clientWrapper: ExerciseClientWrapper) {
         if (clientWrapper.client === undefined) {
             return;
         }
-        const reactivateAction: ExerciseAction = {
-            type: '[Client] Reactivate client',
+        const activeAction: ExerciseAction = {
+            type: '[Client] Set client active',
             clientId: clientWrapper.client.id,
         };
-        this.applyAction(reactivateAction, clientWrapper.client.id);
+        this.applyAction(activeAction, clientWrapper.client.id);
         this.clients.add(clientWrapper);
     }
 

--- a/backend/src/exercise/active-exercise.ts
+++ b/backend/src/exercise/active-exercise.ts
@@ -219,6 +219,39 @@ export class ActiveExercise {
         }
     }
 
+    public setClientInactive(clientWrapper: ExerciseClientWrapper) {
+        if (!this.clients.has(clientWrapper)) {
+            return;
+        }
+        const client = clientWrapper.client!;
+        const inactiveAction: ExerciseAction = {
+            type: '[Client] Set client inactive',
+            clientId: client.id,
+        };
+        this.applyAction(inactiveAction, client.id, () => {
+            this.clients.delete(clientWrapper);
+        });
+        if (
+            this.clients.size === 0 &&
+            this.exercise.currentStateString.currentStatus === 'running' &&
+            this.exercise.parallelExerciseId === null
+        ) {
+            this.applyAction({ type: '[Exercise] Pause' }, null);
+        }
+    }
+
+    public reactivateClient(clientWrapper: ExerciseClientWrapper) {
+        if (clientWrapper.client === undefined) {
+            return;
+        }
+        const reactivateAction: ExerciseAction = {
+            type: '[Client] Reactivate client',
+            clientId: clientWrapper.client.id,
+        };
+        this.applyAction(reactivateAction, clientWrapper.client.id);
+        this.clients.add(clientWrapper);
+    }
+
     public start() {
         this.tickHandler.start();
     }

--- a/backend/src/exercise/client-wrapper.ts
+++ b/backend/src/exercise/client-wrapper.ts
@@ -91,6 +91,31 @@ export class ExerciseClientWrapper extends ClientWrapper {
     }
 
     /**
+     * Reconnect to an existing inactive client in an exercise.
+     * @param exerciseKey The exercise key to use.
+     * @param clientId The id of the existing (inactive) client to reactivate.
+     * @returns The client's id on success, or null if the client could not be reconnected.
+     */
+    public reconnectToExercise(
+        exerciseKey: ExerciseKey,
+        clientId: UUID
+    ): UUID | null {
+        this.chosenExercise = this.services.exerciseService.getExerciseByKey(
+            exerciseKey,
+            this.session
+        );
+        const existingClient =
+            this.chosenExercise.getStateSnapshot().clients[clientId];
+        if (!existingClient?.isInactive) {
+            this.chosenExercise = undefined;
+            return null;
+        }
+        this.relatedExerciseClient = existingClient;
+        this.chosenExercise.reactivateClient(this);
+        return existingClient.id;
+    }
+
+    /**
      * Note that this method simply returns when the client did not join an exercise.
      */
     public leaveExercise() {
@@ -116,7 +141,13 @@ export class ExerciseClientWrapper extends ClientWrapper {
     }
 
     public override disconnect() {
-        this.leaveExercise();
+        if (
+            this.chosenExercise !== undefined &&
+            this.relatedExerciseClient !== undefined
+        ) {
+            this.chosenExercise.setClientInactive(this);
+            this.chosenExercise = undefined;
+        }
         super.disconnect();
     }
 }

--- a/backend/src/exercise/client-wrapper.ts
+++ b/backend/src/exercise/client-wrapper.ts
@@ -93,7 +93,7 @@ export class ExerciseClientWrapper extends ClientWrapper {
     /**
      * Reconnect to an existing inactive client in an exercise.
      * @param exerciseKey The exercise key to use.
-     * @param clientId The id of the existing (inactive) client to reactivate.
+     * @param clientId The id of the existing (inactive) client to set active.
      * @returns The client's id on success, or null if the client could not be reconnected.
      */
     public reconnectToExercise(
@@ -106,12 +106,12 @@ export class ExerciseClientWrapper extends ClientWrapper {
         );
         const existingClient =
             this.chosenExercise.getStateSnapshot().clients[clientId];
-        if (!existingClient?.isInactive) {
+        if (existingClient?.isActive) {
             this.chosenExercise = undefined;
             return null;
         }
         this.relatedExerciseClient = existingClient;
-        this.chosenExercise.reactivateClient(this);
+        this.chosenExercise.setClientActive(this);
         return existingClient.id;
     }
 

--- a/backend/src/exercise/client-wrapper.ts
+++ b/backend/src/exercise/client-wrapper.ts
@@ -112,7 +112,7 @@ export class ExerciseClientWrapper extends ClientWrapper {
         }
         this.relatedExerciseClient = existingClient;
         this.chosenExercise.setClientActive(this);
-        return existingClient.id;
+        return existingClient?.id ?? null;
     }
 
     /**

--- a/backend/src/exercise/websocket-handler/disconnect-handler.spec.ts
+++ b/backend/src/exercise/websocket-handler/disconnect-handler.spec.ts
@@ -4,7 +4,7 @@ import { createTestEnvironment, createExercise } from '../../test/utils.js';
 describe('disconnect socket', () => {
     const environment = createTestEnvironment();
 
-    it('removes client from state on disconnect', async () => {
+    it('marks client as inactive on disconnect', async () => {
         const participantKey = (await createExercise(environment))
             .participantKey;
 
@@ -12,7 +12,10 @@ describe('disconnect socket', () => {
         const innerName = 'My Name';
 
         await environment.withWebsocket(async (outerSocket) => {
-            await outerSocket.emit('joinExercise', participantKey, outerName);
+            await outerSocket.emit('joinExercise', {
+                exerciseKey: participantKey,
+                clientName: outerName,
+            });
 
             let state = await outerSocket.emit('getState');
             expect(state.success).toBe(true);
@@ -20,14 +23,18 @@ describe('disconnect socket', () => {
             const previousClientIds = Object.keys(state.payload.clients);
 
             await environment.withWebsocket(async (innerSocket) =>
-                innerSocket.emit('joinExercise', participantKey, innerName)
+                innerSocket.emit('joinExercise', {
+                    exerciseKey: participantKey,
+                    clientName: innerName,
+                })
             );
 
             state = await outerSocket.emit('getState');
             expect(state.success).toBe(true);
             assert(state.success);
             const afterClientIds = Object.keys(state.payload.clients);
-            expect(afterClientIds).toStrictEqual(previousClientIds);
+            // After disconnect, the client is marked inactive (not removed), so both clients remain
+            expect(afterClientIds.length).toBe(previousClientIds.length + 1);
         });
     });
 });

--- a/backend/src/exercise/websocket-handler/join-exercise-handler.spec.ts
+++ b/backend/src/exercise/websocket-handler/join-exercise-handler.spec.ts
@@ -23,11 +23,10 @@ describe('join exercise', () => {
         await environment.withWebsocket(async (clientSocket) => {
             const clientName = 'someRandomName';
 
-            const joinExercise = await clientSocket.emit(
-                'joinExercise',
+            const joinExercise = await clientSocket.emit('joinExercise', {
                 exerciseKey,
-                clientName
-            );
+                clientName,
+            });
 
             expect(joinExercise.success).toBe(true);
             assert(joinExercise.success);
@@ -51,7 +50,10 @@ describe('join exercise', () => {
         const id = '123456' as ParticipantKey;
 
         await environment.withWebsocket(async (socket) => {
-            const join = await socket.emit('joinExercise', id, 'Test Client');
+            const join = await socket.emit('joinExercise', {
+                exerciseKey: id,
+                clientName: 'Test Client',
+            });
 
             expect(join.success).toBe(false);
         });
@@ -69,11 +71,10 @@ describe('join exercise', () => {
         });
         it('fails joining with trainer key if not logged in', async () => {
             await environment.withWebsocket(async (socket) => {
-                const join = await socket.emit(
-                    'joinExercise',
-                    exerciseTemplate.trainerKey,
-                    'Test Client'
-                );
+                const join = await socket.emit('joinExercise', {
+                    exerciseKey: exerciseTemplate.trainerKey,
+                    clientName: 'Test Client',
+                });
 
                 expect(join.success).toBe(false);
             });
@@ -81,11 +82,10 @@ describe('join exercise', () => {
 
         it('succeeds joining with trainer key if logged in', async () => {
             await environment.withWebsocket(async (socket) => {
-                const join = await socket.emit(
-                    'joinExercise',
-                    exerciseTemplate.trainerKey,
-                    'Test Client'
-                );
+                const join = await socket.emit('joinExercise', {
+                    exerciseKey: exerciseTemplate.trainerKey,
+                    clientName: 'Test Client',
+                });
 
                 expect(join.success).toBe(true);
             }, session);
@@ -96,11 +96,10 @@ describe('join exercise', () => {
                 user: alternativeTestUserSessionData,
             });
             await environment.withWebsocket(async (socket) => {
-                const join = await socket.emit(
-                    'joinExercise',
-                    exerciseTemplate.trainerKey,
-                    'Test Client'
-                );
+                const join = await socket.emit('joinExercise', {
+                    exerciseKey: exerciseTemplate.trainerKey,
+                    clientName: 'Test Client',
+                });
 
                 expect(join.success).toBe(false);
             }, session2);
@@ -111,11 +110,10 @@ describe('join exercise', () => {
                 .TESTING_getExerciseMap()
                 .get(exerciseTemplate.trainerKey)!;
             await environment.withWebsocket(async (socket) => {
-                const join = await socket.emit(
-                    'joinExercise',
-                    exercise.participantKey,
-                    'Test Client'
-                );
+                const join = await socket.emit('joinExercise', {
+                    exerciseKey: exercise.participantKey,
+                    clientName: 'Test Client',
+                });
 
                 expect(join.success).toBe(false);
             });
@@ -125,11 +123,10 @@ describe('join exercise', () => {
                 .TESTING_getExerciseMap()
                 .get(exerciseTemplate.trainerKey)!;
             await environment.withWebsocket(async (socket) => {
-                const join = await socket.emit(
-                    'joinExercise',
-                    exercise.participantKey,
-                    'Test Client'
-                );
+                const join = await socket.emit('joinExercise', {
+                    exerciseKey: exercise.participantKey,
+                    clientName: 'Test Client',
+                });
 
                 expect(join.success).toBe(false);
             }, session);
@@ -144,20 +141,18 @@ describe('join exercise', () => {
         await environment.withWebsocket(async (firstClientSocket) => {
             const firstClientName = 'someRandomName';
 
-            await firstClientSocket.emit(
-                'joinExercise',
-                firstExerciseKey,
-                firstClientName
-            );
+            await firstClientSocket.emit('joinExercise', {
+                exerciseKey: firstExerciseKey,
+                clientName: firstClientName,
+            });
 
             await environment.withWebsocket(async (secondClientSocket) => {
                 const secondClientName = 'anotherRandomName';
 
-                await secondClientSocket.emit(
-                    'joinExercise',
-                    secondExerciseKey,
-                    secondClientName
-                );
+                await secondClientSocket.emit('joinExercise', {
+                    exerciseKey: secondExerciseKey,
+                    clientName: secondClientName,
+                });
 
                 const state = await firstClientSocket.emit('getState');
 
@@ -179,20 +174,18 @@ describe('join exercise', () => {
 
             firstClientSocket.spyOn('performAction');
 
-            await firstClientSocket.emit(
-                'joinExercise',
+            await firstClientSocket.emit('joinExercise', {
                 exerciseKey,
-                firstClientName
-            );
+                clientName: firstClientName,
+            });
 
             await environment.withWebsocket(async (secondClientSocket) => {
                 const secondClientName = 'anotherRandomName';
 
-                await secondClientSocket.emit(
-                    'joinExercise',
+                await secondClientSocket.emit('joinExercise', {
                     exerciseKey,
-                    secondClientName
-                );
+                    clientName: secondClientName,
+                });
 
                 expect(firstClientSocket.getTimesCalled('performAction')).toBe(
                     1
@@ -205,19 +198,20 @@ describe('join exercise', () => {
         const exerciseKeys = await createExercise(environment);
 
         await environment.withWebsocket(async (trainerSocket) => {
-            const joinTrainer = await trainerSocket.emit(
-                'joinExercise',
-                exerciseKeys.trainerKey,
-                'trainer'
-            );
+            const joinTrainer = await trainerSocket.emit('joinExercise', {
+                exerciseKey: exerciseKeys.trainerKey,
+                clientName: 'trainer',
+            });
 
             expect(joinTrainer.success).toBe(true);
 
             await environment.withWebsocket(async (participantSocket) => {
                 const joinParticipant = await participantSocket.emit(
                     'joinExercise',
-                    exerciseKeys.participantKey,
-                    'participant'
+                    {
+                        exerciseKey: exerciseKeys.participantKey,
+                        clientName: 'participant',
+                    }
                 );
 
                 expect(joinParticipant.success).toBe(true);
@@ -275,11 +269,10 @@ describe('join exercise', () => {
 
         const pauseSpy = jest.spyOn(ActiveExercise.prototype, 'pause');
         await environment.withWebsocket(async (socket) => {
-            const joinResponse = await socket.emit(
-                'joinExercise',
-                exerciseKeys.trainerKey,
-                'Test'
-            );
+            const joinResponse = await socket.emit('joinExercise', {
+                exerciseKey: exerciseKeys.trainerKey,
+                clientName: 'Test',
+            });
             expect(joinResponse.success).toBe(true);
 
             const startResponse = await socket.emit('proposeAction', {
@@ -290,5 +283,13 @@ describe('join exercise', () => {
         // Let the socket disconnect.
         await sleep(1000);
         expect(pauseSpy).toHaveBeenCalledTimes(1);
+
+        const activeExercise = environment.services.exerciseService
+            .TESTING_getExerciseMap()
+            .get(exerciseKeys.trainerKey)!;
+        const state = activeExercise.getStateSnapshot();
+        const clients = Object.values(state.clients);
+        expect(clients.length).toBeGreaterThan(0);
+        expect(clients.every((c) => c.isInactive)).toBe(true);
     });
 });

--- a/backend/src/exercise/websocket-handler/join-exercise-handler.spec.ts
+++ b/backend/src/exercise/websocket-handler/join-exercise-handler.spec.ts
@@ -290,6 +290,6 @@ describe('join exercise', () => {
         const state = activeExercise.getStateSnapshot();
         const clients = Object.values(state.clients);
         expect(clients.length).toBeGreaterThan(0);
-        expect(clients.every((c) => c.isInactive)).toBe(true);
+        expect(clients.every((c) => !c.isActive)).toBe(true);
     });
 });

--- a/backend/src/exercise/websocket-handler/join-exercise-handler.ts
+++ b/backend/src/exercise/websocket-handler/join-exercise-handler.ts
@@ -1,3 +1,4 @@
+import { isUUID } from 'class-validator';
 import {
     type UUID,
     type ExerciseKey,
@@ -18,7 +19,18 @@ export function registerJoinExerciseHandler(
     secureOn(
         socket,
         'joinExercise',
-        (exerciseKey: ExerciseKey, clientName: string, callback) => {
+        (
+            {
+                exerciseKey,
+                clientName,
+                clientId,
+            }: {
+                exerciseKey: ExerciseKey;
+                clientName?: string;
+                clientId?: UUID;
+            },
+            callback
+        ) => {
             const clientWrapper = ClientWrapper.init(
                 ExerciseClientWrapper,
                 socket,
@@ -43,14 +55,46 @@ export function registerJoinExerciseHandler(
                 });
                 return;
             }
+            if (clientId === undefined && clientName === undefined) {
+                callback({
+                    success: false,
+                    message: 'Either clientId or clientName must be provided',
+                    expected: false,
+                });
+                return;
+            }
+            if (clientId !== undefined && !isUUID(clientId, 4)) {
+                callback({
+                    success: false,
+                    message: 'Invalid clientId format',
+                    expected: false,
+                });
+                return;
+            }
 
             clientWrapper.getSessionInformation().then(() => {
-                let clientId: UUID | undefined;
+                let joinedClientId: UUID | null = null;
                 try {
-                    clientId = clientWrapper.joinExercise(
-                        exerciseKey,
-                        clientName
-                    );
+                    if (clientId !== undefined) {
+                        joinedClientId = clientWrapper.reconnectToExercise(
+                            exerciseKey,
+                            clientId
+                        );
+                        if (joinedClientId === null) {
+                            callback({
+                                success: false,
+                                message:
+                                    'The client could not be reconnected (not found or not inactive)',
+                                expected: true,
+                            });
+                            return;
+                        }
+                    } else {
+                        joinedClientId = clientWrapper.joinExercise(
+                            exerciseKey,
+                            clientName!
+                        );
+                    }
                 } catch (e: unknown) {
                     if (e instanceof NotFoundError) {
                         callback({
@@ -73,7 +117,7 @@ export function registerJoinExerciseHandler(
                 callback({
                     success: true,
                     payload: joinExerciseResponseDataSchema.encode({
-                        clientId,
+                        clientId: joinedClientId,
                         exerciseTemplate: clientWrapper.exercise!.template
                             ? {
                                   ...clientWrapper.exercise!.template,

--- a/backend/src/exercise/websocket-handler/join-parallel-exercise-handler.spec.ts
+++ b/backend/src/exercise/websocket-handler/join-parallel-exercise-handler.spec.ts
@@ -159,11 +159,10 @@ describe('join parallel exercise', () => {
                 const responsePromise = socket.waitOn(
                     'updateExerciseInstances'
                 );
-                await clientSocket.emit(
-                    'joinExercise',
-                    joinedParticipant.participantKey,
-                    clientName
-                );
+                await clientSocket.emit('joinExercise', {
+                    exerciseKey: joinedParticipant.participantKey,
+                    clientName,
+                });
 
                 const response = await responsePromise;
                 expect(response.exerciseInstances.length).toBe(1);
@@ -193,11 +192,10 @@ describe('join parallel exercise', () => {
                 const responsePromise = socket.waitOn(
                     'updateExerciseInstances'
                 );
-                await clientSocket.emit(
-                    'joinExercise',
-                    joinedParticipant.participantKey,
-                    clientName
-                );
+                await clientSocket.emit('joinExercise', {
+                    exerciseKey: joinedParticipant.participantKey,
+                    clientName,
+                });
 
                 await responsePromise;
             });
@@ -228,18 +226,16 @@ describe('join parallel exercise', () => {
             );
 
             await environment.withWebsocket(async (clientSocket1) => {
-                await clientSocket1.emit(
-                    'joinExercise',
-                    joinedParticipant1.participantKey,
-                    ''
-                );
+                await clientSocket1.emit('joinExercise', {
+                    exerciseKey: joinedParticipant1.participantKey,
+                    clientName: '',
+                });
 
                 await environment.withWebsocket(async (clientSocket2) => {
-                    await clientSocket2.emit(
-                        'joinExercise',
-                        joinedParticipant2.participantKey,
-                        ''
-                    );
+                    await clientSocket2.emit('joinExercise', {
+                        exerciseKey: joinedParticipant2.participantKey,
+                        clientName: '',
+                    });
 
                     await socket.emit('controlParallelExercise', 'start');
 

--- a/backend/src/exercise/websocket-handler/propose-action-handler.spec.ts
+++ b/backend/src/exercise/websocket-handler/propose-action-handler.spec.ts
@@ -19,11 +19,10 @@ describe('propose action', () => {
         const exerciseKeys = await createExercise(environment);
 
         await environment.withWebsocket(async (socket) => {
-            const join = await socket.emit(
-                'joinExercise',
-                exerciseKeys.trainerKey,
-                'Name'
-            );
+            const join = await socket.emit('joinExercise', {
+                exerciseKey: exerciseKeys.trainerKey,
+                clientName: 'Name',
+            });
 
             expect(join.success).toBe(true);
 
@@ -40,11 +39,10 @@ describe('propose action', () => {
         const exerciseKeys = await createExercise(environment);
 
         await environment.withWebsocket(async (socket) => {
-            const join = await socket.emit(
-                'joinExercise',
-                exerciseKeys.trainerKey,
-                'Name'
-            );
+            const join = await socket.emit('joinExercise', {
+                exerciseKey: exerciseKeys.trainerKey,
+                clientName: 'Name',
+            });
 
             expect(join.success).toBe(true);
 
@@ -61,11 +59,10 @@ describe('propose action', () => {
         const exerciseKeys = await createExercise(environment);
 
         await environment.withWebsocket(async (socket) => {
-            const join = await socket.emit(
-                'joinExercise',
-                exerciseKeys.trainerKey,
-                'Name'
-            );
+            const join = await socket.emit('joinExercise', {
+                exerciseKey: exerciseKeys.trainerKey,
+                clientName: 'Name',
+            });
 
             expect(join.success).toBe(true);
 
@@ -82,11 +79,10 @@ describe('propose action', () => {
         const exerciseKeys = await createExercise(environment);
 
         await environment.withWebsocket(async (socket) => {
-            const join = await socket.emit(
-                'joinExercise',
-                exerciseKeys.participantKey,
-                'Name'
-            );
+            const join = await socket.emit('joinExercise', {
+                exerciseKey: exerciseKeys.participantKey,
+                clientName: 'Name',
+            });
 
             expect(join.success).toBe(true);
 

--- a/backend/src/routers/exercise-router.spec.ts
+++ b/backend/src/routers/exercise-router.spec.ts
@@ -355,11 +355,10 @@ describe('exercise router', () => {
         it('disconnects clients of the removed exercise', async () => {
             const exerciseKey = (await createExercise(environment)).trainerKey;
             await environment.withWebsocket(async (socket) => {
-                const joinExercise = await socket.emit(
-                    'joinExercise',
+                const joinExercise = await socket.emit('joinExercise', {
                     exerciseKey,
-                    ''
-                );
+                    clientName: '',
+                });
 
                 expect(joinExercise.success).toBe(true);
 

--- a/frontend/cypress/e2e/exercise.cy.ts
+++ b/frontend/cypress/e2e/exercise.cy.ts
@@ -781,13 +781,18 @@ describe('A trainer on the exercise page', () => {
         cy.wait(commonErrorTimeout);
         cy.get('@trainerSocketPerformedActions')
             .lastElement()
-            .should('have.property', 'type', '[Client] Remove client');
+            .should('have.property', 'type', '[Client] Set client inactive');
 
-        cy.getState()
-            .its('exerciseState')
-            .its('clients')
-            .itsValues()
-            .should('have.length', 2);
+        cy.get('@participantSocketUUID', { log: false }).then(
+            (participantSocketUUID: any) => {
+                cy.getState()
+                    .its('exerciseState')
+                    .its('clients')
+                    .its(participantSocketUUID)
+                    .its('isActive')
+                    .should('equal', false);
+            }
+        );
     });
 
     it('can manage an exercise settings', () => {

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -153,8 +153,7 @@ export function initializeParticipantSocket() {
                         (resolve) => {
                             participantSocket.emit(
                                 'joinExercise',
-                                participantKey,
-                                '',
+                                { exerciseKey: participantKey, clientName: '' },
                                 (
                                     response: SocketResponse<JoinExerciseResponseDataInput>
                                 ) => resolve(response)
@@ -204,8 +203,7 @@ export function initializeTrainerSocket() {
                     (resolve) => {
                         trainerSocket.emit(
                             'joinExercise',
-                            trainerKey,
-                            '',
+                            { exerciseKey: trainerKey, clientName: '' },
                             (
                                 response: SocketResponse<JoinExerciseResponseDataInput>
                             ) => resolve(response)

--- a/frontend/src/app/core/application.service.ts
+++ b/frontend/src/app/core/application.service.ts
@@ -10,6 +10,7 @@ import {
 import { selectStateSnapshot } from '../state/get-state-snapshot';
 import { ExerciseService } from './exercise.service';
 import { TimeTravelService } from './time-travel.service';
+import { getReconnectToken } from './reconnect-token';
 
 /**
  * This service encapsulates the logic for switching between the live exercise, timeTravel and an empty state (e.g. on the landing page).
@@ -60,10 +61,13 @@ export class ApplicationService {
      * Rejoin this exercise with the same credentials as the last time
      */
     public async rejoinExercise() {
-        return this.joinExercise(
-            selectStateSnapshot(selectExerciseKey, this.store)!,
-            selectStateSnapshot(selectLastClientName, this.store)!
-        );
+        const exerciseKey = selectStateSnapshot(selectExerciseKey, this.store)!;
+        const clientName = selectStateSnapshot(
+            selectLastClientName,
+            this.store
+        )!;
+        const storedClientId = getReconnectToken(exerciseKey) ?? undefined;
+        return this.joinExercise(exerciseKey, clientName, storedClientId);
     }
 
     public async startTimeTravel(

--- a/frontend/src/app/core/exercise.service.ts
+++ b/frontend/src/app/core/exercise.service.ts
@@ -8,6 +8,7 @@ import type {
     JoinExerciseResponseData,
     ServerToClientEvents,
     SocketResponse,
+    UUID,
 } from 'fuesim-digital-shared';
 import {
     joinExerciseResponseDataSchema,
@@ -33,9 +34,12 @@ import {
     createLeaveExerciseAction,
     createSetExerciseStateAction,
 } from '../state/application/application.actions';
-import { selectExerciseStateMode } from '../state/application/selectors/application.selectors';
 import {
-    selectClients,
+    selectExerciseStateMode,
+    selectExerciseKey,
+} from '../state/application/selectors/application.selectors';
+import {
+    selectActiveClients,
     selectExerciseState,
 } from '../state/application/selectors/exercise.selectors';
 import {
@@ -45,6 +49,11 @@ import {
 } from '../state/application/selectors/shared.selectors';
 import { selectStateSnapshot } from '../state/get-state-snapshot';
 import { websocketOrigin } from './api-origins';
+import {
+    saveReconnectToken,
+    clearReconnectToken,
+    clearExpiredTokens,
+} from './reconnect-token';
 import { MessageService } from './messages/message.service';
 import { OptimisticActionHandler } from './optimistic-action-handler';
 import { openConnectionLostModal } from './connection-lost-modal/open-connection-lost-modal';
@@ -81,6 +90,7 @@ export class ExerciseService {
         signal<JoinExerciseResponseData | null>(null);
 
     constructor() {
+        clearExpiredTokens();
         this.socket.on('performAction', (action: ExerciseAction) => {
             freeze(action, true);
             this.optimisticActionHandler?.performAction(action);
@@ -103,7 +113,8 @@ export class ExerciseService {
      */
     public async joinExercise(
         exerciseKey: ExerciseKey,
-        clientName: string
+        clientName: string,
+        clientId?: UUID
     ): Promise<boolean> {
         this.socket.connect().on('connect_error', (error) => {
             this.messageService.postError({
@@ -115,17 +126,22 @@ export class ExerciseService {
             (resolve) => {
                 this.socket.emit(
                     'joinExercise',
-                    exerciseKey,
-                    clientName,
+                    {
+                        exerciseKey,
+                        clientName: clientId ? undefined : clientName,
+                        clientId,
+                    },
                     resolve
                 );
             }
         );
         if (!joinResponse.success) {
-            this.messageService.postError({
-                title: 'Fehler beim Beitreten der Übung',
-                error: joinResponse.message,
-            });
+            if (!joinResponse.expected) {
+                this.messageService.postError({
+                    title: 'Fehler beim Beitreten der Übung',
+                    error: joinResponse.message,
+                });
+            }
             return false;
         }
         const joinResponsePayload = joinExerciseResponseDataSchema.parse(
@@ -146,14 +162,20 @@ export class ExerciseService {
             });
             return false;
         }
+        // Use the actual client name from state when reconnecting
+        const resolvedClientName = clientId
+            ? (getStateResponse.payload.clients[joinResponsePayload.clientId]
+                  ?.name ?? clientName)
+            : clientName;
         this.store.dispatch(
             createJoinExerciseAction(
                 joinResponsePayload.clientId,
                 getStateResponse.payload,
                 exerciseKey,
-                clientName
+                resolvedClientName
             )
         );
+        saveReconnectToken(exerciseKey, joinResponsePayload.clientId);
         // Only do this after the correct state is in the store
         this.optimisticActionHandler = new OptimisticActionHandler<
             ExerciseAction,
@@ -213,6 +235,8 @@ export class ExerciseService {
      * Use the function in ApplicationService instead
      */
     public leaveExercise() {
+        const exerciseKey = selectStateSnapshot(selectExerciseKey, this.store);
+        if (exerciseKey) clearReconnectToken(exerciseKey);
         this.socket.disconnect();
         this.stopNotifications();
         this.optimisticActionHandler = undefined;
@@ -250,7 +274,7 @@ export class ExerciseService {
             .select(selectCurrentMainRole)
             .pipe(
                 filter((role) => role === 'trainer'),
-                switchMap(() => this.store.select(selectClients)),
+                switchMap(() => this.store.select(selectActiveClients)),
                 pairwise(),
                 takeUntil(this.stopNotifications$)
             )

--- a/frontend/src/app/core/reconnect-token.spec.ts
+++ b/frontend/src/app/core/reconnect-token.spec.ts
@@ -1,0 +1,71 @@
+import {
+    saveReconnectToken,
+    getReconnectToken,
+    clearReconnectToken,
+    clearExpiredTokens,
+} from './reconnect-token';
+
+const exerciseKey = 'test-key-123' as any;
+const clientId = 'client-uuid-abc' as any;
+
+// localStorage mock for node test environment
+function makeLocalStorageMock() {
+    let store: { [key: string]: string } = {};
+    return {
+        getItem: (key: string) => store[key] ?? null,
+        setItem: (key: string, value: string) => {
+            store[key] = value;
+        },
+        removeItem: (key: string) => {
+            delete store[key];
+        },
+        clear: () => {
+            store = {};
+        },
+        get length() {
+            return Object.keys(store).length;
+        },
+        key: (index: number) => Object.keys(store)[index] ?? null,
+    };
+}
+
+const localStorageMock = makeLocalStorageMock();
+Object.defineProperty(globalThis, 'localStorage', {
+    value: localStorageMock,
+    writable: true,
+});
+
+describe('reconnect-token', () => {
+    beforeEach(() => localStorage.clear());
+
+    it('getReconnectToken returns null when nothing stored', () => {
+        expect(getReconnectToken(exerciseKey)).toBeNull();
+    });
+
+    it('saveReconnectToken and getReconnectToken roundtrip', () => {
+        saveReconnectToken(exerciseKey, clientId);
+        expect(getReconnectToken(exerciseKey)).toBe(clientId);
+    });
+
+    it('getReconnectToken returns null after clearReconnectToken', () => {
+        saveReconnectToken(exerciseKey, clientId);
+        clearReconnectToken(exerciseKey);
+        expect(getReconnectToken(exerciseKey)).toBeNull();
+    });
+
+    it('getReconnectToken returns null for expired entry', () => {
+        const entry = { clientId, expiresAt: Date.now() - 1000 };
+        localStorage.setItem(`reconnect:${exerciseKey}`, JSON.stringify(entry));
+        expect(getReconnectToken(exerciseKey)).toBeNull();
+        expect(localStorage.getItem(`reconnect:${exerciseKey}`)).toBeNull();
+    });
+
+    it('clearExpiredTokens removes expired entries', () => {
+        const expired = { clientId: 'x', expiresAt: Date.now() - 1000 };
+        localStorage.setItem('reconnect:expired-key', JSON.stringify(expired));
+        saveReconnectToken(exerciseKey, clientId); // valid
+        clearExpiredTokens();
+        expect(localStorage.getItem('reconnect:expired-key')).toBeNull();
+        expect(getReconnectToken(exerciseKey)).toBe(clientId);
+    });
+});

--- a/frontend/src/app/core/reconnect-token.ts
+++ b/frontend/src/app/core/reconnect-token.ts
@@ -1,0 +1,60 @@
+import type { ExerciseKey, UUID } from 'fuesim-digital-shared';
+
+const expiryMs = 60 * 60 * 1000; // 1 hour
+const keyPrefix = 'reconnect:';
+
+interface ReconnectEntry {
+    clientId: UUID;
+    expiresAt: number;
+}
+
+export function saveReconnectToken(
+    exerciseKey: ExerciseKey,
+    clientId: UUID
+): void {
+    const entry: ReconnectEntry = {
+        clientId,
+        expiresAt: Date.now() + expiryMs,
+    };
+    localStorage.setItem(`${keyPrefix}${exerciseKey}`, JSON.stringify(entry));
+}
+
+export function getReconnectToken(exerciseKey: ExerciseKey): UUID | null {
+    const raw = localStorage.getItem(`${keyPrefix}${exerciseKey}`);
+    if (!raw) return null;
+    let entry: ReconnectEntry;
+    try {
+        entry = JSON.parse(raw) as ReconnectEntry;
+    } catch {
+        clearReconnectToken(exerciseKey);
+        return null;
+    }
+    if (Date.now() > entry.expiresAt) {
+        clearReconnectToken(exerciseKey);
+        return null;
+    }
+    return entry.clientId;
+}
+
+export function clearReconnectToken(exerciseKey: ExerciseKey): void {
+    localStorage.removeItem(`${keyPrefix}${exerciseKey}`);
+}
+
+export function clearExpiredTokens(): void {
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key?.startsWith(keyPrefix)) {
+            const raw = localStorage.getItem(key);
+            if (raw) {
+                try {
+                    const entry = JSON.parse(raw) as ReconnectEntry;
+                    if (Date.now() > entry.expiresAt) keysToRemove.push(key);
+                } catch {
+                    keysToRemove.push(key);
+                }
+            }
+        }
+    }
+    keysToRemove.forEach((key) => localStorage.removeItem(key));
+}

--- a/frontend/src/app/pages/exercises/exercise/shared/client-overview-table/client-overview-table.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/client-overview-table/client-overview-table.component.html
@@ -5,13 +5,17 @@
             <th scope="col">Modus</th>
             <th scope="col">Kartenansicht</th>
             <th scope="col">In der Übung</th>
+            <th scope="col"></th>
         </tr>
     </thead>
     <tbody>
         @for (client of clients$ | async | values; track client.id) {
-            <tr>
+            <tr [class.text-muted]="client.isInactive">
                 <td class="align-middle">
                     {{ client.name }}
+                    @if (client.isInactive) {
+                        <span class="badge bg-secondary ms-1">Getrennt</span>
+                    }
                 </td>
                 @if (client.role.mainRole === 'trainer') {
                     <td class="align-middle">
@@ -27,6 +31,7 @@
                         <button
                             class="btn btn-outline-primary btn-sm"
                             ngbDropdownToggle
+                            [disabled]="client.isInactive"
                             data-cy="clientPopupSetRoleButton"
                         >
                             {{
@@ -70,8 +75,9 @@
                 <td ngbDropdown>
                     <button
                         [class.d-none]="
-                            client.role.specificRole !== 'mapOperator' &&
-                            client.role.mainRole !== 'trainer'
+                            client.isInactive ||
+                            (client.role.specificRole !== 'mapOperator' &&
+                                client.role.mainRole !== 'trainer')
                         "
                         class="btn btn-outline-primary btn-sm"
                         ngbDropdownToggle
@@ -112,15 +118,30 @@
                     </div>
                 </td>
                 <td class="align-middle">
-                    <div class="form-switch">
-                        <input
-                            [ngModel]="!client.isInWaitingRoom"
-                            (ngModelChange)="setWaitingRoom(client.id, !$event)"
-                            class="form-check-input"
-                            type="checkbox"
-                            data-cy="clientPopupSetWaitingRoomCheckbox"
-                        />
-                    </div>
+                    @if (!client.isInactive) {
+                        <div class="form-switch">
+                            <input
+                                [ngModel]="!client.isInWaitingRoom"
+                                (ngModelChange)="
+                                    setWaitingRoom(client.id, !$event)
+                                "
+                                class="form-check-input"
+                                type="checkbox"
+                                data-cy="clientPopupSetWaitingRoomCheckbox"
+                            />
+                        </div>
+                    }
+                </td>
+                <td class="align-middle">
+                    @if (client.isInactive) {
+                        <button
+                            class="btn btn-outline-danger btn-sm"
+                            (click)="removeClient(client.id)"
+                            title="Teilnehmer entfernen"
+                        >
+                            <i class="bi bi-trash-fill"></i>
+                        </button>
+                    }
                 </td>
             </tr>
         }

--- a/frontend/src/app/pages/exercises/exercise/shared/client-overview-table/client-overview-table.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/client-overview-table/client-overview-table.component.html
@@ -10,10 +10,10 @@
     </thead>
     <tbody>
         @for (client of clients$ | async | values; track client.id) {
-            <tr [class.text-muted]="client.isInactive">
+            <tr [class.text-muted]="!client.isActive">
                 <td class="align-middle">
                     {{ client.name }}
-                    @if (client.isInactive) {
+                    @if (!client.isActive) {
                         <span class="badge bg-secondary ms-1">Getrennt</span>
                     }
                 </td>
@@ -31,7 +31,7 @@
                         <button
                             class="btn btn-outline-primary btn-sm"
                             ngbDropdownToggle
-                            [disabled]="client.isInactive"
+                            [disabled]="!client.isActive"
                             data-cy="clientPopupSetRoleButton"
                         >
                             {{
@@ -75,7 +75,7 @@
                 <td ngbDropdown>
                     <button
                         [class.d-none]="
-                            client.isInactive ||
+                            client.isActive ||
                             (client.role.specificRole !== 'mapOperator' &&
                                 client.role.mainRole !== 'trainer')
                         "
@@ -118,7 +118,7 @@
                     </div>
                 </td>
                 <td class="align-middle">
-                    @if (!client.isInactive) {
+                    @if (client.isActive) {
                         <div class="form-switch">
                             <input
                                 [ngModel]="!client.isInWaitingRoom"
@@ -133,7 +133,7 @@
                     }
                 </td>
                 <td class="align-middle">
-                    @if (client.isInactive) {
+                    @if (!client.isActive) {
                         <button
                             class="btn btn-outline-danger btn-sm"
                             (click)="removeClient(client.id)"

--- a/frontend/src/app/pages/exercises/exercise/shared/client-overview-table/client-overview-table.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/client-overview-table/client-overview-table.component.html
@@ -75,7 +75,7 @@
                 <td ngbDropdown>
                     <button
                         [class.d-none]="
-                            client.isActive ||
+                            !client.isActive ||
                             (client.role.specificRole !== 'mapOperator' &&
                                 client.role.mainRole !== 'trainer')
                         "
@@ -137,7 +137,7 @@
                         <button
                             class="btn btn-outline-danger btn-sm"
                             (click)="removeClient(client.id)"
-                            title="Teilnehmer entfernen"
+                            ngbTooltip="Entfernen"
                         >
                             <i class="bi bi-trash-fill"></i>
                         </button>

--- a/frontend/src/app/pages/exercises/exercise/shared/client-overview-table/client-overview-table.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/client-overview-table/client-overview-table.component.ts
@@ -72,4 +72,11 @@ export class ClientOverviewTableComponent {
             shouldBeInWaitingRoom,
         });
     }
+
+    public removeClient(clientId: UUID): void {
+        this.exerciseService.proposeAction({
+            type: '[Client] Remove client',
+            clientId,
+        });
+    }
 }

--- a/frontend/src/app/pages/exercises/exercise/shared/client-overview-table/client-overview-table.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/client-overview-table/client-overview-table.component.ts
@@ -8,6 +8,7 @@ import {
     NgbDropdownMenu,
     NgbDropdownButtonItem,
     NgbDropdownItem,
+    NgbTooltip,
 } from '@ng-bootstrap/ng-bootstrap';
 import { FormsModule } from '@angular/forms';
 import { AsyncPipe } from '@angular/common';
@@ -34,6 +35,7 @@ import { ValuesPipe } from '../../../../../shared/pipes/values.pipe';
         AsyncPipe,
         SpecificRoleDisplayNamePipe,
         ValuesPipe,
+        NgbTooltip,
     ],
 })
 export class ClientOverviewTableComponent {

--- a/frontend/src/app/pages/exercises/guards/join-exercise.guard.ts
+++ b/frontend/src/app/pages/exercises/guards/join-exercise.guard.ts
@@ -12,6 +12,10 @@ import { ApiService } from '../../../core/api.service';
 import type { AppState } from '../../../state/app.state';
 import { selectExerciseStateMode } from '../../../state/application/selectors/application.selectors';
 import { selectStateSnapshot } from '../../../state/get-state-snapshot';
+import {
+    getReconnectToken,
+    clearReconnectToken,
+} from '../../../core/reconnect-token';
 
 @Injectable({
     providedIn: 'root',
@@ -37,6 +41,29 @@ export class JoinExerciseGuard {
             const exerciseExists = await this.apiService.exerciseExists(
                 route.params['exerciseId']
             );
+
+            // Attempt auto-reconnect if a stored token exists
+            if (exerciseExists.exists) {
+                const storedClientId = getReconnectToken(
+                    route.params['exerciseId']
+                );
+                if (storedClientId) {
+                    try {
+                        const reconnected =
+                            await this.applicationService.joinExercise(
+                                route.params['exerciseId'],
+                                '',
+                                storedClientId
+                            );
+                        if (reconnected) return true;
+                        // Token was stale/invalid — clear it and fall through to normal join
+                        clearReconnectToken(route.params['exerciseId']);
+                    } catch (error) {
+                        clearReconnectToken(route.params['exerciseId']);
+                        throw error; // re-throw so outer catch still navigates to '/'
+                    }
+                }
+            }
 
             let successfullyJoined = false;
             if (exerciseExists.autojoin) {

--- a/frontend/src/app/state/application/selectors/exercise.selectors.ts
+++ b/frontend/src/app/state/application/selectors/exercise.selectors.ts
@@ -54,6 +54,13 @@ export const selectTransferPoints = selectPropertyFactory('transferPoints');
 export const selectHospitals = selectPropertyFactory('hospitals');
 export const selectHospitalPatients = selectPropertyFactory('hospitalPatients');
 export const selectClients = selectPropertyFactory('clients');
+export const selectActiveClients = createSelector(
+    selectClients,
+    (clients) =>
+        Object.fromEntries(
+            Object.entries(clients).filter(([, client]) => !client.isInactive)
+        ) as typeof clients
+);
 export const selectRadiograms = selectPropertyFactory('radiograms');
 export const selectRestrictedZones = selectPropertyFactory('restrictedZones');
 export const selectOperationalSections = selectPropertyFactory(

--- a/frontend/src/app/state/application/selectors/exercise.selectors.ts
+++ b/frontend/src/app/state/application/selectors/exercise.selectors.ts
@@ -58,7 +58,7 @@ export const selectActiveClients = createSelector(
     selectClients,
     (clients) =>
         Object.fromEntries(
-            Object.entries(clients).filter(([, client]) => !client.isInactive)
+            Object.entries(clients).filter(([, client]) => client.isActive)
         ) as typeof clients
 );
 export const selectRadiograms = selectPropertyFactory('radiograms');

--- a/shared/src/models/client.spec.ts
+++ b/shared/src/models/client.spec.ts
@@ -1,0 +1,29 @@
+import { newClient, clientSchema } from './client.js';
+import { newClientRole } from './client-role.js';
+
+describe('Client model', () => {
+    it('newClient sets isInactive to false', () => {
+        const client = newClient(
+            'Alice',
+            newClientRole('participant', 'mapOperator'),
+            false
+        );
+        expect(client.isInactive).toBe(false);
+    });
+
+    it('clientSchema accepts isInactive field', () => {
+        const result = clientSchema.safeParse({
+            id: '00000000-0000-4000-a000-000000000001',
+            type: 'client',
+            name: 'Alice',
+            role: {
+                type: 'clientRole',
+                mainRole: 'participant',
+                specificRole: 'mapOperator',
+            },
+            isInWaitingRoom: false,
+            isInactive: true,
+        });
+        expect(result.success).toBe(true);
+    });
+});

--- a/shared/src/models/client.spec.ts
+++ b/shared/src/models/client.spec.ts
@@ -2,16 +2,16 @@ import { newClient, clientSchema } from './client.js';
 import { newClientRole } from './client-role.js';
 
 describe('Client model', () => {
-    it('newClient sets isInactive to false', () => {
+    it('newClient sets isActive to true', () => {
         const client = newClient(
             'Alice',
             newClientRole('participant', 'mapOperator'),
             false
         );
-        expect(client.isInactive).toBe(false);
+        expect(client.isActive).toBe(true);
     });
 
-    it('clientSchema accepts isInactive field', () => {
+    it('clientSchema accepts isActive field', () => {
         const result = clientSchema.safeParse({
             id: '00000000-0000-4000-a000-000000000001',
             type: 'client',
@@ -22,7 +22,7 @@ describe('Client model', () => {
                 specificRole: 'mapOperator',
             },
             isInWaitingRoom: false,
-            isInactive: true,
+            isActive: true,
         });
         expect(result.success).toBe(true);
     });

--- a/shared/src/models/client.ts
+++ b/shared/src/models/client.ts
@@ -10,6 +10,7 @@ export const clientSchema = z.strictObject({
     role: clientRoleSchema,
     viewRestrictedToViewportId: uuidSchema.optional(),
     isInWaitingRoom: z.boolean(),
+    isInactive: z.boolean(),
 });
 export type Client = z.infer<typeof clientSchema>;
 
@@ -25,5 +26,6 @@ export function newClient(
         role,
         viewRestrictedToViewportId: undefined,
         isInWaitingRoom,
+        isInactive: false,
     };
 }

--- a/shared/src/models/client.ts
+++ b/shared/src/models/client.ts
@@ -10,7 +10,7 @@ export const clientSchema = z.strictObject({
     role: clientRoleSchema,
     viewRestrictedToViewportId: uuidSchema.optional(),
     isInWaitingRoom: z.boolean(),
-    isInactive: z.boolean(),
+    isActive: z.boolean(),
 });
 export type Client = z.infer<typeof clientSchema>;
 
@@ -26,6 +26,6 @@ export function newClient(
         role,
         viewRestrictedToViewportId: undefined,
         isInWaitingRoom,
-        isInactive: false,
+        isActive: false,
     };
 }

--- a/shared/src/models/client.ts
+++ b/shared/src/models/client.ts
@@ -26,6 +26,6 @@ export function newClient(
         role,
         viewRestrictedToViewportId: undefined,
         isInWaitingRoom,
-        isActive: false,
+        isActive: true,
     };
 }

--- a/shared/src/socket-api/socket-types.ts
+++ b/shared/src/socket-api/socket-types.ts
@@ -16,8 +16,13 @@ export interface ServerToClientEvents {
 // The last argument is always expected to be the callback function. (To be able to use it in advanced typings)
 export interface ClientToServerEvents {
     joinExercise: (
-        exerciseKey: ExerciseKey,
-        clientName: string,
+        payload: {
+            exerciseKey: ExerciseKey;
+            /** Present on fresh join; absent on reconnect. */
+            clientName?: string;
+            /** Present on reconnect attempt; absent on fresh join. */
+            clientId?: UUID;
+        },
         callback: (
             response: SocketResponse<JoinExerciseResponseDataInput>
         ) => void

--- a/shared/src/state-migrations/53-add-is-active-to-client.ts
+++ b/shared/src/state-migrations/53-add-is-active-to-client.ts
@@ -1,15 +1,15 @@
 import type { UUID } from '../utils/uuid.js';
 import type { Migration } from './migration-functions.js';
 
-export const addIsInactiveToClient53: Migration = {
+export const addIsActiveToClient53: Migration = {
     action: (_, action) => {
         const typedAction = action as { type: string };
         switch (typedAction.type) {
             case '[Client] Add client': {
                 const typedClientAction = action as {
-                    client: { isInactive?: boolean };
+                    client: { isActive?: boolean };
                 };
-                typedClientAction.client.isInactive ??= false;
+                typedClientAction.client.isActive ??= true;
                 break;
             }
             default:
@@ -20,12 +20,12 @@ export const addIsInactiveToClient53: Migration = {
     state: (state) => {
         const typedState = state as {
             clients: {
-                [Key in UUID]: { isInactive?: boolean };
+                [Key in UUID]: { isActive?: boolean };
             };
         };
 
         for (const client of Object.values(typedState.clients)) {
-            client.isInactive ??= false;
+            client.isActive ??= true;
         }
     },
 };

--- a/shared/src/state-migrations/53-add-is-inactive-to-client.ts
+++ b/shared/src/state-migrations/53-add-is-inactive-to-client.ts
@@ -1,0 +1,31 @@
+import type { UUID } from '../utils/uuid.js';
+import type { Migration } from './migration-functions.js';
+
+export const addIsInactiveToClient53: Migration = {
+    action: (_, action) => {
+        const typedAction = action as { type: string };
+        switch (typedAction.type) {
+            case '[Client] Add client': {
+                const typedClientAction = action as {
+                    client: { isInactive?: boolean };
+                };
+                typedClientAction.client.isInactive ??= false;
+                break;
+            }
+            default:
+                break;
+        }
+        return true;
+    },
+    state: (state) => {
+        const typedState = state as {
+            clients: {
+                [Key in UUID]: { isInactive?: boolean };
+            };
+        };
+
+        for (const client of Object.values(typedState.clients)) {
+            client.isInactive ??= false;
+        }
+    },
+};

--- a/shared/src/state-migrations/migration-functions.ts
+++ b/shared/src/state-migrations/migration-functions.ts
@@ -50,6 +50,7 @@ import { addAutojoinViewport48 } from './48-autojoin-viewport.js';
 import { addScoutables50 } from './50-add-scoutables.js';
 import { addUUIDtoAddEocLogEntryAction51 } from './51-add-uuid-to-add-eoc-log-action.js';
 import { fixInfinity52 } from './52-fix-infinity.js';
+import { addIsInactiveToClient53 } from './53-add-is-inactive-to-client.js';
 
 /**
  * Migrate a single action
@@ -128,4 +129,5 @@ export const migrations: {
     50: addScoutables50,
     51: addUUIDtoAddEocLogEntryAction51,
     52: fixInfinity52,
+    53: addIsInactiveToClient53,
 };

--- a/shared/src/state-migrations/migration-functions.ts
+++ b/shared/src/state-migrations/migration-functions.ts
@@ -50,7 +50,7 @@ import { addAutojoinViewport48 } from './48-autojoin-viewport.js';
 import { addScoutables50 } from './50-add-scoutables.js';
 import { addUUIDtoAddEocLogEntryAction51 } from './51-add-uuid-to-add-eoc-log-action.js';
 import { fixInfinity52 } from './52-fix-infinity.js';
-import { addIsInactiveToClient53 } from './53-add-is-inactive-to-client.js';
+import { addIsActiveToClient53 } from './53-add-is-active-to-client.js';
 
 /**
  * Migrate a single action
@@ -129,5 +129,5 @@ export const migrations: {
     50: addScoutables50,
     51: addUUIDtoAddEocLogEntryAction51,
     52: fixInfinity52,
-    53: addIsInactiveToClient53,
+    53: addIsActiveToClient53,
 };

--- a/shared/src/state.ts
+++ b/shared/src/state.ts
@@ -243,5 +243,5 @@ export class ExerciseState {
      *
      * This number MUST be increased every time a change to any object (that is part of the state or the state itself) is made in a way that there may be states valid before that are no longer valid.
      */
-    static readonly currentStateVersion = 52;
+    static readonly currentStateVersion = 53;
 }

--- a/shared/src/store/action-reducers/client.spec.ts
+++ b/shared/src/store/action-reducers/client.spec.ts
@@ -24,10 +24,10 @@ describe('ClientActionReducers', () => {
     });
 
     describe('SetClientInactiveAction', () => {
-        it('sets isInactive to true and keeps client in state', () => {
+        it('sets isActive to false and keeps client in state', () => {
             // Verify client is initially active
             expect(state.clients[clientId]).toBeDefined();
-            expect(state.clients[clientId]!.isInactive).toBe(false);
+            expect(state.clients[clientId]!.isActive).toBe(true);
 
             // Apply the action
             state = reduceExerciseState(state, {
@@ -35,29 +35,29 @@ describe('ClientActionReducers', () => {
                 clientId,
             });
 
-            // Verify client still exists and isInactive is now true
+            // Verify client still exists and isActive is now false
             expect(state.clients[clientId]).toBeDefined();
-            expect(state.clients[clientId]!.isInactive).toBe(true);
+            expect(state.clients[clientId]!.isActive).toBe(false);
         });
     });
 
-    describe('ReactivateClientAction', () => {
-        it('sets isInactive to false', () => {
+    describe('SetClientActiveAction', () => {
+        it('sets isActive to true', () => {
             // First set the client as inactive
             state = reduceExerciseState(state, {
                 type: '[Client] Set client inactive',
                 clientId,
             });
-            expect(state.clients[clientId]!.isInactive).toBe(true);
+            expect(state.clients[clientId]!.isActive).toBe(false);
 
-            // Apply the reactivate action
+            // Apply the action
             state = reduceExerciseState(state, {
-                type: '[Client] Reactivate client',
+                type: '[Client] Set client active',
                 clientId,
             });
 
             // Verify client is now active
-            expect(state.clients[clientId]!.isInactive).toBe(false);
+            expect(state.clients[clientId]!.isActive).toBe(true);
         });
     });
 });

--- a/shared/src/store/action-reducers/client.spec.ts
+++ b/shared/src/store/action-reducers/client.spec.ts
@@ -1,0 +1,63 @@
+import { ExerciseState } from '../../state.js';
+import type { ParticipantKey } from '../../exercise-keys.js';
+import { type UUID } from '../../utils/uuid.js';
+import { reduceExerciseState } from '../reduce-exercise-state.js';
+import { newClient } from '../../models/client.js';
+import { newClientRole } from '../../models/client-role.js';
+
+describe('ClientActionReducers', () => {
+    let state: ExerciseState;
+    let clientId: UUID;
+
+    beforeEach(() => {
+        state = ExerciseState.create('123456' as ParticipantKey);
+        // Add a client to the state
+        const client = newClient(
+            'Test Client',
+            newClientRole('participant', 'mapOperator')
+        );
+        clientId = client.id;
+        state = reduceExerciseState(state, {
+            type: '[Client] Add client',
+            client,
+        });
+    });
+
+    describe('SetClientInactiveAction', () => {
+        it('sets isInactive to true and keeps client in state', () => {
+            // Verify client is initially active
+            expect(state.clients[clientId]).toBeDefined();
+            expect(state.clients[clientId]!.isInactive).toBe(false);
+
+            // Apply the action
+            state = reduceExerciseState(state, {
+                type: '[Client] Set client inactive',
+                clientId,
+            });
+
+            // Verify client still exists and isInactive is now true
+            expect(state.clients[clientId]).toBeDefined();
+            expect(state.clients[clientId]!.isInactive).toBe(true);
+        });
+    });
+
+    describe('ReactivateClientAction', () => {
+        it('sets isInactive to false', () => {
+            // First set the client as inactive
+            state = reduceExerciseState(state, {
+                type: '[Client] Set client inactive',
+                clientId,
+            });
+            expect(state.clients[clientId]!.isInactive).toBe(true);
+
+            // Apply the reactivate action
+            state = reduceExerciseState(state, {
+                type: '[Client] Reactivate client',
+                clientId,
+            });
+
+            // Verify client is now active
+            expect(state.clients[clientId]!.isInactive).toBe(false);
+        });
+    });
+});

--- a/shared/src/store/action-reducers/client.ts
+++ b/shared/src/store/action-reducers/client.ts
@@ -61,9 +61,9 @@ export class SetClientInactiveAction implements Action {
     public readonly clientId!: UUID;
 }
 
-export class ReactivateClientAction implements Action {
-    @IsValue('[Client] Reactivate client' as const)
-    public readonly type = '[Client] Reactivate client';
+export class SetClientActiveAction implements Action {
+    @IsValue('[Client] Set client active' as const)
+    public readonly type = '[Client] Set client active';
     @IsUUID(4, uuidValidationOptions)
     public readonly clientId!: UUID;
 }
@@ -145,17 +145,17 @@ export namespace ClientActionReducers {
         action: SetClientInactiveAction,
         reducer: (draftState, { clientId }) => {
             const client = getElement(draftState, 'client', clientId);
-            client.isInactive = true;
+            client.isActive = false;
             return draftState;
         },
         rights: 'server',
     };
 
-    export const reactivateClient: ActionReducer<ReactivateClientAction> = {
-        action: ReactivateClientAction,
+    export const setClientActive: ActionReducer<SetClientActiveAction> = {
+        action: SetClientActiveAction,
         reducer: (draftState, { clientId }) => {
             const client = getElement(draftState, 'client', clientId);
-            client.isInactive = false;
+            client.isActive = true;
             return draftState;
         },
         rights: 'server',

--- a/shared/src/store/action-reducers/client.ts
+++ b/shared/src/store/action-reducers/client.ts
@@ -54,6 +54,20 @@ export class ChangeSpecificClientRoleAction implements Action {
     public readonly newRole!: SpecificRole;
 }
 
+export class SetClientInactiveAction implements Action {
+    @IsValue('[Client] Set client inactive' as const)
+    public readonly type = '[Client] Set client inactive';
+    @IsUUID(4, uuidValidationOptions)
+    public readonly clientId!: UUID;
+}
+
+export class ReactivateClientAction implements Action {
+    @IsValue('[Client] Reactivate client' as const)
+    public readonly type = '[Client] Reactivate client';
+    @IsUUID(4, uuidValidationOptions)
+    public readonly clientId!: UUID;
+}
+
 export namespace ClientActionReducers {
     export const addClient: ActionReducer<AddClientAction> = {
         action: AddClientAction,
@@ -87,7 +101,7 @@ export namespace ClientActionReducers {
             delete draftState.clients[clientId];
             return draftState;
         },
-        rights: 'server',
+        rights: 'trainer',
     };
 
     export const restrictViewToViewport: ActionReducer<RestrictViewToViewportAction> =
@@ -126,4 +140,24 @@ export namespace ClientActionReducers {
             },
             rights: 'trainer',
         };
+
+    export const setClientInactive: ActionReducer<SetClientInactiveAction> = {
+        action: SetClientInactiveAction,
+        reducer: (draftState, { clientId }) => {
+            const client = getElement(draftState, 'client', clientId);
+            client.isInactive = true;
+            return draftState;
+        },
+        rights: 'server',
+    };
+
+    export const reactivateClient: ActionReducer<ReactivateClientAction> = {
+        action: ReactivateClientAction,
+        reducer: (draftState, { clientId }) => {
+            const client = getElement(draftState, 'client', clientId);
+            client.isInactive = false;
+            return draftState;
+        },
+        rights: 'server',
+    };
 }


### PR DESCRIPTION
### Summary

Closes #1471 by adding `isActive` property to clients and, instead of removing them, setting clients inactive on disconnect. Through localStorage (browser-scoped, not tab-scoped to also enable this when accidentally closing a tab), the `clientId` is saved to allow the client to rejoin. Trainers can manually remove inactive clients if they are actually not used anymore.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
