### PR TITLE
Fix cypress pipeline flakiness

### DIFF
--- a/frontend/cypress/e2e/exercise.cy.ts
+++ b/frontend/cypress/e2e/exercise.cy.ts
@@ -68,7 +68,6 @@ describe('A trainer on the exercise page', () => {
     });
 
     it('can interact with the map', () => {
-        cy.get('[data-cy=viewportsTransferPointsAccordionButton]').click();
         cy.log('drag a viewport to the map').dragToMap(
             '[data-cy=draggableViewportDiv]'
         );

--- a/frontend/cypress/e2e/exercise.cy.ts
+++ b/frontend/cypress/e2e/exercise.cy.ts
@@ -68,6 +68,9 @@ describe('A trainer on the exercise page', () => {
     });
 
     it('can interact with the map', () => {
+        cy.get('[data-cy=draggableViewportDiv]', { timeout: 20000 }).should(
+            'be.visible'
+        );
         cy.log('drag a viewport to the map').dragToMap(
             '[data-cy=draggableViewportDiv]'
         );


### PR DESCRIPTION
### Summary

Fixes Chrome Cypress flakiness caused by two bugs: a click was closing the already-open accordion panel instead of opening it, and the drag then raced a 4s timeout against the app's post-join render — both worse on Chrome due to [CDP](https://chromedevtools.github.io/devtools-protocol/) overhead. Removes the bad click and adds a longer-timeout visibility wait before the first interaction.

### PR Checklist

Please make sure to fulfil the following conditions before marking this PR ready for review:

- [x] If this PR adds or changes features or fixes bugs, this has been added to the changelog.
- [x] If this PR adds or changes features, the related documentation has been updated.
- [x] If this PR adds new actions or other ways to alter the state, [test scenarios](https://github.com/hpi-sam/fuesim-digital-public-test-scenarios) have been added.
- [x] By signing off my commits (`git commit -s`), I certify that I have read and adhere to the terms of the [Developer Certificate of Origin 1.1](https://developercertificate.org/) and license the code in this Pull Request under this projects license ([LICENSE-README.md](https://github.com/hpi-sam/fuesim-digital/blob/dev/LICENSE-README.md)).
- [x] If I have used third party code that requires attribution, I have mentioned it in the code and updated [inspired-by-or-copied-from-list.html](https://github.com/hpi-sam/fuesim-digital/blob/dev/inspired-by-or-copied-from-list.html).
