### PR TITLE
Fix Migration of old exercises below v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 - Creating a parallel exercise with many (>10) exercise instances no longer slows down the server significantly.
 - Massively reduce the server start up time with many exercises.
+- Old exercise exports don't fail the validation anymore
 
 ## [0.12.1] - 2026-05-21
 

--- a/shared/src/state-migrations/17-add-type-property.ts
+++ b/shared/src/state-migrations/17-add-type-property.ts
@@ -192,7 +192,12 @@ export const addTypeProperty17: Migration = {
             };
             patientCategories: {
                 type: 'patientCategory';
-                patientTemplates: { type: 'patientTemplate' }[];
+                patientTemplates: {
+                    type: 'patientTemplate';
+                    healthStates: {
+                        [key: UUID]: { type: 'patientHealthState' };
+                    };
+                }[];
             }[];
             patients: {
                 [key: UUID]: {
@@ -280,6 +285,11 @@ export const addTypeProperty17: Migration = {
                 patientCategory.type = 'patientCategory';
                 patientCategory.patientTemplates.forEach((patientTemplate) => {
                     patientTemplate.type = 'patientTemplate';
+                    Object.values(patientTemplate.healthStates).forEach(
+                        (healthState) => {
+                            healthState.type = 'patientHealthState';
+                        }
+                    );
                 });
             }
         );

--- a/shared/src/state-migrations/4-remove-set-participant-id-action.ts
+++ b/shared/src/state-migrations/4-remove-set-participant-id-action.ts
@@ -1,8 +1,27 @@
-import type { Action } from '../store/action-reducer.js';
 import type { Migration } from './migration-functions.js';
 
 export const removeSetParticipantIdAction4: Migration = {
-    action: (_intermediaryState, action) =>
-        (action as Action).type !== '[Exercise] Set Participant Id',
-    state: null,
+    // INFO: This action migration used to remove the action
+    // "[Exercise] Set Participant Id" which set the participantId in the state.
+    //
+    // HOWEVER, if we start with initialState.participantId = null (stateVersion <4),
+    // the removal of this action will cause the participantId to remain null.
+    // This causes a Validation Error.
+    action: null,
+    state: (state) => {
+        const typedState = state as {
+            participantId: string;
+        };
+
+        // on old exercises, the participantid may not yet be set.
+        //
+        // we assert a non-null participantId in initialState in newer versions
+        //
+        // since the initialState gets overwritten anyway, this should not cause any problems
+        if (typedState.participantId.length === 0) {
+            typedState.participantId = '000000';
+        }
+
+        return typedState;
+    },
 };

--- a/shared/src/store/action-reducers/exercise.ts
+++ b/shared/src/store/action-reducers/exercise.ts
@@ -6,6 +6,7 @@ import {
     IsInt,
     IsPositive,
     IsUUID,
+    IsString,
 } from 'class-validator';
 import { WritableDraft } from 'immer';
 import { changePosition } from '../../models/utils/position/position-helpers-mutable.js';
@@ -31,6 +32,7 @@ import {
 import { type UUID, uuid, uuidValidationOptions } from '../../utils/uuid.js';
 import { newTransferPositionFor } from '../../models/utils/position/transfer-position.js';
 import type { ResourceDescription } from '../../models/utils/resource-description.js';
+import { ParticipantKey } from '../../exercise-keys.js';
 import { PatientUpdate } from './utils/patient-updates.js';
 import {
     logPatientVisibleStatusChanged,
@@ -95,6 +97,21 @@ export class ImportTemplatesAction implements Action {
     @ValidateNested()
     @Type(() => PartialExport)
     public readonly partialExport!: PartialExport;
+}
+
+/**
+ * WARNING: THIS IS ABSOLUTELY LEGACY
+ * --- DO NOT USE ---
+ * This is used only for legacy purposes for exercises created with an empty intitialState participantId (stateVersion <4)
+ * We cannot migrate them properly without this action
+ *
+ * @deprecated
+ */
+export class SetParticipantIdAction implements Action {
+    @IsString()
+    public readonly type = `[Exercise] Set Participant Id`;
+    @IsString()
+    public readonly participantId!: string;
 }
 
 export namespace ExerciseActionReducers {
@@ -236,6 +253,22 @@ export namespace ExerciseActionReducers {
             return draftState;
         },
         rights: 'trainer',
+    };
+    /**
+     * WARNING: THIS IS ABSOLUTELY LEGACY
+     * --- DO NOT USE ---
+     * This is used only for legacy purposes for exercises created with an empty intitialState participantId (stateVersion <4)
+     * We cannot migrate them properly without this action
+     *
+     * @deprecated
+     */
+    export const setParticipantId: ActionReducer<SetParticipantIdAction> = {
+        action: SetParticipantIdAction,
+        reducer: (draftState, { participantId }) => {
+            draftState.participantKey = participantId as ParticipantKey;
+            return draftState;
+        },
+        rights: 'server',
     };
 }
 


### PR DESCRIPTION
### Summary

This PR fixes the migration of old exercises below state versions 4.

A previously allowed empty string for `initialState.participantId` plus a removed action for setting the participantid caused the migration to fail.

closes #1380 

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [X] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [ ] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [X] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [X] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
