### PR TITLE
Allow Touch DragDrop from Trainer Editor Sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
+### Added
+
+- Trainers can now drag elements from the sidebar onto the map on touch devices as well.
+
 ### Changed
 
 - Trainers now have access to the 'Einsatzübersicht' in Exercises and Exercise Templates.

--- a/docs/src/2_exercises/2_user_interfaces.md
+++ b/docs/src/2_exercises/2_user_interfaces.md
@@ -98,9 +98,6 @@ Im rechten Bereich der unteren Menüleiste befindet sich ein roter Button, mit d
 
 Übungsleitende sehen am rechten Rand der Karte den sogenannten Editor. Dieser besteht aus einem Auswahlmenü mit Vorlagen für alle in der Übung platzierbaren [Übungselemente](3_exercise_elements.md). Wenn diese angeklickt und auf die Übungskarte "gezogen" werden, wird basierend auf der Vorlage ein entsprechendes Übungselement entstellt.
 
-> [!IMPORTANT]
-> Der Editor kann aus technischen Gründen nicht auf Touch-Geräten benutzt werden. Übungsleitende müssen eine Maus verwenden, um Übungselemente aus dem Editor auf der Karte zu platzieren. Die Interaktion mit allen anderen Teilen der Übung ist für Übungsleitende allerdings auch auf Touch-Geräten möglich.
-
 #### Platzierbare Übungselemente
 
 Der Editor ist in folgende Kategorien unterteilt:

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -56,7 +56,7 @@ export function dragToMap(
 ) {
     const mapSelector = '[data-cy=openLayersContainer]';
 
-    cy.get(elementSelector).first().trigger('mousedown');
+    cy.get(elementSelector).first().trigger('pointerdown');
 
     return (
         cy
@@ -65,7 +65,7 @@ export function dragToMap(
              * We have to force the click here, as the img
              * of the element being dragged is in front of the map
              **/
-            .trigger('mousemove', { force: true, ...offset })
+            .trigger('pointermove', { force: true, ...offset })
             .click({ force: true })
     );
 }

--- a/frontend/src/app/pages/exercises/exercise/shared/core/drag-element.service.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/core/drag-element.service.ts
@@ -78,7 +78,17 @@ export class DragElementService {
      * @param event the mouse event
      * @param transferTemplate the template to be added
      */
-    public onMouseDown(event: MouseEvent, transferTemplate: TransferTemplate) {
+    public onMouseDown(
+        event: PointerEvent,
+        transferTemplate: TransferTemplate
+    ) {
+        if (this.dragElement) {
+            console.warn(
+                'A drag is already in progress, ignoring new drag start',
+                this
+            );
+            return;
+        }
         this.transferringTemplate = transferTemplate;
         // Create the drag image
         const imageProperties = transferTemplate.template.image;
@@ -105,20 +115,21 @@ export class DragElementService {
         // The dragging logic
         event.preventDefault();
         document.body.style.cursor = 'move';
-        document.addEventListener('mousemove', this.onMouseMove);
-        document.addEventListener('mouseup', this.onMouseUp);
+        document.addEventListener('pointermove', this.onMouseMove);
+        document.addEventListener('pointerup', this.onMouseUp);
     }
 
-    private readonly onMouseMove = (event: MouseEvent) => {
+    private readonly onMouseMove = (event: PointerEvent) => {
         event.preventDefault();
         this.updateDragElementPosition(event);
     };
 
-    private updateDragElementPosition(event: MouseEvent) {
+    private updateDragElementPosition(event: PointerEvent) {
         if (!this.dragElement || !this.imageDimensions) {
             console.log('dragElement or imageDimensions are undefined', this);
             return;
         }
+
         // max and min to not move out of the window
         this.dragElement.style.left = `${Math.max(
             Math.min(
@@ -140,9 +151,11 @@ export class DragElementService {
         // Remove the dragging stuff
         event.preventDefault();
         document.body.style.cursor = 'default';
-        document.removeEventListener('mousemove', this.onMouseMove);
-        document.removeEventListener('mouseup', this.onMouseUp);
+        document.removeEventListener('pointermove', this.onMouseMove);
+        document.removeEventListener('pointerup', this.onMouseUp);
+
         this.dragElement?.remove();
+        delete this.dragElement;
 
         if (!this.transferringTemplate || !this.olMap) {
             console.error('No template or map to add the element to', this);

--- a/frontend/src/app/pages/exercises/exercise/shared/editor-panel/map-editor-card/map-editor-card.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/editor-panel/map-editor-card/map-editor-card.component.html
@@ -1,7 +1,8 @@
 <div
     class="card text-center me-1 mb-1"
-    (mousedown)="elementMousedown.emit($event)"
     [attr.data-cy]="dataCy()"
+    (touchstart)="$event.preventDefault()"
+    (pointerdown)="elementPointerdown.emit($event)"
 >
     <ng-content>
         <div
@@ -13,7 +14,7 @@
         <div style="top: 0; right: 0" class="position-absolute">
             @if (enableEditButton()) {
                 <button
-                    (mousedown)="elementEdit.emit(); $event.stopPropagation()"
+                    (pointerdown)="elementEdit.emit(); $event.stopPropagation()"
                     class="btn btn-outline-warning btn-sm"
                 >
                     <i class="bi bi-pencil-fill"></i>
@@ -21,7 +22,9 @@
             }
             @if (enableDeleteButton()) {
                 <button
-                    (mousedown)="elementDelete.emit(); $event.stopPropagation()"
+                    (pointerdown)="
+                        elementDelete.emit(); $event.stopPropagation()
+                    "
                     class="btn btn-outline-danger btn-sm"
                 >
                     <i class="bi bi-trash"></i>

--- a/frontend/src/app/pages/exercises/exercise/shared/editor-panel/map-editor-card/map-editor-card.component.ts
+++ b/frontend/src/app/pages/exercises/exercise/shared/editor-panel/map-editor-card/map-editor-card.component.ts
@@ -1,7 +1,5 @@
-import { Component, output, inject, input } from '@angular/core';
-import { Store } from '@ngrx/store';
+import { Component, output, input } from '@angular/core';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
-import type { AppState } from '../../../../../../state/app.state';
 
 @Component({
     selector: 'app-map-editor-card',
@@ -10,9 +8,7 @@ import type { AppState } from '../../../../../../state/app.state';
     imports: [NgbTooltip],
 })
 export class MapEditorCardComponent {
-    private readonly store = inject<Store<AppState>>(Store);
-
-    readonly elementMousedown = output<MouseEvent>();
+    readonly elementPointerdown = output<PointerEvent>();
     readonly elementEdit = output();
     readonly elementDelete = output();
 

--- a/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.html
@@ -53,7 +53,7 @@
                                     [imageUrl]="viewportTemplate.image.url"
                                     [darkBackground]="true"
                                     dataCy="draggableViewportDiv"
-                                    (elementMousedown)="
+                                    (elementPointerdown)="
                                         dragElementService.onMouseDown($event, {
                                             type: 'viewport',
                                             template: viewportTemplate,
@@ -66,7 +66,7 @@
                                     title="Transferpunkt"
                                     [imageUrl]="transferPointTemplate.image.url"
                                     dataCy="draggableTransferPointDiv"
-                                    (elementMousedown)="
+                                    (elementPointerdown)="
                                         dragElementService.onMouseDown($event, {
                                             type: 'transferPoint',
                                             template: transferPointTemplate,
@@ -115,7 +115,7 @@
                                         track simulatedRegionDragTemplate
                                     ) {
                                         <app-map-editor-card
-                                            (elementMousedown)="
+                                            (elementPointerdown)="
                                                 dragElementService.onMouseDown(
                                                     $event,
                                                     {
@@ -160,7 +160,7 @@
                                         track restrictedZoneDragTemplate
                                     ) {
                                         <app-map-editor-card
-                                            (elementMousedown)="
+                                            (elementPointerdown)="
                                                 dragElementService.onMouseDown(
                                                     $event,
                                                     {
@@ -256,7 +256,7 @@
                                                 track patientCategory
                                             ) {
                                                 <app-map-editor-card
-                                                    (elementMousedown)="
+                                                    (elementPointerdown)="
                                                         dragElementService.onMouseDown(
                                                             $event,
                                                             {
@@ -366,7 +366,7 @@
                                         track vehicleTemplate.id
                                     ) {
                                         <app-map-editor-card
-                                            (elementMousedown)="
+                                            (elementPointerdown)="
                                                 dragElementService.onMouseDown(
                                                     $event,
                                                     {
@@ -430,7 +430,7 @@
                                         track mapImageTemplate.id
                                     ) {
                                         <app-map-editor-card
-                                            (elementMousedown)="
+                                            (elementPointerdown)="
                                                 dragElementService.onMouseDown(
                                                     $event,
                                                     {
@@ -489,7 +489,7 @@
                                         track category
                                     ) {
                                         <app-map-editor-card
-                                            (elementMousedown)="
+                                            (elementPointerdown)="
                                                 dragElementService.onMouseDown(
                                                     $event,
                                                     {
@@ -511,7 +511,7 @@
                                         </app-map-editor-card>
                                     }
                                     <app-map-editor-card
-                                        (elementMousedown)="
+                                        (elementPointerdown)="
                                             dragElementService.onMouseDown(
                                                 $event,
                                                 {


### PR DESCRIPTION
### Todo
- [x] Edit Button no longer works :(

### Summary

This PR changes the event handler from handling only mouse events to also reacting to touch events via the pointer-events handler.

This allows e.g. trainers to use tablets or smartboards to add new elements from the sidebar to the exercise

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [X] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [X] If this PR adds or changes features, the related documentation has been updated.
- [X] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [X] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [X] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
