### PR TITLE
Add fast forward of parallel exercise instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 - There are now notifications when viewing an exercise replay whenever a measure is taken or a scoutable element is viewed.
 - There is now a banner that is displayed when the application is unable to start properly, informing the user about potential causes.
+- New participants joining a parallel exercise after it started now get fast-forwarded to be in sync with all other participants.
 
 ### Fixed
 

--- a/backend/src/database/services/parallel-exercise-service.ts
+++ b/backend/src/database/services/parallel-exercise-service.ts
@@ -9,9 +9,14 @@ import type { SessionInformation } from '../../auth/auth-service.js';
 import type { ParallelExercise, ParallelExerciseInsert } from '../schema.js';
 import {
     ApiError,
+    ExerciseAlreadyStartedError,
     NotFoundError,
     PermissionDeniedError,
 } from '../../utils/http.js';
+import {
+    fastForwardExercise,
+    MAX_FAST_FORWARD_DURATION_MS,
+} from '../../exercise/fast-forward-exercise.js';
 import type { ParallelExerciseRepository } from '../repositories/parallel-exercise-repository.js';
 import type { ActiveExercise } from '../../exercise/active-exercise.js';
 import { AccessKeyRepository } from '../repositories/access-key-repository.js';
@@ -68,6 +73,18 @@ export class ParallelExerciseService {
         const parallelExercise =
             await this.getParallelExerciseByParticipantKey(key);
 
+        const referenceInstance = await this.getMostProgressedStartedInstance(
+            parallelExercise.id
+        );
+
+        if (
+            referenceInstance &&
+            referenceInstance.exercise.currentStateString.currentTime >
+                MAX_FAST_FORWARD_DURATION_MS
+        ) {
+            throw new ExerciseAlreadyStartedError();
+        }
+
         const exercise =
             await this.exerciseManagerService.createExerciseFromTemplate(
                 parallelExercise.template.id,
@@ -82,11 +99,54 @@ export class ParallelExerciseService {
         };
         exercise.applyAction(setAutojoinViewportAction, null);
 
+        if (referenceInstance) {
+            fastForwardExercise(
+                exercise,
+                referenceInstance.exercise.currentStateString.currentTime,
+                referenceInstance.exercise.currentStateString.currentStatus
+            );
+        }
+
         this.newJoin.next({
             parallelExerciseId: parallelExercise.id,
             activeExercise: exercise,
         });
         return exercise;
+    }
+
+    /**
+     * Returns the existing instance of {@link parallelExerciseId} with the
+     * highest `currentTime` among those that have been started (i.e.
+     * `currentStatus !== 'notStarted'`), or `null` if none have been started
+     * yet.
+     */
+    private async getMostProgressedStartedInstance(
+        parallelExerciseId: ParallelExerciseId
+    ): Promise<ActiveExercise | null> {
+        const instanceEntries =
+            await this.parallelExerciseRepository.getParallelExerciseInstancesById(
+                parallelExerciseId
+            );
+        const instances = await Promise.all(
+            instanceEntries.map(async (entry) =>
+                this.exerciseService.getExerciseByKey(entry.participantKey)
+            )
+        );
+        return instances
+            .filter(
+                (instance) =>
+                    instance.exercise.currentStateString.currentStatus !==
+                    'notStarted'
+            )
+            .reduce<ActiveExercise | null>(
+                (furthest, instance) =>
+                    !furthest ||
+                    instance.exercise.currentStateString.currentTime >
+                        furthest.exercise.currentStateString.currentTime
+                        ? instance
+                        : furthest,
+                null
+            );
     }
 
     public async createParallelExercise(

--- a/backend/src/exercise/active-exercise.ts
+++ b/backend/src/exercise/active-exercise.ts
@@ -23,7 +23,7 @@ import { IncrementIdGenerator } from '../utils/increment-id-generator.js';
 import { RestoreError } from '../utils/restore-error.js';
 import { ActionWrapper } from './action-wrapper.js';
 import type { ExerciseClientWrapper } from './client-wrapper.js';
-import { patientTick } from './patient-ticking.js';
+import { buildTickAction } from './tick-action.js';
 import { PeriodicEventHandler } from './periodic-events/periodic-event-handler.js';
 
 export class ActiveExercise {
@@ -85,32 +85,16 @@ export class ActiveExercise {
     public readonly emitterId = null;
 
     /**
-     * How many ticks have to pass until treatments get recalculated (e.g. with {@link tickInterval} === 1000 and {@link refreshTreatmentInterval} === 60 every minute)
-     */
-    private readonly refreshTreatmentInterval = 20;
-    /**
      * This function gets called once every second in case the exercise is running.
      * All periodic actions of the exercise (e.g. status changes for patients) should happen here.
      */
     private readonly tick = async () => {
         try {
-            const patientUpdates = patientTick(
+            const updateAction = buildTickAction(
                 this.getStateSnapshot(),
-                this.tickInterval
+                this.tickInterval,
+                this.exercise.tickCounter
             );
-            const updateAction: ExerciseAction = {
-                type: '[Exercise] Tick',
-                patientUpdates,
-                /**
-                 * Refresh every {@link refreshTreatmentInterval} * {@link tickInterval} ms seconds
-                 */
-                // TODO: Refactor this: do this in the reducer instead of sending it in the action
-                refreshTreatments:
-                    this.exercise.tickCounter %
-                        this.refreshTreatmentInterval ===
-                    0,
-                tickInterval: this.tickInterval,
-            };
             this.applyAction(updateAction, this.emitterId);
             this.exercise.tickCounter++;
             this.markAsModified();

--- a/backend/src/exercise/fast-forward-exercise.spec.ts
+++ b/backend/src/exercise/fast-forward-exercise.spec.ts
@@ -1,0 +1,32 @@
+import { createTestEnvironment } from '../test/utils.js';
+import { fastForwardExercise } from './fast-forward-exercise.js';
+
+describe('fastForwardExercise', () => {
+    const environment = createTestEnvironment();
+
+    it('advances currentTime and starts the exercise', async () => {
+        const exercise =
+            await environment.services.exerciseService.createExerciseFromBlank();
+
+        fastForwardExercise(exercise, 5000, 'running');
+
+        expect(exercise.exercise.currentStateString.currentTime).toBe(5000);
+        expect(exercise.exercise.currentStateString.currentStatus).toBe(
+            'running'
+        );
+
+        exercise.pause();
+    });
+
+    it('advances currentTime and leaves the exercise paused', async () => {
+        const exercise =
+            await environment.services.exerciseService.createExerciseFromBlank();
+
+        fastForwardExercise(exercise, 3000, 'paused');
+
+        expect(exercise.exercise.currentStateString.currentTime).toBe(3000);
+        expect(exercise.exercise.currentStateString.currentStatus).toBe(
+            'paused'
+        );
+    });
+});

--- a/backend/src/exercise/fast-forward-exercise.ts
+++ b/backend/src/exercise/fast-forward-exercise.ts
@@ -1,0 +1,46 @@
+import type { ExerciseStatus } from 'fuesim-digital-shared';
+import type { ActiveExercise } from './active-exercise.js';
+import { buildTickAction } from './tick-action.js';
+
+/**
+ * Untested, higher values may be possible, but 30min seems like
+ * a reasonable limit.
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const MAX_FAST_FORWARD_DURATION_MS = 30 * 60 * 1000;
+
+const tickInterval = 1000;
+
+/**
+ * Advances {@link activeExercise} from its current state to
+ * {@link targetTime} and {@link targetStatus} by repeatedly applying
+ * `[Exercise] Tick` actions, then syncing the run/pause status.
+ */
+export function fastForwardExercise(
+    activeExercise: ActiveExercise,
+    targetTime: number,
+    targetStatus: ExerciseStatus
+): void {
+    if (
+        targetStatus !== 'notStarted' &&
+        activeExercise.exercise.currentStateString.currentStatus !== 'running'
+    ) {
+        activeExercise.applyAction({ type: '[Exercise] Start' }, null);
+    }
+
+    while (
+        activeExercise.exercise.currentStateString.currentTime < targetTime
+    ) {
+        const tickAction = buildTickAction(
+            activeExercise.getStateSnapshot(),
+            tickInterval,
+            activeExercise.exercise.tickCounter
+        );
+        activeExercise.applyAction(tickAction, null);
+        activeExercise.exercise.tickCounter++;
+    }
+
+    if (targetStatus === 'paused') {
+        activeExercise.applyAction({ type: '[Exercise] Pause' }, null);
+    }
+}

--- a/backend/src/exercise/tick-action.ts
+++ b/backend/src/exercise/tick-action.ts
@@ -1,0 +1,30 @@
+import type { ExerciseAction, ExerciseState } from 'fuesim-digital-shared';
+import { patientTick } from './patient-ticking.js';
+
+/**
+ * How many ticks have to pass until treatments get recalculated (e.g. with
+ * {@link tickInterval} === 1000 and {@link REFRESH_TREATMENT_INTERVAL} === 20,
+ * every 20 seconds).
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const REFRESH_TREATMENT_INTERVAL = 20;
+
+/**
+ * Builds an `[Exercise] Tick` action for {@link state}, advancing the exercise
+ * by {@link tickInterval} ms. {@link tickCounter} is the number of ticks that
+ * have already been applied to this exercise (used to decide whether treatments
+ * should be refreshed on this tick).
+ */
+export function buildTickAction(
+    state: ExerciseState,
+    tickInterval: number,
+    tickCounter: number
+): ExerciseAction {
+    return {
+        type: '[Exercise] Tick',
+        patientUpdates: patientTick(state, tickInterval),
+        // TODO: Refactor this: do this in the reducer instead of sending it in the action
+        refreshTreatments: tickCounter % REFRESH_TREATMENT_INTERVAL === 0,
+        tickInterval,
+    };
+}

--- a/backend/src/routers/parallel-exercise-router.spec.ts
+++ b/backend/src/routers/parallel-exercise-router.spec.ts
@@ -24,6 +24,7 @@ import {
     joinParallelExercise,
 } from '../test/parallel-exercise-utils.js';
 import type { OrganisationEntry } from '../database/schema.js';
+import { MAX_FAST_FORWARD_DURATION_MS } from '../exercise/fast-forward-exercise.js';
 
 describe('parallel exercise router', () => {
     const environment = createTestEnvironment();
@@ -436,6 +437,132 @@ describe('parallel exercise router', () => {
             expect(
                 newExercise.temporaryActionHistory[0]!.getAction().actionString
             ).toMatchObject(action);
+        });
+
+        it('fast-forwards a new instance to match a running instance', async () => {
+            const firstJoin = await environment
+                .httpRequest(
+                    'post',
+                    `/api/parallel_exercises/join/${parallelExercise.participantKey}`
+                )
+                .expect(201);
+            const firstParticipant =
+                postJoinParallelExerciseResponseDataSchema.parse(
+                    firstJoin.body
+                );
+            const firstInstance = environment.services.exerciseService
+                .TESTING_getExerciseMap()
+                .get(firstParticipant.participantKey)!;
+
+            firstInstance.exercise.currentStateString = {
+                ...firstInstance.exercise.currentStateString,
+                currentStatus: 'running',
+                currentTime: 10 * 60 * 1000,
+            };
+
+            const secondJoin = await environment
+                .httpRequest(
+                    'post',
+                    `/api/parallel_exercises/join/${parallelExercise.participantKey}`
+                )
+                .expect(201);
+            const secondParticipant =
+                postJoinParallelExerciseResponseDataSchema.parse(
+                    secondJoin.body
+                );
+            const secondInstance = environment.services.exerciseService
+                .TESTING_getExerciseMap()
+                .get(secondParticipant.participantKey)!;
+
+            expect(
+                secondInstance.exercise.currentStateString.currentStatus
+            ).toBe('running');
+            expect(secondInstance.exercise.currentStateString.currentTime).toBe(
+                10 * 60 * 1000
+            );
+
+            secondInstance.pause();
+        });
+
+        it('fast-forwards a new instance to match a paused instance', async () => {
+            const firstJoin = await environment
+                .httpRequest(
+                    'post',
+                    `/api/parallel_exercises/join/${parallelExercise.participantKey}`
+                )
+                .expect(201);
+            const firstParticipant =
+                postJoinParallelExerciseResponseDataSchema.parse(
+                    firstJoin.body
+                );
+            const firstInstance = environment.services.exerciseService
+                .TESTING_getExerciseMap()
+                .get(firstParticipant.participantKey)!;
+
+            firstInstance.exercise.currentStateString = {
+                ...firstInstance.exercise.currentStateString,
+                currentStatus: 'paused',
+                currentTime: 15 * 60 * 1000,
+            };
+
+            const secondJoin = await environment
+                .httpRequest(
+                    'post',
+                    `/api/parallel_exercises/join/${parallelExercise.participantKey}`
+                )
+                .expect(201);
+            const secondParticipant =
+                postJoinParallelExerciseResponseDataSchema.parse(
+                    secondJoin.body
+                );
+            const secondInstance = environment.services.exerciseService
+                .TESTING_getExerciseMap()
+                .get(secondParticipant.participantKey)!;
+
+            expect(
+                secondInstance.exercise.currentStateString.currentStatus
+            ).toBe('paused');
+            expect(secondInstance.exercise.currentStateString.currentTime).toBe(
+                15 * 60 * 1000
+            );
+        });
+
+        it('rejects joining when the reference instance is too far along', async () => {
+            const firstJoin = await environment
+                .httpRequest(
+                    'post',
+                    `/api/parallel_exercises/join/${parallelExercise.participantKey}`
+                )
+                .expect(201);
+            const firstParticipant =
+                postJoinParallelExerciseResponseDataSchema.parse(
+                    firstJoin.body
+                );
+            const firstInstance = environment.services.exerciseService
+                .TESTING_getExerciseMap()
+                .get(firstParticipant.participantKey)!;
+
+            firstInstance.exercise.currentStateString = {
+                ...firstInstance.exercise.currentStateString,
+                currentStatus: 'running',
+                currentTime: MAX_FAST_FORWARD_DURATION_MS + 1000,
+            };
+
+            const sizeBefore =
+                environment.services.exerciseService.TESTING_getExerciseMap()
+                    .size;
+
+            await environment
+                .httpRequest(
+                    'post',
+                    `/api/parallel_exercises/join/${parallelExercise.participantKey}`
+                )
+                .expect(409);
+
+            expect(
+                environment.services.exerciseService.TESTING_getExerciseMap()
+                    .size
+            ).toBe(sizeBefore);
         });
     });
 });

--- a/backend/src/utils/http.ts
+++ b/backend/src/utils/http.ts
@@ -13,3 +13,9 @@ export class PermissionDeniedError extends ApiError {
         super('Sie haben keine Berechtigung für diese Operation.');
     }
 }
+export class ExerciseAlreadyStartedError extends ApiError {
+    public override statusCode = 409;
+    public constructor() {
+        super('Diese Übung läuft bereits zu lange, um noch beizutreten.');
+    }
+}


### PR DESCRIPTION
### Summary

Closes #1515 by implementing fast-forward logic which puts a newly joined exercise instance in a parallel exercise in sync with the existing instances.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [x] If this PR adds or changes features, the related documentation has been updated.
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
