### PR TITLE
Add fallback message for when the app fails to bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 ### Added
 
 - There are now notifications when viewing an exercise replay whenever a measure is taken or a scoutable element is viewed.
+- There is now a banner that is displayed when the application is unable to start properly, informing the user about potential causes.
 
 ### Fixed
 

--- a/frontend/cypress/e2e/fallback-banner.cy.ts
+++ b/frontend/cypress/e2e/fallback-banner.cy.ts
@@ -1,0 +1,44 @@
+describe('Fallback banner', () => {
+    it('stays hidden when the app loads normally', () => {
+        cy.visit('/');
+
+        // Once Angular has bootstrapped, app-root contains
+        // <router-outlet> and <app-display-messages>.
+        cy.get('app-root router-outlet').should('exist');
+
+        cy.get('#fallback-banner')
+            .should('have.css', 'display', 'none')
+            .and('have.attr', 'aria-hidden', 'true');
+
+        // Wait past the 5s detection timeout and make sure it's still hidden.
+        cy.wait(6000);
+
+        cy.get('#fallback-banner')
+            .should('have.css', 'display', 'none')
+            .and('have.attr', 'aria-hidden', 'true');
+    });
+
+    it('shows when the app fails to bootstrap', () => {
+        // Delay the request AuthService.initialize() depends on past the
+        // 5s detection timeout, so bootstrapApplication() never resolves
+        // and <app-root> stays empty.
+        cy.intercept('GET', '**/api/auth/user-data', {
+            statusCode: 200,
+            body: { user: undefined },
+            delay: 10000,
+        });
+
+        cy.visit('/');
+
+        cy.wait(6000);
+
+        cy.get('#fallback-banner')
+            .should('have.css', 'display', 'flex')
+            .and('have.attr', 'aria-hidden', 'false');
+
+        cy.contains(
+            '#fallback-banner',
+            'Die Anwendung konnte nicht geladen werden'
+        );
+    });
+});

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -12,6 +12,27 @@
         <link rel="author" href="mailto:kontakt@manv-simulation.de" />
     </head>
     <body>
+        <!--
+            Shown if the app fails to bootstrap within 5s (e.g. old browser
+            can't run the Angular bundle, or the backend is unreachable).
+        -->
+        <div
+            id="fallback-banner"
+            class="position-fixed top-0 end-0 bottom-0 start-0 z-n1 align-items-center justify-content-center text-center bg-white text-body p-4"
+            style="display: none"
+            aria-hidden="true"
+        >
+            <div class="col-11 col-sm-8 col-md-6 col-lg-5">
+                <h1 class="h4 mb-3">
+                    Die Anwendung konnte nicht geladen werden
+                </h1>
+                <p class="m-0">
+                    Bitte überprüfen Sie, ob Sie eine veraltete Browserversion
+                    nutzen. Falls Sie an einem Smartboard arbeiten, versuchen
+                    Sie bitte, stattdessen einen Laptop anzuschließen.
+                </p>
+            </div>
+        </div>
         <app-root></app-root>
         <noscript>
             <div class="container">
@@ -27,5 +48,18 @@
                 </div>
             </div>
         </noscript>
+        <script>
+            (function () {
+                setTimeout(function () {
+                    var appRoot = document.querySelector('app-root');
+                    if (appRoot && appRoot.children.length === 0) {
+                        var fallback =
+                            document.getElementById('fallback-banner');
+                        fallback.style.display = 'flex';
+                        fallback.setAttribute('aria-hidden', 'false');
+                    }
+                }, 5000);
+            })();
+        </script>
     </body>
 </html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -62,4 +62,11 @@ bootstrapApplication(AppComponent, {
             async (): Promise<void> => inject(AuthService).initialize()
         ),
     ],
-}).catch((err) => console.error(err));
+})
+    .then(() => {
+        const fallback =
+            document.querySelector<HTMLElement>('#fallback-banner');
+        fallback?.style.setProperty('display', 'none');
+        fallback?.setAttribute('aria-hidden', 'true');
+    })
+    .catch((err) => console.error(err));


### PR DESCRIPTION
### Summary

Closes #1488 by implementing a fallback banner that appears if the app fails to bootstrap within reasonable time.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [ ] If this PR adds or changes features, the related documentation has been updated.
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
