### PR TITLE
Fix transactions for Exercise from Template in Exercise Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+### Fixed
+
+- The server no longer freezes when creating a new exercise from a template with `DFM_USE_DB=false`
+
 ## [0.13.1] - 2026-06-01
 
 ### Fixed

--- a/backend/src/database/services/exercise-manager-service.ts
+++ b/backend/src/database/services/exercise-manager-service.ts
@@ -124,9 +124,7 @@ export class ExerciseManagerService {
             const accessKeyRepository = new AccessKeyRepository(tx);
 
             const exerciseTemplate =
-                await this.exerciseRepository.getExerciseTemplateById(
-                    templateId
-                );
+                await tx.getExerciseTemplateById(templateId);
             if (!exerciseTemplate) {
                 throw new NotFoundError();
             }
@@ -155,17 +153,15 @@ export class ExerciseManagerService {
                 baseTemplateId: exerciseTemplate.id,
             } satisfies ExerciseInsert;
 
-            const exerciseEntry =
-                await this.exerciseRepository.createExercise(exerciseInsert);
+            const exerciseEntry = await tx.createExercise(exerciseInsert);
             if (!exerciseEntry) throw new ApiError();
 
             const activeExercise = new ActiveExercise(exerciseEntry, []);
             this.exerciseService.loadExercise(activeExercise);
 
-            await this.exerciseRepository.updateExerciseTemplate(
-                exerciseTemplate.id,
-                { lastExerciseCreatedAt: new Date() }
-            );
+            await tx.updateExerciseTemplate(exerciseTemplate.id, {
+                lastExerciseCreatedAt: new Date(),
+            });
             return activeExercise;
         });
     }


### PR DESCRIPTION
### Summary

This fixes the Drizzle transaction used in in ExerciseManager for creating a new Exercise based on a Template.
Mainly this fixes the bug, where PgLite freezes up, when a normal drizzle call to a non-transaction-drizzle-reference is made inside a drizzle transaction (closes #1490 ).

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [X] If this PR adds or changes features or fixes bugs, this has been added to the changelog
- [X] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [X] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [X] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
