### PR TITLE
Disable @typescript-eslint/no-redeclare

### DIFF
--- a/.eslint/typescript.eslintrc.mjs
+++ b/.eslint/typescript.eslintrc.mjs
@@ -391,7 +391,6 @@ export default {
         '@typescript-eslint/no-invalid-this': 'warn',
         '@typescript-eslint/no-loop-func': 'warn',
         '@typescript-eslint/no-loss-of-precision': 'warn',
-        '@typescript-eslint/no-redeclare': 'warn',
         '@typescript-eslint/no-shadow': [
             'warn',
             {


### PR DESCRIPTION
Disables the no-redeclare eslint rule. As this is already enforced by the typescript compiler and recommended by @typescript-eslint:

https://typescript-eslint.io/rules/no-redeclare/

Further, without additional configuration, this prevents declaration merging.

### Summary

_Please provide a short summary of the proposed changes here. Reference the addressed issue or provide a short rationale for the changes._

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [x] If this PR adds or changes features, the related documentation has been updated.
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
