### PR TITLE
Fix parallel exercise instance initial state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 - Elements are now only marked scoutable once their name or content is specified, and can be marked as unscoutable again.
 - The measures toolbar no longer interferes with map interactions.
 - Show exercise import validation error messages in a readable format.
+- Exercise instances in a parallel exercise are now created based on the state the exercise template was in when the parallel exercise was created.
 
 ## [0.17.0] - 2026-06-30
 

--- a/backend/drizzle/0014_parallel_exercise_state_string.sql
+++ b/backend/drizzle/0014_parallel_exercise_state_string.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "parallel_exercise" ADD COLUMN "templateStateString" json;
+--> statement-breakpoint
+UPDATE "parallel_exercise" pe
+SET "templateStateString" = (
+    SELECT
+        ee."currentStateString"
+    FROM
+        "exercise_entity" ee
+    WHERE
+        ee."templateId" = pe."templateId"
+);
+--> statement-breakpoint
+ALTER TABLE "parallel_exercise" ALTER COLUMN "templateStateString"
+    SET NOT NULL;
+

--- a/backend/drizzle/meta/0014_snapshot.json
+++ b/backend/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1095 @@
+{
+    "id": "bf77e34c-9dca-4eb2-9691-0b59f36cfaf5",
+    "prevId": "4d1bded3-6972-432a-891c-3fbaf9363a42",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.access_key": {
+            "name": "access_key",
+            "schema": "",
+            "columns": {
+                "key": {
+                    "name": "key",
+                    "type": "varchar",
+                    "primaryKey": true,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.action_entity": {
+            "name": "action_entity",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "emitterId": {
+                    "name": "emitterId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "index": {
+                    "name": "index",
+                    "type": "bigint",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "actionString": {
+                    "name": "actionString",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "exerciseId": {
+                    "name": "exerciseId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "FK_180a58767f06b503216ba2b0982": {
+                    "name": "FK_180a58767f06b503216ba2b0982",
+                    "tableFrom": "action_entity",
+                    "tableTo": "exercise_entity",
+                    "columnsFrom": ["exerciseId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "cascade"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "action_entity_index_exerciseId_unique": {
+                    "name": "action_entity_index_exerciseId_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["index", "exerciseId"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.collection_dependency_mapping": {
+            "name": "collection_dependency_mapping",
+            "schema": "",
+            "columns": {
+                "dependentCollectionEntityId": {
+                    "name": "dependentCollectionEntityId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "dependentCollectionVersionId": {
+                    "name": "dependentCollectionVersionId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "collectionEntityId": {
+                    "name": "collectionEntityId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "collectionVersionId": {
+                    "name": "collectionVersionId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "collection_dependency_mapping_dependentCollectionVersionId_collections_versionId_fk": {
+                    "name": "collection_dependency_mapping_dependentCollectionVersionId_collections_versionId_fk",
+                    "tableFrom": "collection_dependency_mapping",
+                    "tableTo": "collections",
+                    "columnsFrom": ["dependentCollectionVersionId"],
+                    "columnsTo": ["versionId"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "collection_dependency_mapping_collectionVersionId_collections_versionId_fk": {
+                    "name": "collection_dependency_mapping_collectionVersionId_collections_versionId_fk",
+                    "tableFrom": "collection_dependency_mapping",
+                    "tableTo": "collections",
+                    "columnsFrom": ["collectionVersionId"],
+                    "columnsTo": ["versionId"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "unique_collection_dependency": {
+                    "name": "unique_collection_dependency",
+                    "nullsNotDistinct": false,
+                    "columns": [
+                        "dependentCollectionVersionId",
+                        "collectionEntityId"
+                    ]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.collection_join_codes": {
+            "name": "collection_join_codes",
+            "schema": "",
+            "columns": {
+                "code": {
+                    "name": "code",
+                    "type": "varchar",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "collection": {
+                    "name": "collection",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "expiresAt": {
+                    "name": "expiresAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "collection_join_codes_collection_unique": {
+                    "name": "collection_join_codes_collection_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["collection"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.collection_organisation_mapping": {
+            "name": "collection_organisation_mapping",
+            "schema": "",
+            "columns": {
+                "collection": {
+                    "name": "collection",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "organisationId": {
+                    "name": "organisationId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "owner": {
+                    "name": "owner",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "collection_organisation_mapping_organisationId_organisation_id_fk": {
+                    "name": "collection_organisation_mapping_organisationId_organisation_id_fk",
+                    "tableFrom": "collection_organisation_mapping",
+                    "tableTo": "organisation",
+                    "columnsFrom": ["organisationId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "collection_organisation_mapping_collection_organisationId_pk": {
+                    "name": "collection_organisation_mapping_collection_organisationId_pk",
+                    "columns": ["collection", "organisationId"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.collections": {
+            "name": "collections",
+            "schema": "",
+            "columns": {
+                "versionId": {
+                    "name": "versionId",
+                    "type": "varchar",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "entityId": {
+                    "name": "entityId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "version": {
+                    "name": "version",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "stateVersion": {
+                    "name": "stateVersion",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "editedAt": {
+                    "name": "editedAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "title": {
+                    "name": "title",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "visibility": {
+                    "name": "visibility",
+                    "type": "collection_visibility_enum",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'private'"
+                },
+                "draftState": {
+                    "name": "draftState",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "archived": {
+                    "name": "archived",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "collections_versionId_unique": {
+                    "name": "collections_versionId_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["versionId"]
+                },
+                "unique_collection_version": {
+                    "name": "unique_collection_version",
+                    "nullsNotDistinct": false,
+                    "columns": ["entityId", "version"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.element_to_collection_mapping": {
+            "name": "element_to_collection_mapping",
+            "schema": "",
+            "columns": {
+                "collectionEntityId": {
+                    "name": "collectionEntityId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "collectionVersionId": {
+                    "name": "collectionVersionId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "elementEntityId": {
+                    "name": "elementEntityId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "elementVersionId": {
+                    "name": "elementVersionId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "isBaseReference": {
+                    "name": "isBaseReference",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "element_to_collection_mapping_collectionVersionId_collections_versionId_fk": {
+                    "name": "element_to_collection_mapping_collectionVersionId_collections_versionId_fk",
+                    "tableFrom": "element_to_collection_mapping",
+                    "tableTo": "collections",
+                    "columnsFrom": ["collectionVersionId"],
+                    "columnsTo": ["versionId"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "element_to_collection_mapping_elementVersionId_elements_versionId_fk": {
+                    "name": "element_to_collection_mapping_elementVersionId_elements_versionId_fk",
+                    "tableFrom": "element_to_collection_mapping",
+                    "tableTo": "elements",
+                    "columnsFrom": ["elementVersionId"],
+                    "columnsTo": ["versionId"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "unique_element_collection_mapping": {
+                    "name": "unique_element_collection_mapping",
+                    "nullsNotDistinct": false,
+                    "columns": ["collectionVersionId", "elementVersionId"]
+                },
+                "unique_element_collection_mapping_2": {
+                    "name": "unique_element_collection_mapping_2",
+                    "nullsNotDistinct": false,
+                    "columns": ["collectionVersionId", "elementEntityId"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.elements": {
+            "name": "elements",
+            "schema": "",
+            "columns": {
+                "versionId": {
+                    "name": "versionId",
+                    "type": "varchar",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "entityId": {
+                    "name": "entityId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "version": {
+                    "name": "version",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "stateVersion": {
+                    "name": "stateVersion",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "editedAt": {
+                    "name": "editedAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "title": {
+                    "name": "title",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "content": {
+                    "name": "content",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "elements_versionId_unique": {
+                    "name": "elements_versionId_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["versionId"]
+                },
+                "unique_template_version": {
+                    "name": "unique_template_version",
+                    "nullsNotDistinct": false,
+                    "columns": ["entityId", "version"]
+                },
+                "unique_template_id": {
+                    "name": "unique_template_id",
+                    "nullsNotDistinct": false,
+                    "columns": ["entityId", "versionId"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.exercise_entity": {
+            "name": "exercise_entity",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "tickCounter": {
+                    "name": "tickCounter",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 0
+                },
+                "initialStateString": {
+                    "name": "initialStateString",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "participantKey": {
+                    "name": "participantKey",
+                    "type": "char(6)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "trainerKey": {
+                    "name": "trainerKey",
+                    "type": "char(8)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "currentStateString": {
+                    "name": "currentStateString",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "stateVersion": {
+                    "name": "stateVersion",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "organisationId": {
+                    "name": "organisationId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "lastUsedAt": {
+                    "name": "lastUsedAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "templateId": {
+                    "name": "templateId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "baseTemplateId": {
+                    "name": "baseTemplateId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "parallelExerciseId": {
+                    "name": "parallelExerciseId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "exercise_entity_organisationId_organisation_id_fk": {
+                    "name": "exercise_entity_organisationId_organisation_id_fk",
+                    "tableFrom": "exercise_entity",
+                    "tableTo": "organisation",
+                    "columnsFrom": ["organisationId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "exercise_entity_templateId_exercise_template_id_fk": {
+                    "name": "exercise_entity_templateId_exercise_template_id_fk",
+                    "tableFrom": "exercise_entity",
+                    "tableTo": "exercise_template",
+                    "columnsFrom": ["templateId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "exercise_entity_baseTemplateId_exercise_template_id_fk": {
+                    "name": "exercise_entity_baseTemplateId_exercise_template_id_fk",
+                    "tableFrom": "exercise_entity",
+                    "tableTo": "exercise_template",
+                    "columnsFrom": ["baseTemplateId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                },
+                "exercise_entity_parallelExerciseId_parallel_exercise_id_fk": {
+                    "name": "exercise_entity_parallelExerciseId_parallel_exercise_id_fk",
+                    "tableFrom": "exercise_entity",
+                    "tableTo": "parallel_exercise",
+                    "columnsFrom": ["parallelExerciseId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "exercise_entity_participantKey_unique": {
+                    "name": "exercise_entity_participantKey_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["participantKey"]
+                },
+                "exercise_entity_trainerKey_unique": {
+                    "name": "exercise_entity_trainerKey_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["trainerKey"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.exercise_template": {
+            "name": "exercise_template",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "organisationId": {
+                    "name": "organisationId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "lastUpdatedAt": {
+                    "name": "lastUpdatedAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "lastExerciseCreatedAt": {
+                    "name": "lastExerciseCreatedAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "''"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "exercise_template_organisationId_organisation_id_fk": {
+                    "name": "exercise_template_organisationId_organisation_id_fk",
+                    "tableFrom": "exercise_template",
+                    "tableTo": "organisation",
+                    "columnsFrom": ["organisationId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.organisation_invite_link": {
+            "name": "organisation_invite_link",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "token": {
+                    "name": "token",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "organisationId": {
+                    "name": "organisationId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "expirationDate": {
+                    "name": "expirationDate",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "organisation_invite_link_organisationId_organisation_id_fk": {
+                    "name": "organisation_invite_link_organisationId_organisation_id_fk",
+                    "tableFrom": "organisation_invite_link",
+                    "tableTo": "organisation",
+                    "columnsFrom": ["organisationId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.organisation_membership": {
+            "name": "organisation_membership",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "userId": {
+                    "name": "userId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "organisationId": {
+                    "name": "organisationId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "role": {
+                    "name": "role",
+                    "type": "organisation_membership_role",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "joinedAt": {
+                    "name": "joinedAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "organisation_membership_organisationId_role_index": {
+                    "name": "organisation_membership_organisationId_role_index",
+                    "columns": [
+                        {
+                            "expression": "organisationId",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "role",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "organisation_membership_userId_users_id_fk": {
+                    "name": "organisation_membership_userId_users_id_fk",
+                    "tableFrom": "organisation_membership",
+                    "tableTo": "users",
+                    "columnsFrom": ["userId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "organisation_membership_organisationId_organisation_id_fk": {
+                    "name": "organisation_membership_organisationId_organisation_id_fk",
+                    "tableFrom": "organisation_membership",
+                    "tableTo": "organisation",
+                    "columnsFrom": ["organisationId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "organisation_membership_userId_organisationId_unique": {
+                    "name": "organisation_membership_userId_organisationId_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["userId", "organisationId"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.organisation": {
+            "name": "organisation",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "''"
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "personalOrganisationOf": {
+                    "name": "personalOrganisationOf",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "organisation_personalOrganisationOf_users_id_fk": {
+                    "name": "organisation_personalOrganisationOf_users_id_fk",
+                    "tableFrom": "organisation",
+                    "tableTo": "users",
+                    "columnsFrom": ["personalOrganisationOf"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "organisation_personalOrganisationOf_unique": {
+                    "name": "organisation_personalOrganisationOf_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["personalOrganisationOf"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.parallel_exercise": {
+            "name": "parallel_exercise",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "organisationId": {
+                    "name": "organisationId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "name": {
+                    "name": "name",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "templateId": {
+                    "name": "templateId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "templateStateString": {
+                    "name": "templateStateString",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "participantKey": {
+                    "name": "participantKey",
+                    "type": "char(7)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "joinViewportId": {
+                    "name": "joinViewportId",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "parallel_exercise_organisationId_organisation_id_fk": {
+                    "name": "parallel_exercise_organisationId_organisation_id_fk",
+                    "tableFrom": "parallel_exercise",
+                    "tableTo": "organisation",
+                    "columnsFrom": ["organisationId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "parallel_exercise_templateId_exercise_template_id_fk": {
+                    "name": "parallel_exercise_templateId_exercise_template_id_fk",
+                    "tableFrom": "parallel_exercise",
+                    "tableTo": "exercise_template",
+                    "columnsFrom": ["templateId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "parallel_exercise_participantKey_unique": {
+                    "name": "parallel_exercise_participantKey_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["participantKey"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.sessions": {
+            "name": "sessions",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "userId": {
+                    "name": "userId",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "type": "timestamp (3)",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "expiresAt": {
+                    "name": "expiresAt",
+                    "type": "timestamp (3)",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "accessToken": {
+                    "name": "accessToken",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "sessions_userId_users_id_fk": {
+                    "name": "sessions_userId_users_id_fk",
+                    "tableFrom": "sessions",
+                    "tableTo": "users",
+                    "columnsFrom": ["userId"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "cascade"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.users": {
+            "name": "users",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "varchar",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "username": {
+                    "name": "username",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "displayName": {
+                    "name": "displayName",
+                    "type": "varchar",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "type": "timestamp (3)",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {
+        "public.collection_visibility_enum": {
+            "name": "collection_visibility_enum",
+            "schema": "public",
+            "values": ["public", "private", "embedded"]
+        }
+    },
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
             "when": 1784034245345,
             "tag": "0013_exercises_parallel_exercises_orgs",
             "breakpoints": true
+        },
+        {
+            "idx": 14,
+            "version": "7",
+            "when": 1784047030463,
+            "tag": "0014_parallel_exercise_state_string",
+            "breakpoints": true
         }
     ]
 }

--- a/backend/src/database/schema.ts
+++ b/backend/src/database/schema.ts
@@ -481,6 +481,7 @@ export const parallelExerciseTable = pgTable('parallel_exercise', {
         .$type<ExerciseTemplateId>()
         .references(() => exerciseTemplateTable.id, { onDelete: 'cascade' })
         .notNull(),
+    templateStateString: json().$type<ExerciseState>().notNull(),
     participantKey: char({ length: 7 })
         .$type<ParallelExerciseKey>()
         .notNull()

--- a/backend/src/database/services/exercise-manager-service.ts
+++ b/backend/src/database/services/exercise-manager-service.ts
@@ -1,6 +1,7 @@
 import type {
     ExerciseType,
     ExerciseTemplateId,
+    ExerciseState,
     StateExport,
     ParticipantKey,
     TrainerKey,
@@ -182,7 +183,8 @@ export class ExerciseManagerService {
         templateId: ExerciseTemplateId,
         type: ExerciseType = 'standalone',
         session?: SessionInformation,
-        optionalData?: Partial<Omit<ExerciseInsert, 'baseTemplateId' | 'user'>>
+        optionalData?: Partial<Omit<ExerciseInsert, 'baseTemplateId' | 'user'>>,
+        initialStateOverride?: ExerciseState
     ): Promise<ActiveExercise> {
         await this.exerciseService.saveUnsavedExercises();
 
@@ -212,7 +214,8 @@ export class ExerciseManagerService {
                 await accessKeyRepository.generateKey<TrainerKey>(8);
 
             const initialState = {
-                ...exerciseTemplate.exercise.currentStateString,
+                ...(initialStateOverride ??
+                    exerciseTemplate.exercise.currentStateString),
                 participantKey,
                 type,
             };

--- a/backend/src/database/services/parallel-exercise-service.ts
+++ b/backend/src/database/services/parallel-exercise-service.ts
@@ -25,6 +25,7 @@ import type { ParallelExerciseRepository } from '../repositories/parallel-exerci
 import type { ActiveExercise } from '../../exercise/active-exercise.js';
 import { AccessKeyRepository } from '../repositories/access-key-repository.js';
 import type { OrganisationRepository } from '../repositories/organisation-repository.js';
+import type { ExerciseRepository } from '../repositories/exercise-repository.js';
 import type { ExerciseManagerService } from './exercise-manager-service.js';
 import type { ExerciseService } from './exercise-service.js';
 
@@ -36,6 +37,7 @@ export class ParallelExerciseService {
     public newJoin = new Subject<ParallelExerciseJoin>();
     public constructor(
         private readonly parallelExerciseRepository: ParallelExerciseRepository,
+        private readonly exerciseRepository: ExerciseRepository,
         private readonly exerciseManagerService: ExerciseManagerService,
         private readonly exerciseService: ExerciseService,
         private readonly organisationRepository: OrganisationRepository
@@ -129,7 +131,8 @@ export class ParallelExerciseService {
                 parallelExercise.template.id,
                 'parallel',
                 undefined,
-                { parallelExerciseId: parallelExercise.id }
+                { parallelExerciseId: parallelExercise.id },
+                parallelExercise.templateStateString
             );
 
         const setAutojoinViewportAction: SetAutojoinViewportAction = {
@@ -195,6 +198,8 @@ export class ParallelExerciseService {
         >,
         session: SessionInformation
     ): Promise<ParallelExerciseDetailsEntryWithUserRole> {
+        await this.exerciseService.saveUnsavedExercises();
+
         const template =
             await this.exerciseManagerService.getExerciseTemplateById(
                 data.templateId,
@@ -212,6 +217,7 @@ export class ParallelExerciseService {
         return this.parallelExerciseRepository.transaction(async (tx) => {
             const created = await tx.createParallelExercise({
                 ...data,
+                templateStateString: template.exercise.currentStateString,
                 participantKey: await new AccessKeyRepository(tx).generateKey(
                     7
                 ),

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -76,6 +76,7 @@ async function main() {
     );
     const parallelExerciseService = new ParallelExerciseService(
         repositories.parallelExerciseRepository,
+        repositories.exerciseRepository,
         exerciseManagerService,
         exerciseService,
         repositories.organisationRepository

--- a/backend/src/test/utils.ts
+++ b/backend/src/test/utils.ts
@@ -278,6 +278,7 @@ export function createTestEnvironment(): TestEnvironment {
         );
         parallelExerciseService = new ParallelExerciseService(
             parallelExerciseRepository,
+            exerciseRepository,
             exerciseManagerService,
             exerciseService,
             organisationRepository


### PR DESCRIPTION
### Summary

Closes #1394 by saving the current `currentStateString` of the `exercise_entity` attached to the `exercise_template` in the `parallel_exercise`, using this snapshot for the creation of all future exercise instances.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [x] If this PR adds or changes features, the related documentation has been updated.
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
