### PR TITLE
Fix removal of alarm groups in measure templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 - There are now notifications when viewing an exercise replay whenever a measure is taken or a scoutable element is viewed.
 
+### Fixed
+
+- The deletion of alarm groups no longer breaks breaks measure templates that use them.
+
 ## [0.14.0] - 2026-06-11
 
 ### Added

--- a/shared/src/store/action-reducers/alarm-group.ts
+++ b/shared/src/store/action-reducers/alarm-group.ts
@@ -134,6 +134,18 @@ export namespace AlarmGroupActionReducers {
         reducer: (draftState, { alarmGroupId }) => {
             getElement(draftState, 'alarmGroup', alarmGroupId);
             delete draftState.alarmGroups[alarmGroupId];
+            // Remove this alarm group from every measure template's alarm properties
+            for (const category of Object.values(draftState.measureTemplates)) {
+                for (const template of Object.values(category.templates)) {
+                    for (const property of template.properties) {
+                        if (property.type === 'alarm') {
+                            property.alarmGroups = property.alarmGroups.filter(
+                                (id) => id !== alarmGroupId
+                            );
+                        }
+                    }
+                }
+            }
             return draftState;
         },
         rights: 'trainer',


### PR DESCRIPTION
### Summary

Closes #1458 by properly propagating the removal of alarm groups into measure templates / measure properties.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [x] If this PR adds or changes features, the related documentation has been updated.
- [ ] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
