### PR TITLE
Allow removal of scoutability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 ### Fixed
 
 - The deletion of alarm groups no longer breaks breaks measure templates that use them.
+- Elements are now only marked scoutable once their name or content is specified, and can be marked as unscoutable again.
 
 ## [0.17.0] - 2026-06-30
 

--- a/frontend/src/app/shared/components/scoutable-element-nav-item/scoutable-element-nav-item.component.html
+++ b/frontend/src/app/shared/components/scoutable-element-nav-item/scoutable-element-nav-item.component.html
@@ -1,49 +1,59 @@
-@if (scoutable(); as scoutable) {
-    @if (currentRole() === 'trainer') {
-        <div class="p-2">
-            <div class="form-group pb-3">
-                <label class="form-label mb-0">Interner Name</label>
-                <p class="small text-muted mb-1">
-                    Dieser Name wird in der Auswertung angezeigt.
-                </p>
-                <input
-                    #nameInput="ngModel"
-                    [ngModel]="scoutable.name"
-                    (appSaveOnTyping)="rename($event)"
-                    type="text"
-                    class="form-control"
-                />
-                <app-display-validation
-                    [ngModelInput]="nameInput"
-                ></app-display-validation>
-            </div>
-            @if (scoutable.isVisibleForParticipants) {
-                <button
-                    class="btn btn-outline-primary btn-sm me-2"
-                    ngbTooltip="Für Teilnehmende verstecken"
-                    (click)="setVisibility(false)"
-                >
-                    <i class="bi bi-eye"></i>
-                </button>
-                <span>Inhalte sind für Teilnehmende sichtbar.</span>
-            } @else {
-                <button
-                    class="btn btn-outline-primary btn-sm me-2"
-                    ngbTooltip="Für Teilnehmende sichtbar machen"
-                    (click)="setVisibility(true)"
-                >
-                    <i class="bi bi-eye-slash"></i>
-                </button>
-                <span>Inhalte sind für Teilnehmende nicht sichtbar.</span>
-            }
+@if (currentRole() === 'trainer') {
+    <div class="p-2">
+        <div class="form-group pb-3">
+            <label class="form-label mb-0">Interner Name</label>
+            <p class="small text-muted mb-1">
+                Dieser Name wird in der Auswertung angezeigt.
+            </p>
+            <input
+                #nameInput="ngModel"
+                [ngModel]="model().name"
+                (appSaveOnTyping)="changeName($event)"
+                type="text"
+                class="form-control"
+            />
+            <app-display-validation
+                [ngModelInput]="nameInput"
+            ></app-display-validation>
         </div>
-    }
+        @if (model().isVisibleForParticipants) {
+            <button
+                class="btn btn-outline-primary btn-sm me-2"
+                ngbTooltip="Für Teilnehmende verstecken"
+                (click)="changeVisibility(false)"
+            >
+                <i class="bi bi-eye"></i>
+            </button>
+            <span>Inhalte sind für Teilnehmende sichtbar.</span>
+        } @else {
+            <button
+                class="btn btn-outline-primary btn-sm me-2"
+                ngbTooltip="Für Teilnehmende sichtbar machen"
+                (click)="changeVisibility(true)"
+            >
+                <i class="bi bi-eye-slash"></i>
+            </button>
+            <span>Inhalte sind für Teilnehmende nicht sichtbar.</span>
+        }
+        <app-user-generated-content-editor
+            [userGeneratedContent]="model().content"
+            (userGeneratedContentChange)="changeContent($event)"
+        />
+        <button
+            class="btn btn-primary"
+            [disabled]="element().scoutableId === null"
+            (click)="removeScoutability()"
+        >
+            Erkundung entfernen
+        </button>
+    </div>
+}
 
-    @if (currentRole() === 'trainer' || scoutable.isVisibleForParticipants) {
+@if (scoutable(); as scoutable) {
+    @if (currentRole() !== 'trainer' && scoutable.isVisibleForParticipants) {
         <div>
             <app-user-generated-content-editor
-                [userGeneratedContent]="scoutable.userGeneratedContent"
-                (userGeneratedContentChange)="updateContent($event)"
+                [userGeneratedContent]="model().content"
             />
         </div>
     }

--- a/frontend/src/app/shared/components/scoutable-element-nav-item/scoutable-element-nav-item.component.ts
+++ b/frontend/src/app/shared/components/scoutable-element-nav-item/scoutable-element-nav-item.component.ts
@@ -1,13 +1,21 @@
 import {
     Component,
     computed,
+    effect,
     inject,
     input,
+    linkedSignal,
     OnInit,
     signal,
 } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { newScoutable, ScoutableElement } from 'fuesim-digital-shared';
+import {
+    cloneDeepMutable,
+    newScoutable,
+    newUserGeneratedContent,
+    ScoutableElement,
+    userGeneratedContentSchema,
+} from 'fuesim-digital-shared';
 import { FormsModule } from '@angular/forms';
 import type { UserGeneratedContent, Scoutable } from 'fuesim-digital-shared';
 import { form, validateStandardSchema } from '@angular/forms/signals';
@@ -44,42 +52,89 @@ export class ScoutableElementNavItemComponent implements OnInit {
     });
     readonly currentRole = this.store.selectSignal(selectCurrentMainRole);
 
-    readonly model = signal<{ name: string }>({
-        name: '',
+    readonly model = linkedSignal<
+        Scoutable | null,
+        {
+            name: string;
+            content: UserGeneratedContent;
+            isVisibleForParticipants: boolean;
+        }
+    >({
+        source: this.scoutable,
+        computation: (scoutable, previous) => {
+            if (previous && this.hasLocalEdits()) return previous.value;
+
+            return {
+                name: scoutable?.name ?? '',
+                content:
+                    scoutable?.userGeneratedContent ??
+                    newUserGeneratedContent(),
+                isVisibleForParticipants:
+                    scoutable?.isVisibleForParticipants ?? true,
+            };
+        },
     });
     scoutableForm = form(this.model, (schemaPath) => {
-        validateStandardSchema(schemaPath, z.object({ name: z.string() }));
+        validateStandardSchema(
+            schemaPath,
+            z.object({
+                name: z.string(),
+                content: userGeneratedContentSchema,
+                isVisibleForParticipants: z.boolean(),
+            })
+        );
     });
+    readonly hasLocalEdits = signal<boolean>(false);
+
+    constructor() {
+        effect(() => {
+            const value = this.model();
+            const isValid = this.scoutableForm().valid();
+            const isDirty = this.scoutableForm().dirty();
+
+            if (isDirty && isValid) {
+                this.hasLocalEdits.set(false);
+                this.scoutableForm().reset();
+                if (
+                    value.name.trim() === '' &&
+                    (value.content.content.trim() === '' ||
+                        value.content.content === '<p></p>')
+                ) {
+                    if (this.element().scoutableId !== null)
+                        this.removeScoutability();
+                    return;
+                } else if (this.element().scoutableId === null) {
+                    const draftScoutable = cloneDeepMutable(newScoutable());
+                    draftScoutable.name = value.name;
+                    draftScoutable.userGeneratedContent = value.content;
+                    draftScoutable.isVisibleForParticipants =
+                        value.isVisibleForParticipants;
+                    this.makeScoutable(this.element(), draftScoutable);
+                    return;
+                }
+                const scoutable = this.scoutable()!;
+                if (value.name !== scoutable.name) this.rename(value.name);
+                if (
+                    value.content.content !==
+                    scoutable.userGeneratedContent.content
+                )
+                    this.updateContent(value.content);
+                if (
+                    value.isVisibleForParticipants !==
+                    scoutable.isVisibleForParticipants
+                )
+                    this.setVisibility(value.isVisibleForParticipants);
+            }
+        });
+    }
 
     ngOnInit() {
-        if (this.element().scoutableId === null) {
-            this.makeScoutable(this.element());
-        }
         if (this.currentRole() === 'participant') {
             this.markAsViewed();
         }
     }
 
-    makeScoutable(element: ScoutableElement) {
-        this.exerciseService.proposeAction(
-            {
-                type: '[Scoutable] Make scoutable',
-                elementId: element.id,
-                elementType: element.type,
-                scoutable: newScoutable(),
-            },
-            true
-        );
-    }
-
-    markAsViewed() {
-        this.exerciseService.proposeAction({
-            type: '[Scoutable] Mark as viewed',
-            scoutableId: this.scoutable()!.id,
-        });
-    }
-
-    rename(name: string) {
+    private rename(name: string) {
         this.exerciseService.proposeAction(
             {
                 type: '[Scoutable] Rename',
@@ -90,7 +145,15 @@ export class ScoutableElementNavItemComponent implements OnInit {
         );
     }
 
-    setVisibility(value: boolean) {
+    private updateContent(content: UserGeneratedContent) {
+        this.exerciseService.proposeAction({
+            type: '[Scoutable] Update content',
+            scoutableId: this.scoutable()!.id,
+            userGeneratedContent: content,
+        });
+    }
+
+    private setVisibility(value: boolean) {
         this.exerciseService.proposeAction({
             type: '[Scoutable] Set isVisibleForParticipants',
             scoutableId: this.scoutable()!.id,
@@ -98,11 +161,51 @@ export class ScoutableElementNavItemComponent implements OnInit {
         });
     }
 
-    updateContent(content: UserGeneratedContent) {
+    makeScoutable(element: ScoutableElement, scoutable: Scoutable) {
+        this.exerciseService.proposeAction(
+            {
+                type: '[Scoutable] Make scoutable',
+                elementId: element.id,
+                elementType: element.type,
+                scoutable,
+            },
+            true
+        );
+    }
+
+    removeScoutability() {
         this.exerciseService.proposeAction({
-            type: '[Scoutable] Update content',
-            scoutableId: this.scoutable()!.id,
-            userGeneratedContent: content,
+            type: '[Scoutable] Remove scoutability',
+            elementType: this.element().type,
+            elementId: this.element().id,
         });
+    }
+
+    markAsViewed() {
+        this.exerciseService.proposeAction({
+            type: '[Scoutable] Mark as viewed',
+            scoutableId: this.scoutable()!.id,
+        });
+    }
+
+    changeName(name: string) {
+        this.model.update(({ ...model }) => ({ ...model, name }));
+        this.scoutableForm.name().markAsDirty();
+        this.hasLocalEdits.set(true);
+    }
+
+    changeContent(content: UserGeneratedContent) {
+        this.model.update(({ ...model }) => ({ ...model, content }));
+        this.scoutableForm.content().markAsDirty();
+        this.hasLocalEdits.set(true);
+    }
+
+    changeVisibility(isVisibleForParticipants: boolean) {
+        this.model.update(({ ...model }) => ({
+            ...model,
+            isVisibleForParticipants,
+        }));
+        this.scoutableForm.isVisibleForParticipants().markAsDirty();
+        this.hasLocalEdits.set(true);
     }
 }

--- a/shared/src/state-migrations/56-technical-challenges-measures-extended-scoutables.ts
+++ b/shared/src/state-migrations/56-technical-challenges-measures-extended-scoutables.ts
@@ -1,9 +1,18 @@
 import type { UUID } from '../utils/uuid.js';
 import type { Migration } from './migration-functions.js';
 
+interface UserGeneratedContent {
+    content: string;
+}
+
 interface Scoutable {
     name?: string;
     viewedByParticipants?: boolean;
+    userGeneratedContent?: UserGeneratedContent;
+}
+
+function isEmptyContent(content: string | undefined): boolean {
+    return content === '' || content === '<p></p>';
 }
 
 export const technicalChallengesMeasuresExtendedScoutables57: Migration = {
@@ -15,12 +24,70 @@ export const technicalChallengesMeasuresExtendedScoutables57: Migration = {
             };
             typedScoutableAction.scoutable.name = '';
             typedScoutableAction.scoutable.viewedByParticipants = false;
+        } else if (typedAction.type === '[Scoutable] Update content') {
+            const typedUpdateAction = action as {
+                scoutableId: UUID;
+                userGeneratedContent: UserGeneratedContent;
+            };
+            if (
+                isEmptyContent(typedUpdateAction.userGeneratedContent?.content)
+            ) {
+                const typedState = intermediateState as {
+                    patients: { [key in UUID]: { scoutableId: UUID | null } };
+                    mapImages: { [key in UUID]: { scoutableId: UUID | null } };
+                };
+
+                let elementType: string | undefined;
+                let elementId: string | undefined;
+
+                for (const [id, patient] of Object.entries(
+                    typedState.patients
+                )) {
+                    if (patient.scoutableId === typedUpdateAction.scoutableId) {
+                        elementType = 'patient';
+                        elementId = id;
+                        break;
+                    }
+                }
+
+                if (elementType === undefined) {
+                    for (const [id, mapImage] of Object.entries(
+                        typedState.mapImages
+                    )) {
+                        if (
+                            mapImage.scoutableId ===
+                            typedUpdateAction.scoutableId
+                        ) {
+                            elementType = 'mapImage';
+                            elementId = id;
+                            break;
+                        }
+                    }
+                }
+
+                if (elementType !== undefined && elementId !== undefined) {
+                    const mutableAction = action as {
+                        type: string;
+                        elementType: string;
+                        elementId: string;
+                        scoutableId?: unknown;
+                        userGeneratedContent?: unknown;
+                    };
+                    mutableAction.type = '[Scoutable] Remove scoutability';
+                    mutableAction.elementType = elementType;
+                    mutableAction.elementId = elementId;
+                    delete mutableAction.scoutableId;
+                    delete mutableAction.userGeneratedContent;
+                }
+            }
         }
         return true;
     },
     state: (state: any) => {
         const typedState = state as {
             scoutables: { [key in UUID]: Scoutable };
+            patients: { [key in UUID]: { scoutableId: UUID | null } };
+            mapImages: { [key in UUID]: { scoutableId: UUID | null } };
         };
 
         state.technicalChallenges = {};
@@ -32,6 +99,37 @@ export const technicalChallengesMeasuresExtendedScoutables57: Migration = {
         Object.values(typedState.scoutables).forEach((scoutable) => {
             scoutable.name = '';
             scoutable.viewedByParticipants = false;
+        });
+
+        const emptyContentScoutableIds = new Set(
+            Object.entries(typedState.scoutables)
+                .filter(([_, scoutable]) =>
+                    isEmptyContent(scoutable.userGeneratedContent?.content)
+                )
+                .map(([id]) => id)
+        );
+
+        emptyContentScoutableIds.forEach(
+            (id) =>
+                delete (typedState.scoutables as { [key: string]: unknown })[id]
+        );
+
+        Object.values(typedState.patients).forEach((patient) => {
+            if (
+                patient.scoutableId !== null &&
+                emptyContentScoutableIds.has(patient.scoutableId)
+            ) {
+                patient.scoutableId = null;
+            }
+        });
+
+        Object.values(typedState.mapImages).forEach((mapImage) => {
+            if (
+                mapImage.scoutableId !== null &&
+                emptyContentScoutableIds.has(mapImage.scoutableId)
+            ) {
+                mapImage.scoutableId = null;
+            }
         });
     },
 };

--- a/shared/src/state-migrations/56-technical-challenges-measures-extended-scoutables.ts
+++ b/shared/src/state-migrations/56-technical-challenges-measures-extended-scoutables.ts
@@ -27,7 +27,7 @@ export const technicalChallengesMeasuresExtendedScoutables57: Migration = {
         } else if (typedAction.type === '[Scoutable] Update content') {
             const typedUpdateAction = action as {
                 scoutableId: UUID;
-                userGeneratedContent: UserGeneratedContent;
+                userGeneratedContent?: UserGeneratedContent;
             };
             if (
                 isEmptyContent(typedUpdateAction.userGeneratedContent?.content)

--- a/shared/src/store/action-reducers/scoutable.ts
+++ b/shared/src/store/action-reducers/scoutable.ts
@@ -8,6 +8,7 @@ import {
 import { userGeneratedContentSchema } from '../../models/user-generated-content.js';
 import { uuidSchema } from '../../utils/uuid.js';
 import { cloneDeepMutable } from '../../utils/clone-deep.js';
+import { ReducerError } from '../reducer-error.js';
 import { getElement } from './utils/get-element.js';
 import { logScoutableViewed } from './utils/log.js';
 
@@ -28,6 +29,15 @@ const makeElementScoutableActionSchema = z.strictObject({
 });
 export type MakeElementScoutableAction = z.infer<
     typeof makeElementScoutableActionSchema
+>;
+
+const removeElementScoutabilityActionSchema = z.strictObject({
+    type: z.literal('[Scoutable] Remove scoutability'),
+    elementType: scoutableElementTypeSchema,
+    elementId: uuidSchema,
+});
+export type RemoveElementScoutabilityAction = z.infer<
+    typeof removeElementScoutabilityActionSchema
 >;
 
 const setIsVisibleForParticipantsActionSchema = z.strictObject({
@@ -63,6 +73,23 @@ export namespace ScoutableActionReducers {
                 draftState.scoutables[scoutable.id] =
                     cloneDeepMutable(scoutable);
 
+                return draftState;
+            },
+            rights: 'trainer',
+        };
+    export const removeElementScoutability: ActionReducer<RemoveElementScoutabilityAction> =
+        {
+            type: removeElementScoutabilityActionSchema.shape.type.value,
+            actionSchema: removeElementScoutabilityActionSchema,
+            reducer: (draftState, { elementType, elementId }) => {
+                const element = getElement(draftState, elementType, elementId);
+                const scoutableId = element.scoutableId;
+                if (!scoutableId)
+                    throw new ReducerError(
+                        'Cannot remove scoutability on an element that is not scoutable'
+                    );
+                delete draftState.scoutables[scoutableId];
+                element.scoutableId = null;
                 return draftState;
             },
             rights: 'trainer',


### PR DESCRIPTION
### Summary

Closes #1449 by deferring the creation of a scoutable element to save-time and allowing for the removal of scoutability, both automatically and explicitly.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [x] If this PR adds or changes features, the related documentation has been updated.
- [ ] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
