### PR TITLE
Fix/refresh exercise templates 1613

### DIFF
--- a/frontend/src/app/core/exercise.service.ts
+++ b/frontend/src/app/core/exercise.service.ts
@@ -440,5 +440,11 @@ export class ExerciseService {
         if (fileList) {
             await componentInstance.importFile(fileList);
         }
+
+        return new Promise<void>((resolve) => {
+            componentInstance.created.subscribe(() => {
+                resolve();
+            });
+        });
     }
 }

--- a/frontend/src/app/core/exercise.service.ts
+++ b/frontend/src/app/core/exercise.service.ts
@@ -440,11 +440,5 @@ export class ExerciseService {
         if (fileList) {
             await componentInstance.importFile(fileList);
         }
-
-        return new Promise<void>((resolve) => {
-            componentInstance.created.subscribe(() => {
-                resolve();
-            });
-        });
     }
 }

--- a/frontend/src/app/pages/exercises/template-list/exercise-template-list.component.ts
+++ b/frontend/src/app/pages/exercises/template-list/exercise-template-list.component.ts
@@ -35,5 +35,6 @@ export class ExerciseTemplateListComponent {
 
     async createExerciseTemplate(fileList?: FileList) {
         await this.exerciseService.createExerciseTemplate(fileList);
+        this.exerciseTemplates.reload();
     }
 }

--- a/frontend/src/app/pages/exercises/template-list/exercise-template-list.component.ts
+++ b/frontend/src/app/pages/exercises/template-list/exercise-template-list.component.ts
@@ -34,7 +34,8 @@ export class ExerciseTemplateListComponent {
     }
 
     async createExerciseTemplate(fileList?: FileList) {
-        await this.exerciseService.createExerciseTemplate(fileList);
-        this.exerciseTemplates.reload();
+        await this.exerciseService.createExerciseTemplate(fileList, () => {
+            this.exerciseTemplates.reload();
+        });
     }
 }


### PR DESCRIPTION
### Summary

Closes #1613 

Exercise Template List now automatically refreshes when a new template is created

No Changelog cause it reverses a regression that hasnt hit dev yet

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [x] If this PR adds or changes features, the related documentation has been updated.
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
