### PR TITLE
Add tab layout for parallel exercises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 
 ### Changed
 
-- Menu items in header have ben put into a more logical order.
+- Menu items in header are now in a more logical order.
+- The Parallel Exercise overview page is now structured with tabs.
 
 ### Fixed
 

--- a/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
+++ b/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
@@ -28,22 +28,20 @@
             <div class="col-lg-5 col-md-12">
                 <div class="card bg-secondary-subtle">
                     <div class="card-body row mb-0 p-3 px-4">
-                        @let leadingExercise =
-                            parallelExerciseService.exerciseInstances()[0];
-                        @if (leadingExercise) {
-                            <div class="col h2">
-                                <span
-                                    class="badge rounded-pill bg-light text-dark state-badge h-100 px-3 m-0 d-flex align-items-center"
-                                >
-                                    <span class="text-center w-100">
-                                        <i class="bi bi-people me-1"></i>
-                                        {{
-                                            parallelExerciseService.exerciseInstances()
-                                                .length
-                                        }}
-                                    </span>
+                        @let exerciseInstances =
+                            parallelExerciseService.exerciseInstances();
+                        @let leadingExercise = exerciseInstances[0];
+                        <div class="col h2">
+                            <span
+                                class="badge rounded-pill bg-light text-dark state-badge h-100 px-3 m-0 d-flex align-items-center"
+                            >
+                                <span class="text-center w-100">
+                                    <i class="bi bi-people me-1"></i>
+                                    {{ exerciseInstances.length }}
                                 </span>
-                            </div>
+                            </span>
+                        </div>
+                        @if (leadingExercise) {
                             <app-exercise-state-badge-inner
                                 class="col h1"
                                 [exerciseStatus]="leadingExercise.currentStatus"
@@ -78,8 +76,8 @@
                                 }
                             </div>
                         } @else {
-                            <div class="w-100 h-100">
-                                <p class="text-danger text-center">
+                            <div class="col w-100 h-100">
+                                <p class="h2 text-danger text-center">
                                     Warte auf Teilnehmende.
                                 </p>
                             </div>
@@ -97,13 +95,12 @@
                         <div class="col-lg-6">
                             <h1 class="m-3 text-center">
                                 Bisher
-                                {{
-                                    parallelExerciseService.exerciseInstances()
-                                        .length
+                                {{ exerciseInstances.length }}
+                                Teilnehmende{{
+                                    exerciseInstances.length === 1 ? '(r)' : ''
                                 }}
-                                Teilnehmende
                             </h1>
-                            <h2 class="m-3 text-center">
+                            <h2 class="m-3 mt-5 text-center">
                                 @for (
                                     exerciseInstance of parallelExerciseService.exerciseInstances();
                                     track exerciseInstance.participantKey
@@ -125,6 +122,8 @@
                                                 : exerciseInstance.participantKey
                                         }}
                                     </span>
+                                } @empty {
+                                    <span class="display-1"> :-( </span>
                                 }
                             </h2>
                         </div>
@@ -133,7 +132,9 @@
                                 <div
                                     class="card-header h4 d-flex align-content-center"
                                 >
-                                    <div>Übung als Teilnehmender Beitreten</div>
+                                    <div>
+                                        Übung als Teilnehmende(r) Beitreten
+                                    </div>
                                     <div class="flex-grow-1"></div>
                                     <button
                                         app-copy-button
@@ -162,7 +163,7 @@
                                     <h2 class="text-center m-0 p-0">
                                         ...oder gib die Übungs-PIN
                                     </h2>
-                                    <h1 class="text-center m-0 p-0">
+                                    <h1 class="text-center m-0 p-0 display-3">
                                         <span class="font-monospace fw-bold"
                                             >{{ exercise.participantKey }}
                                         </span>

--- a/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
+++ b/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
@@ -2,42 +2,54 @@
 <main class="container">
     @if (parallelExercise.hasValue()) {
         @let exercise = parallelExercise.value();
-        <h1 class="mb-4 d-flex align-items-center">
-            <div>Parallelübung:&nbsp;</div>
-            @if (exercise.userRole !== 'viewer') {
-                <app-inline-text-editor
-                    class="flex-grow-1"
-                    [required]="true"
-                    [value]="exercise.name"
-                    name="Name der Paralellübung"
-                    (update)="
-                        patchParallelExercise({
-                            name: $event,
-                        })
-                    "
-                    [singleLine]="true"
-                />
-            } @else {
-                {{ exercise.name }}
-            }
-        </h1>
+
         <div class="row mb-4 align-items-stretch">
-            <div class="col">
-                <div class="card h-100">
-                    <div class="card-header h4">Steuerung</div>
-                    <div class="card-body">
-                        <div class="d-flex">
-                            @let leadingExercise =
-                                parallelExerciseService.exerciseInstances()[0];
-                            @if (leadingExercise) {
-                                <app-exercise-state-badge-inner
-                                    class="h1"
-                                    [exerciseStatus]="
-                                        leadingExercise.currentStatus
-                                    "
-                                    [currentTime]="leadingExercise.currentTime"
-                                />
-                                <div class="flex-grow-1"></div>
+            <div class="col-lg-7 col-md-12">
+                <h1 class="mb-4 d-flex align-items-center">
+                    <div>Parallelübung:&nbsp;</div>
+                    @if (exercise.userRole !== 'viewer') {
+                        <app-inline-text-editor
+                            class="flex-grow-1"
+                            [required]="true"
+                            [value]="exercise.name"
+                            name="Name der Paralellübung"
+                            (update)="
+                                patchParallelExercise({
+                                    name: $event,
+                                })
+                            "
+                            [singleLine]="true"
+                        />
+                    } @else {
+                        {{ exercise.name }}
+                    }
+                </h1>
+            </div>
+            <div class="col-lg-5 col-md-12">
+                <div class="card bg-secondary-subtle">
+                    <div class="card-body row mb-0 p-3 px-4">
+                        @let leadingExercise =
+                            parallelExerciseService.exerciseInstances()[0];
+                        @if (leadingExercise) {
+                            <div class="col h2">
+                                <span
+                                    class="badge rounded-pill bg-light text-dark state-badge h-100 px-3 m-0 d-flex align-items-center"
+                                >
+                                    <span class="text-center w-100">
+                                        <i class="bi bi-people me-1"></i>
+                                        {{
+                                            parallelExerciseService.exerciseInstances()
+                                                .length
+                                        }}
+                                    </span>
+                                </span>
+                            </div>
+                            <app-exercise-state-badge-inner
+                                class="col h1"
+                                [exerciseStatus]="leadingExercise.currentStatus"
+                                [currentTime]="leadingExercise.currentTime"
+                            />
+                            <div class="col">
                                 @if (exercise.userRole !== 'viewer') {
                                     @if (
                                         leadingExercise.currentStatus !==
@@ -45,7 +57,7 @@
                                     ) {
                                         <button
                                             type="button"
-                                            class="btn btn-primary"
+                                            class="btn btn-primary btn-lg rounded-pill w-100 h-100 px-3 py-0 m-0"
                                             (click)="
                                                 parallelExerciseService.startParallelExercise()
                                             "
@@ -55,7 +67,7 @@
                                     } @else {
                                         <button
                                             type="button"
-                                            class="btn btn-primary"
+                                            class="btn btn-primary btn-lg rounded-pill w-100 h-100 px-3 py-0 m-0"
                                             (click)="
                                                 parallelExerciseService.pauseParallelExercise()
                                             "
@@ -64,91 +76,125 @@
                                         </button>
                                     }
                                 }
-                            } @else {
-                                <div class="alert alert-info" role="alert">
-                                    Um die Übung zu starten, warten Sie, bis
-                                    Teilnehmende beigetreten sind.
-                                </div>
-                            }
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="card h-100">
-                    <div class="card-header h4 d-flex align-content-center">
-                        <div>
-                            Teilnehmenden-PIN:
-                            <span class="font-monospace fw-bold">{{
-                                exercise.participantKey
-                            }}</span>
-                        </div>
-                        <div class="flex-grow-1"></div>
-                        <button
-                            app-copy-button
-                            class="btn btn-outline-secondary"
-                            [value]="participantUrl()"
-                            text="Teilnehmerlink"
-                            ngbTooltip="Link kopieren"
-                            container="body"
-                        ></button>
-                    </div>
-                    <div class="card-body d-flex justify-content-center py-0">
-                        <qr-code
-                            [value]="participantUrl()"
-                            size="350"
-                            errorCorrectionLevel="M"
-                        />
+                            </div>
+                        } @else {
+                            <div class="w-100 h-100">
+                                <p class="text-danger text-center">
+                                    Warte auf Teilnehmende.
+                                </p>
+                            </div>
+                        }
                     </div>
                 </div>
             </div>
         </div>
 
-        <div class="row">
-            <div class="col">
-                <div class="card">
-                    <div class="card-header h4">
-                        Teilnehmende
-                        <span class="badge bg-secondary float-end">
-                            <i class="bi bi-people me-1"></i>
-                            {{
-                                parallelExerciseService.exerciseInstances()
-                                    .length
-                            }}
-                        </span>
+        <nav #nav="ngbNav" ngbNav class="nav-tabs" [(activeId)]="activeTab">
+            <ng-container ngbNavItem="invite">
+                <a ngbNavLink>Teilnehmende Einladen</a>
+                <ng-template ngbNavContent>
+                    <div class="row">
+                        <div class="col"></div>
+                        <div class="col">
+                            <div class="card h-100">
+                                <div
+                                    class="card-header h4 d-flex align-content-center"
+                                >
+                                    <div>
+                                        Teilnehmenden-PIN:
+                                        <span class="font-monospace fw-bold">{{
+                                            exercise.participantKey
+                                        }}</span>
+                                    </div>
+                                    <div class="flex-grow-1"></div>
+                                    <button
+                                        app-copy-button
+                                        class="btn btn-outline-secondary"
+                                        [value]="participantUrl()"
+                                        text="Teilnehmerlink"
+                                        ngbTooltip="Link kopieren"
+                                        container="body"
+                                    ></button>
+                                </div>
+                                <div
+                                    class="card-body d-flex justify-content-center py-0"
+                                >
+                                    <qr-code
+                                        [value]="participantUrl()"
+                                        size="350"
+                                        errorCorrectionLevel="M"
+                                    />
+                                </div>
+                            </div>
+                        </div>
                     </div>
-                    <table class="table table-striped mb-0">
-                        <thead>
-                            <tr>
-                                <th></th>
-                                <th>Teilnehmenden-PIN</th>
-                                <th>Name(n)</th>
-                                <th>Letzte Aktion</th>
-                                <th></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @for (
-                                exerciseInstance of parallelExerciseService.exerciseInstances();
-                                track exerciseInstance.participantKey
-                            ) {
-                                <tr
-                                    app-parallel-exercise-instance-row
-                                    [exerciseInstance]="exerciseInstance"
-                                ></tr>
-                            } @empty {
-                                <tr>
-                                    <td colspan="5" class="text-muted">
-                                        Es sind noch keine Teilnehmenden der
-                                        Übung beigetreten.
-                                    </td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
+                </ng-template>
+            </ng-container>
+
+            <ng-container ngbNavItem="participants">
+                <a ngbNavLink>Teilnehmende Verwalten</a>
+                <ng-template ngbNavContent>
+                    <div class="row">
+                        <div class="col">
+                            <div class="card">
+                                <div class="card-header h4">
+                                    Teilnehmende
+                                    <span class="badge bg-secondary float-end">
+                                        <i class="bi bi-people me-1"></i>
+                                        {{
+                                            parallelExerciseService.exerciseInstances()
+                                                .length
+                                        }}
+                                    </span>
+                                </div>
+                                <table class="table table-striped mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th></th>
+                                            <th>Teilnehmenden-PIN</th>
+                                            <th>Name(n)</th>
+                                            <th>Letzte Aktion</th>
+                                            <th></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @for (
+                                            exerciseInstance of parallelExerciseService.exerciseInstances();
+                                            track exerciseInstance.participantKey
+                                        ) {
+                                            <tr
+                                                app-parallel-exercise-instance-row
+                                                [exerciseInstance]="
+                                                    exerciseInstance
+                                                "
+                                            ></tr>
+                                        } @empty {
+                                            <tr>
+                                                <td
+                                                    colspan="3"
+                                                    class="text-muted"
+                                                >
+                                                    Es sind noch keine
+                                                    Teilnehmenden der Übung
+                                                    beigetreten.
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </ng-template>
+            </ng-container>
+
+            <ng-container ngbNavItem="overview">
+                <a ngbNavLink>Didaktische Übersicht</a>
+                <ng-template ngbNavContent> </ng-template>
+            </ng-container>
+        </nav>
+
+        <div [ngbNavOutlet]="nav" class="mt-2"></div>
     } @else if (parallelExercise.isLoading()) {
         <div class="row row-cols-3">
             @for (_ of [1, 2, 3]; track $index) {

--- a/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
+++ b/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
@@ -47,7 +47,7 @@
                                 [exerciseStatus]="leadingExercise.currentStatus"
                                 [currentTime]="leadingExercise.currentTime"
                             />
-                            <div class="col">
+                            <div class="col h2">
                                 @if (exercise.userRole !== 'viewer') {
                                     @if (
                                         leadingExercise.currentStatus !==
@@ -55,7 +55,7 @@
                                     ) {
                                         <button
                                             type="button"
-                                            class="btn btn-primary btn-lg rounded-pill w-100 h-100 px-3 py-0 m-0"
+                                            class="btn btn-primary btn-lg rounded-pill w-100 h-100 px-3 m-0"
                                             (click)="
                                                 parallelExerciseService.startParallelExercise()
                                             "
@@ -65,7 +65,7 @@
                                     } @else {
                                         <button
                                             type="button"
-                                            class="btn btn-primary btn-lg rounded-pill w-100 h-100 px-3 py-0 m-0"
+                                            class="btn btn-primary btn-lg rounded-pill w-100 h-100 px-3 m-0"
                                             (click)="
                                                 parallelExerciseService.pauseParallelExercise()
                                             "
@@ -89,51 +89,63 @@
 
         <nav #nav="ngbNav" ngbNav class="nav-tabs" [(activeId)]="activeTab">
             <ng-container ngbNavItem="invite">
-                <a ngbNavLink>Teilnehmende Einladen</a>
+                <a ngbNavLink>Teilnehmende einladen</a>
                 <ng-template ngbNavContent>
                     <div class="row my-5">
                         <div class="col-lg-6">
-                            <h1 class="m-3 text-center">
-                                Bisher
-                                {{ exerciseInstances.length }}
-                                Teilnehmende{{
-                                    exerciseInstances.length === 1 ? '(r)' : ''
-                                }}
-                            </h1>
-                            <h2 class="m-3 mt-5 text-center">
-                                @for (
-                                    exerciseInstance of parallelExerciseService.exerciseInstances();
-                                    track exerciseInstance.participantKey
-                                ) {
-                                    <span
-                                        class="badge m-2"
-                                        [ngClass]="
-                                            exerciseInstance.isActive
-                                                ? 'bg-primary'
-                                                : 'bg-secondary'
-                                        "
-                                    >
-                                        {{
-                                            exerciseInstance.clientNames
-                                                .length > 0
-                                                ? exerciseInstance.clientNames.join(
-                                                      ', '
-                                                  )
-                                                : exerciseInstance.participantKey
+                            <div class="card h-100">
+                                <div
+                                    class="card-header h4 d-flex align-content-center"
+                                >
+                                    <div class="pb-3">
+                                        Teilnehmende
+                                    </div>
+                                </div>
+                                <div class="card-body py-3">
+
+                                    <h1 class="m-3 text-center">
+                                        Aktuell
+                                        {{ exerciseInstances.length }}
+                                        Teilnehmende{{
+                                            exerciseInstances.length === 1 ? '(r)' : ''
                                         }}
-                                    </span>
-                                } @empty {
-                                    <span class="display-1"> :-( </span>
-                                }
-                            </h2>
+                                    </h1>
+                                    <div class="h2 m-3 mt-5 text-center">
+                                        @for (
+                                            exerciseInstance of parallelExerciseService.exerciseInstances();
+                                            track exerciseInstance.participantKey
+                                        ) {
+                                            <span
+                                                class="badge m-2"
+                                                [ngClass]="
+                                                    exerciseInstance.isActive
+                                                        ? 'bg-primary'
+                                                        : 'bg-secondary'
+                                                "
+                                            >
+                                                {{
+                                                    exerciseInstance.clientNames
+                                                        .length > 0
+                                                        ? exerciseInstance.clientNames.join(
+                                                            ', '
+                                                        )
+                                                        : "Übung " + exerciseInstance.participantKey
+                                                }}
+                                            </span>
+                                        } @empty {
+                                            <span class="display-1"> :-( </span>
+                                        }
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         <div class="col-lg-6">
                             <div class="card h-100">
                                 <div
                                     class="card-header h4 d-flex align-content-center"
                                 >
-                                    <div>
-                                        Übung als Teilnehmende(r) Beitreten
+                                    <div class="pb-3">
+                                        Übung beitreten
                                     </div>
                                     <div class="flex-grow-1"></div>
                                     <button
@@ -148,7 +160,7 @@
 
                                 <div class="card-body py-3">
                                     <h2 class="text-center m-0 p-0">
-                                        Scanne den QR-Code...
+                                        Scanne den QR-Code ...
                                     </h2>
                                     <div
                                         class="w-100 m-0 p-0 d-flex justify-content-center"
@@ -161,7 +173,7 @@
                                     </div>
 
                                     <h2 class="text-center m-0 p-0">
-                                        ...oder gib die Übungs-PIN
+                                        ... oder gib die Übungs-PIN
                                     </h2>
                                     <h1 class="text-center m-0 p-0 display-3">
                                         <span class="font-monospace fw-bold"
@@ -183,7 +195,7 @@
             </ng-container>
 
             <ng-container ngbNavItem="participants">
-                <a ngbNavLink>Teilnehmende Verwalten</a>
+                <a ngbNavLink>Teilnehmende verwalten</a>
                 <ng-template ngbNavContent>
                     <div class="card row my-5">
                         <div class="card-header h4">
@@ -229,10 +241,12 @@
                 </ng-template>
             </ng-container>
 
-            <ng-container ngbNavItem="overview">
-                <a ngbNavLink>Didaktische Übersicht</a>
-                <ng-template ngbNavContent> </ng-template>
-            </ng-container>
+            <!--
+                <ng-container ngbNavItem="overview">
+                    <a ngbNavLink>Didaktische Übersicht</a>
+                    <ng-template ngbNavContent> </ng-template>
+                </ng-container>
+            -->
         </nav>
 
         <div [ngbNavOutlet]="nav" class="mt-2 mb-5"></div>

--- a/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
+++ b/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
@@ -27,27 +27,29 @@
             </div>
             <div class="col-lg-5 col-md-12">
                 <div class="card bg-secondary-subtle">
-                    <div class="card-body row mb-0 p-3 px-4">
+                    <div
+                        class="card-body row mb-0 p-3 px-4 align-items-stretch"
+                    >
                         @let exerciseInstances =
                             parallelExerciseService.exerciseInstances();
                         @let leadingExercise = exerciseInstances[0];
-                        <div class="col h2">
-                            <span
-                                class="badge rounded-pill bg-light text-dark state-badge h-100 px-3 m-0 d-flex align-items-center"
+                        <div class="col h2 mb-0">
+                            <div
+                                class="badge rounded-pill bg-light text-dark state-badge h-100 w-100 px-3 m-0 d-flex align-items-center justify-content-center"
                             >
-                                <span class="text-center w-100">
+                                <div>
                                     <i class="bi bi-people me-1"></i>
                                     {{ exerciseInstances.length }}
-                                </span>
-                            </span>
+                                </div>
+                            </div>
                         </div>
                         @if (leadingExercise) {
                             <app-exercise-state-badge-inner
-                                class="col h1"
+                                class="col h1 mb-0"
                                 [exerciseStatus]="leadingExercise.currentStatus"
                                 [currentTime]="leadingExercise.currentTime"
                             />
-                            <div class="col h2">
+                            <div class="col h2 mb-0">
                                 @if (exercise.userRole !== 'viewer') {
                                     @if (
                                         leadingExercise.currentStatus !==
@@ -55,7 +57,7 @@
                                     ) {
                                         <button
                                             type="button"
-                                            class="btn btn-primary btn-lg rounded-pill w-100 h-100 px-3 m-0"
+                                            class="btn btn-primary btn-lg w-100 h-100 px-3 m-0"
                                             (click)="
                                                 parallelExerciseService.startParallelExercise()
                                             "
@@ -65,7 +67,7 @@
                                     } @else {
                                         <button
                                             type="button"
-                                            class="btn btn-primary btn-lg rounded-pill w-100 h-100 px-3 m-0"
+                                            class="btn btn-primary btn-lg w-100 h-100 px-3 m-0"
                                             (click)="
                                                 parallelExerciseService.pauseParallelExercise()
                                             "
@@ -76,9 +78,9 @@
                                 }
                             </div>
                         } @else {
-                            <div class="col w-100 h-100">
-                                <p class="h2 text-danger text-center">
-                                    Warte auf Teilnehmende.
+                            <div class="col mb-0">
+                                <p class="h4 text-center mb-0">
+                                    Warte auf Teilnehmende
                                 </p>
                             </div>
                         }
@@ -91,14 +93,10 @@
             <ng-container ngbNavItem="invite">
                 <a ngbNavLink>Teilnehmende einladen</a>
                 <ng-template ngbNavContent>
-                    <div class="row my-5">
-                        <div class="col-lg-6">
+                    <div class="row">
+                        <div class="col-md-12 col-lg-6 mb-4">
                             <div class="card h-100">
-                                <div
-                                    class="card-header h4 d-flex align-content-center"
-                                >
-                                    <div class="pb-3">Teilnehmende</div>
-                                </div>
+                                <h2 class="card-header h4">Teilnehmende</h2>
                                 <div class="card-body py-3">
                                     <h1 class="m-3 text-center">
                                         Aktuell
@@ -139,16 +137,16 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col-lg-6">
+                        <div class="col-md-12 col-lg-6 mb-4">
                             <div class="card h-100">
                                 <div
-                                    class="card-header h4 d-flex align-content-center"
+                                    class="card-header d-flex align-items-center"
                                 >
-                                    <div class="pb-3">Übung beitreten</div>
+                                    <h2 class="h4 mb-0">Übung beitreten</h2>
                                     <div class="flex-grow-1"></div>
                                     <button
                                         app-copy-button
-                                        class="btn bt-lg btn-outline-secondary"
+                                        class="btn btn-outline-secondary"
                                         [value]="participantUrl()"
                                         text="Teilnehmerlink"
                                         ngbTooltip="Link kopieren"
@@ -196,9 +194,10 @@
                 <a ngbNavLink>Teilnehmende verwalten</a>
                 <ng-template ngbNavContent>
                     <div class="card row my-5">
-                        <div class="card-header h4">
-                            Teilnehmende
-                            <span class="badge bg-secondary float-end">
+                        <div class="card-header d-flex align-items-center">
+                            <h2 class="h4 mb-0">Teilnehmende</h2>
+                            <div class="flex-grow-1"></div>
+                            <span class="badge bg-secondary">
                                 <i class="bi bi-people me-1"></i>
                                 {{
                                     parallelExerciseService.exerciseInstances()

--- a/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
+++ b/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
@@ -93,37 +93,87 @@
             <ng-container ngbNavItem="invite">
                 <a ngbNavLink>Teilnehmende Einladen</a>
                 <ng-template ngbNavContent>
-                    <div class="row">
-                        <div class="col"></div>
-                        <div class="col">
+                    <div class="row my-5">
+                        <div class="col-lg-6">
+                            <h1 class="m-3 text-center">
+                                Bisher
+                                {{
+                                    parallelExerciseService.exerciseInstances()
+                                        .length
+                                }}
+                                Teilnehmende
+                            </h1>
+                            <h2 class="m-3 text-center">
+                                @for (
+                                    exerciseInstance of parallelExerciseService.exerciseInstances();
+                                    track exerciseInstance.participantKey
+                                ) {
+                                    <span
+                                        class="badge m-2"
+                                        [ngClass]="
+                                            exerciseInstance.isActive
+                                                ? 'bg-primary'
+                                                : 'bg-secondary'
+                                        "
+                                    >
+                                        {{
+                                            exerciseInstance.clientNames
+                                                .length > 0
+                                                ? exerciseInstance.clientNames.join(
+                                                      ', '
+                                                  )
+                                                : exerciseInstance.participantKey
+                                        }}
+                                    </span>
+                                }
+                            </h2>
+                        </div>
+                        <div class="col-lg-6">
                             <div class="card h-100">
                                 <div
                                     class="card-header h4 d-flex align-content-center"
                                 >
-                                    <div>
-                                        Teilnehmenden-PIN:
-                                        <span class="font-monospace fw-bold">{{
-                                            exercise.participantKey
-                                        }}</span>
-                                    </div>
+                                    <div>Übung als Teilnehmender Beitreten</div>
                                     <div class="flex-grow-1"></div>
                                     <button
                                         app-copy-button
-                                        class="btn btn-outline-secondary"
+                                        class="btn bt-lg btn-outline-secondary"
                                         [value]="participantUrl()"
                                         text="Teilnehmerlink"
                                         ngbTooltip="Link kopieren"
                                         container="body"
                                     ></button>
                                 </div>
-                                <div
-                                    class="card-body d-flex justify-content-center py-0"
-                                >
-                                    <qr-code
-                                        [value]="participantUrl()"
-                                        size="350"
-                                        errorCorrectionLevel="M"
-                                    />
+
+                                <div class="card-body py-3">
+                                    <h2 class="text-center m-0 p-0">
+                                        Scanne den QR-Code...
+                                    </h2>
+                                    <div
+                                        class="w-100 m-0 p-0 d-flex justify-content-center"
+                                    >
+                                        <qr-code
+                                            [value]="participantUrl()"
+                                            size="400"
+                                            errorCorrectionLevel="M"
+                                        />
+                                    </div>
+
+                                    <h2 class="text-center m-0 p-0">
+                                        ...oder gib die Übungs-PIN
+                                    </h2>
+                                    <h1 class="text-center m-0 p-0">
+                                        <span class="font-monospace fw-bold"
+                                            >{{ exercise.participantKey }}
+                                        </span>
+                                    </h1>
+                                    <h2 class="text-center m-0 p-0">
+                                        auf
+                                        <a href="{{ serviceUrl() }} ">{{
+                                            serviceUrl()
+                                        }}</a>
+                                        ein.
+                                    </h2>
                                 </div>
                             </div>
                         </div>
@@ -134,56 +184,46 @@
             <ng-container ngbNavItem="participants">
                 <a ngbNavLink>Teilnehmende Verwalten</a>
                 <ng-template ngbNavContent>
-                    <div class="row">
-                        <div class="col">
-                            <div class="card">
-                                <div class="card-header h4">
-                                    Teilnehmende
-                                    <span class="badge bg-secondary float-end">
-                                        <i class="bi bi-people me-1"></i>
-                                        {{
-                                            parallelExerciseService.exerciseInstances()
-                                                .length
-                                        }}
-                                    </span>
-                                </div>
-                                <table class="table table-striped mb-0">
-                                    <thead>
-                                        <tr>
-                                            <th></th>
-                                            <th>Teilnehmenden-PIN</th>
-                                            <th>Name(n)</th>
-                                            <th>Letzte Aktion</th>
-                                            <th></th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        @for (
-                                            exerciseInstance of parallelExerciseService.exerciseInstances();
-                                            track exerciseInstance.participantKey
-                                        ) {
-                                            <tr
-                                                app-parallel-exercise-instance-row
-                                                [exerciseInstance]="
-                                                    exerciseInstance
-                                                "
-                                            ></tr>
-                                        } @empty {
-                                            <tr>
-                                                <td
-                                                    colspan="3"
-                                                    class="text-muted"
-                                                >
-                                                    Es sind noch keine
-                                                    Teilnehmenden der Übung
-                                                    beigetreten.
-                                                </td>
-                                            </tr>
-                                        }
-                                    </tbody>
-                                </table>
-                            </div>
+                    <div class="card row my-5">
+                        <div class="card-header h4">
+                            Teilnehmende
+                            <span class="badge bg-secondary float-end">
+                                <i class="bi bi-people me-1"></i>
+                                {{
+                                    parallelExerciseService.exerciseInstances()
+                                        .length
+                                }}
+                            </span>
                         </div>
+                        <table class="table table-striped mb-0">
+                            <thead>
+                                <tr>
+                                    <th></th>
+                                    <th>Teilnehmenden-PIN</th>
+                                    <th>Name(n)</th>
+                                    <th>Letzte Aktion</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @for (
+                                    exerciseInstance of parallelExerciseService.exerciseInstances();
+                                    track exerciseInstance.participantKey
+                                ) {
+                                    <tr
+                                        app-parallel-exercise-instance-row
+                                        [exerciseInstance]="exerciseInstance"
+                                    ></tr>
+                                } @empty {
+                                    <tr>
+                                        <td colspan="3" class="text-muted">
+                                            Es sind noch keine Teilnehmenden der
+                                            Übung beigetreten.
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
                     </div>
                 </ng-template>
             </ng-container>
@@ -194,7 +234,7 @@
             </ng-container>
         </nav>
 
-        <div [ngbNavOutlet]="nav" class="mt-2"></div>
+        <div [ngbNavOutlet]="nav" class="mt-2 mb-5"></div>
     } @else if (parallelExercise.isLoading()) {
         <div class="row row-cols-3">
             @for (_ of [1, 2, 3]; track $index) {

--- a/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
+++ b/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.html
@@ -97,17 +97,16 @@
                                 <div
                                     class="card-header h4 d-flex align-content-center"
                                 >
-                                    <div class="pb-3">
-                                        Teilnehmende
-                                    </div>
+                                    <div class="pb-3">Teilnehmende</div>
                                 </div>
                                 <div class="card-body py-3">
-
                                     <h1 class="m-3 text-center">
                                         Aktuell
                                         {{ exerciseInstances.length }}
                                         Teilnehmende{{
-                                            exerciseInstances.length === 1 ? '(r)' : ''
+                                            exerciseInstances.length === 1
+                                                ? '(r)'
+                                                : ''
                                         }}
                                     </h1>
                                     <div class="h2 m-3 mt-5 text-center">
@@ -127,9 +126,10 @@
                                                     exerciseInstance.clientNames
                                                         .length > 0
                                                         ? exerciseInstance.clientNames.join(
-                                                            ', '
-                                                        )
-                                                        : "Übung " + exerciseInstance.participantKey
+                                                              ', '
+                                                          )
+                                                        : 'Übung ' +
+                                                          exerciseInstance.participantKey
                                                 }}
                                             </span>
                                         } @empty {
@@ -144,9 +144,7 @@
                                 <div
                                     class="card-header h4 d-flex align-content-center"
                                 >
-                                    <div class="pb-3">
-                                        Übung beitreten
-                                    </div>
+                                    <div class="pb-3">Übung beitreten</div>
                                     <div class="flex-grow-1"></div>
                                     <button
                                         app-copy-button

--- a/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.ts
+++ b/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.ts
@@ -1,6 +1,14 @@
 import { Component, computed, effect, inject } from '@angular/core';
 import { HttpResourceRef } from '@angular/common/http';
-import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import {
+    NgbTooltip,
+    NgbNav,
+    NgbNavContent,
+    NgbNavItem,
+    NgbNavLink,
+    NgbNavLinkBase,
+    NgbNavOutlet,
+} from '@ng-bootstrap/ng-bootstrap';
 import {
     GetParallelExerciseResponseData,
     PatchParallelExerciseRequestData,
@@ -28,6 +36,12 @@ import { CopyButtonComponent } from '../../../../shared/components/copy-button/c
         FooterComponent,
         NgbTooltip,
         InlineTextEditorComponent,
+        NgbNav,
+        NgbNavItem,
+        NgbNavLink,
+        NgbNavLinkBase,
+        NgbNavContent,
+        NgbNavOutlet,
         CopyButtonComponent,
     ],
 })
@@ -35,6 +49,8 @@ export class ParallelExerciseComponent {
     private readonly apiService = inject(ApiService);
     private readonly route = inject(ActivatedRoute);
     public readonly parallelExerciseService = inject(ParallelExerciseService);
+
+    activeTab = 'invite';
 
     parallelExercise: HttpResourceRef<
         GetParallelExerciseResponseData | undefined

--- a/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.ts
+++ b/frontend/src/app/pages/exercises/parallel-exercise/parallel-exercise/parallel-exercise.component.ts
@@ -1,5 +1,6 @@
 import { Component, computed, effect, inject } from '@angular/core';
 import { HttpResourceRef } from '@angular/common/http';
+import { NgClass } from '@angular/common';
 import {
     NgbTooltip,
     NgbNav,
@@ -36,6 +37,7 @@ import { CopyButtonComponent } from '../../../../shared/components/copy-button/c
         FooterComponent,
         NgbTooltip,
         InlineTextEditorComponent,
+        NgClass,
         NgbNav,
         NgbNavItem,
         NgbNavLink,
@@ -59,6 +61,7 @@ export class ParallelExerciseComponent {
         () =>
             `${location.origin}/exercises/parallel/join/${this.parallelExercise.value()?.participantKey}`
     );
+    readonly serviceUrl = computed(() => `${location.origin}/`);
 
     async patchParallelExercise(data: PatchParallelExerciseRequestData) {
         const parallelExercise = this.parallelExercise.value();


### PR DESCRIPTION
### Summary

Refactors the layout of the parallel exercise details page to a tabbed layout, with minimal controls at the top and all details below, organized into tabs. Resolves #1604.

<img width="1401" height="997" alt="Recording 2026-07-22 at 23 06 23" src="https://github.com/user-attachments/assets/4edb95e6-a72e-40c5-b19e-eb81b7927448" />

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [x] If this PR adds or changes features, the related documentation has been updated.
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
