### PR TITLE
Fix wrong help links in trainer map editor

### DIFF
--- a/docs/src/2_exercises/3_exercise_elements.md
+++ b/docs/src/2_exercises/3_exercise_elements.md
@@ -4,7 +4,7 @@ Mit Übungselementen sind all jene Objekte gemeint, die im Laufe einer Übung du
 
 ## Ansichten
 
-Bei Ansichten handelt es sich um Bereiche einer Übung, die mit einem weißen REchteck markiert sind.
+Bei Ansichten handelt es sich um Bereiche einer Übung, die mit einem weißen Rechteck markiert sind.
 
 ![Ansichten auf der Übungskarte, mit Einstellungs-Popup](./exercise_elements_viewports_on_map.png)
 

--- a/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.html
+++ b/frontend/src/app/pages/exercises/exercise/shared/trainer-map-editor/trainer-map-editor.component.html
@@ -183,7 +183,7 @@
                                     }
                                 </div>
                                 <app-help-banner
-                                    url="2_exercises/3_exercise_elements.html#ansichten"
+                                    url="2_exercises/3_exercise_elements.html#zonen"
                                     label="Mehr Informationen zu eingeschränkten Zonen"
                                 />
                             </ng-template>
@@ -327,7 +327,7 @@
                                     }
                                 }
                                 <app-help-banner
-                                    url="2_exercises/3_exercise_elements.html#ansichten"
+                                    url="2_exercises/3_exercise_elements.html#patienten"
                                     label="Mehr Informationen zu Patienten"
                                 />
                             </ng-template>
@@ -394,7 +394,7 @@
                                     }
                                 </div>
                                 <app-help-banner
-                                    url="2_exercises/3_exercise_elements.html#ansichten"
+                                    url="2_exercises/3_exercise_elements.html#fahrzeuge-mit-personal-und-material"
                                     label="Mehr Informationen zu Fahrzeugen"
                                 />
                             </ng-template>
@@ -464,7 +464,7 @@
                                     </span>
                                 }
                                 <app-help-banner
-                                    url="2_exercises/3_exercise_elements.html#ansichten"
+                                    url="2_exercises/3_exercise_elements.html#bilder"
                                     label="Mehr Informationen zu Bildern"
                                 />
                             </ng-template>


### PR DESCRIPTION
### Summary

All `<app-help-banner>` components linked to the viewport docs.

Also fixes a typo in the docs.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [x] If this PR adds or changes features, the related documentation has been updated.
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
