### PR TITLE
Fix migration for organisations

### DIFF
--- a/backend/drizzle/0010_organisations.sql
+++ b/backend/drizzle/0010_organisations.sql
@@ -27,7 +27,7 @@ CREATE TABLE "organisation" (
 --> statement-breakpoint
 ALTER TABLE "exercise_template" DROP CONSTRAINT "exercise_template_user_users_id_fk";
 --> statement-breakpoint
-ALTER TABLE "exercise_template" ADD COLUMN "organisationId" uuid NOT NULL;--> statement-breakpoint
+ALTER TABLE "exercise_template" ADD COLUMN "organisationId" uuid;--> statement-breakpoint
 ALTER TABLE "organisation_invite_link" ADD CONSTRAINT "organisation_invite_link_organisationId_organisation_id_fk" FOREIGN KEY ("organisationId") REFERENCES "public"."organisation"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "organisation_membership" ADD CONSTRAINT "organisation_membership_userId_users_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "organisation_membership" ADD CONSTRAINT "organisation_membership_organisationId_organisation_id_fk" FOREIGN KEY ("organisationId") REFERENCES "public"."organisation"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
@@ -39,5 +39,7 @@ select 'Private Inhalte', "id"
 from users on conflict do nothing;
 --> statement-breakpoint
 UPDATE "exercise_template" SET "organisationId" = (select "id" from "organisation" where "personalOrganisationOf" = "exercise_template"."user" limit 1);
+--> statement-breakpoint
+ALTER TABLE "exercise_template" ALTER COLUMN "organisationId" SET NOT NULL;
 --> statement-breakpoint
 ALTER TABLE "exercise_template" DROP COLUMN "user";


### PR DESCRIPTION
### Summary

The migration didn't work for existing exercise templates. 

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [x] If this PR adds or changes features, the related documentation has been updated.
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
