### PR TITLE
Fix/tc scoutable indicator

### DIFF
--- a/frontend/src/app/state/application/selectors/shared.selectors.ts
+++ b/frontend/src/app/state/application/selectors/shared.selectors.ts
@@ -257,33 +257,35 @@ export const selectVisibleScoutableIndicators = createSelector(
                         isInViewport(viewport, scoutableIndicator.position))
             );
         const technicalChallengeScoutables: ScoutableIndicator[] =
-            Object.values(technicalChallenges).flatMap((challenge) =>
-                Object.values(challenge.stateMachines).map((stateMachine) => {
-                    const currentState = currentStateOf(stateMachine);
+            Object.values(technicalChallenges).map((challenge) => {
+                const allStateMachinesViewed = Object.values(
+                    challenge.stateMachines
+                )
+                    .map(currentStateOf)
+                    .every((currentState) => currentState.viewedByParticipants);
 
-                    const offset = { x: challenge.size.width, y: 0 };
-                    const elementPos = currentCoordinatesOf(challenge);
+                const offset = { x: challenge.size.width, y: 0 };
+                const elementPos = currentCoordinatesOf(challenge);
 
-                    const position = newMapCoordinatesAt(
-                        elementPos.x + offset.x,
-                        elementPos.y + offset.y
-                    );
+                const position = newMapCoordinatesAt(
+                    elementPos.x + offset.x,
+                    elementPos.y + offset.y
+                );
 
-                    const viewStatus =
-                        currentState.viewedByParticipants &&
-                        currentRole === 'trainer'
-                            ? 'viewed'
-                            : 'unviewed';
-                    return {
-                        id: `${stateMachine.id}:${currentState.id}`,
-                        position,
-                        scoutableElementType: 'technicalChallenge',
-                        scoutableElementId: challenge.id,
-                        imageUrl: scoutableImages[viewStatus].generic,
-                        height: 50,
-                    };
-                })
-            );
+                const viewStatus =
+                    allStateMachinesViewed && currentRole === 'trainer'
+                        ? 'viewed'
+                        : 'unviewed';
+
+                return {
+                    id: `${challenge.id}:${challenge.id}`,
+                    position,
+                    scoutableElementType: 'technicalChallenge',
+                    scoutableElementId: challenge.id,
+                    imageUrl: scoutableImages[viewStatus].generic,
+                    height: 50,
+                };
+            });
 
         return [...normalScoutables, ...technicalChallengeScoutables].reduce<{
             [id: `${UUID}:${UUID}`]: ScoutableIndicator;

--- a/shared/src/models/technical-challenge/state-machine.ts
+++ b/shared/src/models/technical-challenge/state-machine.ts
@@ -106,14 +106,12 @@ export const stateMachineStateSchema = z.object({
     title: z.string(),
     image: imagePropertiesSchema,
     userGeneratedContent: userGeneratedContentSchema,
-    viewedByParticipants: z.boolean().optional(),
+    viewedByParticipants: z.boolean().optional().default(false),
     /**
      * maps taskId to the task-specific progress multiplier (default 1)
      * */
     possibleTasks: z.record(taskTypeSchema.shape.id, z.number()),
     outgoingTransitions: z.array(transitionSchema),
-
-    viewedByParticipant: z.boolean().optional().default(false),
 });
 export type StateMachineState = Immutable<
     z.infer<typeof stateMachineStateSchema>
@@ -137,7 +135,7 @@ export function newTechnicalChallengeState(
         userGeneratedContent: userGeneratedContent ?? newUserGeneratedContent(),
         possibleTasks,
         outgoingTransitions,
-        viewedByParticipant: false,
+        viewedByParticipants: false,
     };
 }
 


### PR DESCRIPTION
### Summary

Previously, multiple scoutable indicators were shown on top of each other for each technical challenge.
This PR fixes that to only show a single one that combines the "viewed"-state of all it's state machines.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [ ] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [ ] If this PR adds or changes features, the related documentation has been updated.
- [ ] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [ ] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [ ] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
