### PR TITLE
Proposal: Reorder menu items in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project does **not** adhere to [Semantic Versioning](https://semver.org
 - There is now a banner that is displayed when the application is unable to start properly, informing the user about potential causes.
 - New participants joining a parallel exercise after it started now get fast-forwarded to be in sync with all other participants.
 
+### Changed
+
+- Menu items in header have ben put into a more logical order.
+
 ### Fixed
 
 - The deletion of alarm groups no longer breaks breaks measure templates that use them.

--- a/frontend/src/app/pages/organisations/organisation/organisation.component.html
+++ b/frontend/src/app/pages/organisations/organisation/organisation.component.html
@@ -73,21 +73,6 @@
                     />
                 </ng-template>
             </ng-container>
-            <ng-container ngbNavItem="exercise-templates">
-                <a ngbNavLink>
-                    <i class="bi bi-box-seam me-1"></i>
-                    Übungsvorlagen
-                    <span class="badge text-bg-secondary ms-1">{{
-                        org.exerciseTemplatesCount
-                    }}</span>
-                </a>
-                <ng-template ngbNavContent>
-                    <app-organisation-tab-exercise-templates
-                        [organisation]="org"
-                        (update)="reload()"
-                    />
-                </ng-template>
-            </ng-container>
             <ng-container ngbNavItem="parallel-exercises">
                 <a ngbNavLink>
                     <i class="bi bi-box-seam me-1"></i>
@@ -98,6 +83,21 @@
                 </a>
                 <ng-template ngbNavContent>
                     <app-organisation-tab-parallel-exercises
+                        [organisation]="org"
+                        (update)="reload()"
+                    />
+                </ng-template>
+            </ng-container>
+            <ng-container ngbNavItem="exercise-templates">
+                <a ngbNavLink>
+                    <i class="bi bi-box-seam me-1"></i>
+                    Übungsvorlagen
+                    <span class="badge text-bg-secondary ms-1">{{
+                        org.exerciseTemplatesCount
+                    }}</span>
+                </a>
+                <ng-template ngbNavContent>
+                    <app-organisation-tab-exercise-templates
                         [organisation]="org"
                         (update)="reload()"
                     />

--- a/frontend/src/app/shared/components/header/header.component.html
+++ b/frontend/src/app/shared/components/header/header.component.html
@@ -15,15 +15,6 @@
                         Übungen
                     </a>
                 </li>
-                <li ngbNavItem="exercise_templates" class="nav-item mx-2">
-                    <a
-                        ngbNavLink
-                        class="nav-link"
-                        routerLink="/exercises/templates"
-                    >
-                        Übungsvorlagen
-                    </a>
-                </li>
                 @if (exerciseConfig()?.parallelExercisesEnabled) {
                     <li ngbNavItem="parallel" class="nav-item mx-2">
                         <a
@@ -35,6 +26,15 @@
                         </a>
                     </li>
                 }
+                <li ngbNavItem="exercise_templates" class="nav-item mx-2">
+                    <a
+                        ngbNavLink
+                        class="nav-link"
+                        routerLink="/exercises/templates"
+                    >
+                        Übungsvorlagen
+                    </a>
+                </li>
                 <li ngbNavItem="organisations" class="nav-item mx-2">
                     <a ngbNavLink class="nav-link" routerLink="/organisations">
                         Organisationen


### PR DESCRIPTION
### Summary

Moved the "parallel exercises" menu item to the left, so that both types of actual exercises and both types of templates/elements are not listed interleaved.

###### Before
<img width="1319" height="76" alt="image" src="https://github.com/user-attachments/assets/ed67aa94-6c06-4cc3-a83e-718b53534503" />


###### After
<img width="1337" height="439" alt="image" src="https://github.com/user-attachments/assets/2d072fd0-7438-4bbe-9e47-a0ffebd0e2fe" />



### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [x] If this PR adds or changes features, the related documentation has been updated.
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
